### PR TITLE
Refine KV rule loading by stream and subject

### DIFF
--- a/cmd/zen-consumer/README.md
+++ b/cmd/zen-consumer/README.md
@@ -19,6 +19,12 @@ Create a JSON file with the following fields:
 }
 ```
 
+Decision rules are loaded from the KV store using the following key pattern:
+
+```
+agents/<agent-id>/<stream-name>/<subject>/<decision_key>.json
+```
+
 Optionally add TLS settings:
 
 ```json


### PR DESCRIPTION
## Summary
- restrict zen rule path to `<agent>/<stream>/<subject>/<decision>.json`
- update zen-consumer README to document new key pattern

## Testing
- `cargo test` in `cmd/zen-consumer`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fc5aea9588320adf1f5727a042868