### PR TITLE
Add Rust-based SNMP trap receiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ tidy: ## Tidy and format Go code
 	@echo "$(COLOR_BOLD)Formatting Rust code$(COLOR_RESET)"
 	@cd cmd/checkers/rperf-client && $(RUSTFMT) src/*.rs
 	@cd cmd/checkers/sysmon && $(RUSTFMT) src/*.rs
+	@cd cmd/trapd && $(RUSTFMT) src/*.rs
 
 .PHONY: get-golangcilint
 get-golangcilint: ## Install golangci-lint
@@ -72,6 +73,7 @@ lint: get-golangcilint ## Run linting checks
 	@echo "$(COLOR_BOLD)Running Rust linter$(COLOR_RESET)"
 	@cd cmd/checkers/rperf-client && $(CARGO) clippy -- -D warnings
 	@cd cmd/checkers/sysmon && $(CARGO) clippy -- -D warnings
+	@cd cmd/trapd && $(CARGO) clippy -- -D warnings
 
 .PHONY: test
 test: ## Run all tests with coverage
@@ -82,7 +84,8 @@ test: ## Run all tests with coverage
 	@echo "$(COLOR_BOLD)Running Rust tests$(COLOR_RESET)"
 	@cd cmd/checkers/rperf-client && $(CARGO) test
 	@cd cmd/checkers/sysmon && $(CARGO) test
-
+	@cd cmd/trapd && $(CARGO) test
+	
 .PHONY: check-coverage
 check-coverage: test ## Check test coverage against thresholds
 	@echo "$(COLOR_BOLD)Checking test coverage$(COLOR_RESET)"
@@ -119,6 +122,7 @@ clean: ## Clean up build artifacts
 	@rm -rf serviceradar-*_* release-artifacts/
 	@cd cmd/checkers/rperf-client && $(CARGO) clean
 	@cd cmd/checkers/sysmon && $(CARGO) clean
+	@cd cmd/trapd && $(CARGO) clean
 
 .PHONY: generate-proto
 generate-proto: ## Generate Go and Rust code from protobuf definitions

--- a/cmd/trapd/Cargo.toml
+++ b/cmd/trapd/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "serviceradar-trapd"
+version = "0.1.0"
+edition = "2021"
+authors = ["ServiceRadar Team"]
+description = "SNMP Trap receiver for ServiceRadar"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1.0"
+async-nats = "0.42.0"
+bytes = "1.5"
+clap = { version = "4.3", features = ["derive", "env"] }
+env_logger = "0.10"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+snmp2 = { version = "0.4.8", features = ["tokio"] }
+tokio = { version = "1.44", features = ["full"] }

--- a/cmd/trapd/README.md
+++ b/cmd/trapd/README.md
@@ -1,0 +1,21 @@
+# serviceradar-trapd
+
+`serviceradar-trapd` is an asynchronous SNMP trap receiver for the ServiceRadar platform. It listens for traps and publishes them to NATS JetStream in JSON format.
+
+## Configuration
+
+Create a JSON file with the following fields:
+
+```json
+{
+  "listen_addr": "0.0.0.0:162",
+  "nats_url": "nats://localhost:4222",
+  "subject": "snmp.traps"
+}
+```
+
+Run the service with:
+
+```sh
+serviceradar-trapd --config trapd.json
+```

--- a/cmd/trapd/src/config.rs
+++ b/cmd/trapd/src/config.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::{fs, path::Path};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecurityConfig {
+    pub cert_file: Option<String>,
+    pub key_file: Option<String>,
+    pub ca_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub listen_addr: String,
+    pub nats_url: String,
+    pub subject: String,
+    pub security: Option<SecurityConfig>,
+}
+
+impl Config {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = fs::read_to_string(path).context("Failed to read config file")?;
+        let cfg: Config = serde_json::from_str(&content).context("Failed to parse config file")?;
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.listen_addr.is_empty() {
+            anyhow::bail!("listen_addr is required");
+        }
+        if self.nats_url.is_empty() {
+            anyhow::bail!("nats_url is required");
+        }
+        if self.subject.is_empty() {
+            anyhow::bail!("subject is required");
+        }
+        Ok(())
+    }
+}

--- a/cmd/trapd/src/main.rs
+++ b/cmd/trapd/src/main.rs
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use anyhow::Result;
+use clap::Parser;
+use env_logger::Env;
+use log::{error, info, warn};
+use serde::Serialize;
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+
+mod config;
+use config::Config;
+
+#[derive(Parser, Debug)]
+#[command(name = "serviceradar-trapd")]
+#[command(about = "ServiceRadar SNMP Trap Receiver", long_about = None)]
+struct Cli {
+    /// Path to configuration file
+    #[arg(short, long, env = "TRAPD_CONFIG")]
+    config: String,
+}
+
+#[derive(Serialize)]
+struct Varbind {
+    oid: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct TrapMessage {
+    source: String,
+    version: String,
+    community: String,
+    varbinds: Vec<Varbind>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let cli = Cli::parse();
+    let cfg = Config::from_file(&cli.config)?;
+
+    info!("Starting trap receiver on {}", cfg.listen_addr);
+
+    let socket = UdpSocket::bind(&cfg.listen_addr).await?;
+
+    let nats_client = async_nats::connect(&cfg.nats_url).await?;
+    let js = async_nats::jetstream::new(nats_client);
+
+    let mut buf = vec![0u8; 65535];
+    loop {
+        let (len, addr) = socket.recv_from(&mut buf).await?;
+        let data = &buf[..len];
+        match snmp2::Pdu::from_bytes(data) {
+            Ok(pdu) => {
+                let msg = build_message(&pdu, addr);
+                let payload = serde_json::to_vec(&msg)?;
+                if let Err(e) = js.publish(&cfg.subject, payload.into()).await?.await {
+                    warn!("Failed to publish trap: {e}");
+                }
+            }
+            Err(e) => {
+                warn!("Failed to parse SNMP trap from {addr}: {e}");
+            }
+        }
+    }
+}
+
+fn build_message(pdu: &snmp2::Pdu<'_>, addr: SocketAddr) -> TrapMessage {
+    let version = match pdu.version() {
+        Ok(v) => format!("{:?}", v),
+        Err(_) => "unknown".to_string(),
+    };
+    let community = String::from_utf8_lossy(pdu.community).into_owned();
+    let mut varbinds = Vec::new();
+    for (oid, value) in pdu.varbinds.clone() {
+        varbinds.push(Varbind {
+            oid: format!("{}", oid),
+            value: format!("{:?}", value),
+        });
+    }
+    TrapMessage {
+        source: addr.to_string(),
+        version,
+        community,
+        varbinds,
+    }
+}


### PR DESCRIPTION
## Summary
- add new `trapd` crate under `cmd/`
- implement async trap receiver using `snmp2` and publishing to NATS JetStream
- document configuration and usage
- format Rust code in the new crate
- update Makefile to lint/test `trapd`

## Testing
- `make lint` *(fails: can't load config)*
- `make test` *(interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684f8ba2f1e88320be2a3480ca02a042