### PR TITLE
Add KV rule loading to zen-consumer

### DIFF
--- a/cmd/zen-consumer/README.md
+++ b/cmd/zen-consumer/README.md
@@ -13,7 +13,8 @@ Create a JSON file with the following fields:
   "consumer_name": "zen-consumer",
   "subjects": ["events"],
   "decision_key": "example-decision",
-  "rules_dir": "/etc/serviceradar/zen-rules",
+  "agent_id": "agent-01",
+  "kv_bucket": "serviceradar-kv",
   "result_subject": "events.processed"
 }
 ```
@@ -27,7 +28,8 @@ Optionally add TLS settings:
   "consumer_name": "zen-consumer",
   "subjects": ["events"],
   "decision_key": "example-decision",
-  "rules_dir": "/etc/serviceradar/zen-rules",
+  "agent_id": "agent-01",
+  "kv_bucket": "serviceradar-kv",
   "result_subject": "events.processed",
   "security": {
     "cert_file": "/etc/serviceradar/certs/zen-consumer.pem",

--- a/cmd/zen-consumer/src/kv_loader.rs
+++ b/cmd/zen-consumer/src/kv_loader.rs
@@ -1,0 +1,50 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use async_nats::jetstream::kv::Store;
+use serde_json;
+use zen_engine::loader::{DecisionLoader, LoaderError, LoaderResponse};
+use zen_engine::model::DecisionContent;
+
+#[derive(Debug, Clone)]
+pub struct KvLoader {
+    store: Store,
+    prefix: String,
+}
+
+impl KvLoader {
+    pub fn new(store: Store, prefix: String) -> Self {
+        Self { store, prefix }
+    }
+
+    async fn load_from_kv(&self, key: &str) -> LoaderResponse {
+        let full_key = if self.prefix.is_empty() {
+            format!("{}.json", key)
+        } else {
+            format!("{}/{}.json", self.prefix.trim_end_matches('/'), key)
+        };
+        match self.store.get(full_key).await {
+            Ok(Some(bytes)) => {
+                let content: DecisionContent = serde_json::from_slice(&bytes)
+                    .map_err(|e| LoaderError::Internal {
+                        key: key.to_string(),
+                        source: e.into(),
+                    })?;
+                Ok(Arc::new(content))
+            }
+            Ok(None) => Err(LoaderError::NotFound(key.to_string()).into()),
+            Err(e) => Err(LoaderError::Internal {
+                key: key.to_string(),
+                source: e.into(),
+            }
+            .into()),
+        }
+    }
+}
+
+impl DecisionLoader for KvLoader {
+    fn load<'a>(&'a self, key: &'a str) -> impl Future<Output = LoaderResponse> + 'a {
+        async move { self.load_from_kv(key).await }
+    }
+}
+

--- a/cmd/zen-consumer/zen-consumer.json
+++ b/cmd/zen-consumer/zen-consumer.json
@@ -4,6 +4,7 @@
   "consumer_name": "zen-consumer",
   "subjects": ["events"],
   "decision_key": "example-decision",
-  "rules_dir": "/etc/serviceradar/zen-rules",
+  "agent_id": "agent-01",
+  "kv_bucket": "serviceradar-kv",
   "result_subject": "events.processed"
 }


### PR DESCRIPTION
## Summary
- support pulling Zen rules from NATS JetStream KV
- require `agent_id` and optional `kv_bucket` in config
- document new configuration in README

## Testing
- `go test ./...` *(fails: TestSNMPService)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684fbef63cdc8320a09681fb844c1f79