### PR TITLE
Fix trapd TLS connection

### DIFF
--- a/cmd/trapd/README.md
+++ b/cmd/trapd/README.md
@@ -14,6 +14,21 @@ Create a JSON file with the following fields:
 }
 ```
 
+Optionally enable TLS by adding a `security` section:
+
+```json
+{
+  "listen_addr": "0.0.0.0:162",
+  "nats_url": "nats://localhost:4222",
+  "subject": "snmp.traps",
+  "security": {
+    "cert_file": "/etc/serviceradar/certs/trapd.pem",
+    "key_file": "/etc/serviceradar/certs/trapd-key.pem",
+    "ca_file": "/etc/serviceradar/certs/root.pem"
+  }
+}
+```
+
 Run the service with:
 
 ```sh


### PR DESCRIPTION
## Summary
- add TLS certificate options to trapd NATS connection
- document trapd TLS configuration

## Testing
- `cargo build --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f9d0d1dc08320bf82c6577fcef135