### PR TITLE
Add JDM examples for zen-consumer

### DIFF
--- a/cmd/zen-consumer/testdata/host_switch.json
+++ b/cmd/zen-consumer/testdata/host_switch.json
@@ -1,0 +1,57 @@
+{
+  "nodes": [
+    {
+      "id": "23d19fe0-d520-438c-9fae-eaac7effb03f",
+      "type": "inputNode",
+      "position": { "x": 80, "y": 150 },
+      "name": "Request"
+    },
+    {
+      "id": "c616a8c5-fbf3-45c0-b5d5-0e539542325c",
+      "type": "switchNode",
+      "position": { "x": 300, "y": 150 },
+      "name": "Host Switch",
+      "content": {
+        "statements": [
+          { "id": "36766a9c-91a2-4e42-ab61-b2adaa802170", "condition": "host == 'tonka01'" },
+          { "id": "2c58954e-eca8-4f42-b005-dee2380b8dd3", "condition": "" }
+        ]
+      }
+    },
+    {
+      "id": "5c3a0503-d1f5-49b7-947f-f386e3037dfa",
+      "type": "expressionNode",
+      "position": { "x": 560, "y": 120 },
+      "name": "Known Device",
+      "content": {
+        "expressions": [
+          { "id": "3d104576-91dc-4104-8739-b9224021c552", "key": "device", "value": "'unifi'" }
+        ]
+      }
+    },
+    {
+      "id": "06b6eed5-529c-48bb-bdb3-45e832729f67",
+      "type": "expressionNode",
+      "position": { "x": 560, "y": 240 },
+      "name": "Unknown Device",
+      "content": {
+        "expressions": [
+          { "id": "ec61085f-f8c2-42e0-9fbe-3dc702714b52", "key": "device", "value": "'other'" }
+        ]
+      }
+    },
+    {
+      "id": "c5494e63-4bbd-4562-b347-909a21f3288d",
+      "type": "outputNode",
+      "position": { "x": 820, "y": 180 },
+      "name": "Response"
+    }
+  ],
+  "edges": [
+    { "id": "c6e10fab-1038-48c9-8ead-aeab189a3bee", "sourceId": "23d19fe0-d520-438c-9fae-eaac7effb03f", "type": "edge", "targetId": "c616a8c5-fbf3-45c0-b5d5-0e539542325c" },
+    { "id": "04867e89-df5e-4e66-9265-067ade65e342", "sourceId": "c616a8c5-fbf3-45c0-b5d5-0e539542325c", "type": "edge", "targetId": "5c3a0503-d1f5-49b7-947f-f386e3037dfa", "sourceHandle": "36766a9c-91a2-4e42-ab61-b2adaa802170" },
+    { "id": "65a28212-f634-4dca-8cbb-136ca27cf22d", "sourceId": "c616a8c5-fbf3-45c0-b5d5-0e539542325c", "type": "edge", "targetId": "06b6eed5-529c-48bb-bdb3-45e832729f67", "sourceHandle": "2c58954e-eca8-4f42-b005-dee2380b8dd3" },
+    { "id": "2ee0c6c1-8017-4240-81b3-8330022ae90f", "sourceId": "5c3a0503-d1f5-49b7-947f-f386e3037dfa", "type": "edge", "targetId": "c5494e63-4bbd-4562-b347-909a21f3288d" },
+    { "id": "9a7d8ed4-9aab-4ed0-8fef-3ff59629642e", "sourceId": "06b6eed5-529c-48bb-bdb3-45e832729f67", "type": "edge", "targetId": "c5494e63-4bbd-4562-b347-909a21f3288d" }
+  ]
+}

--- a/cmd/zen-consumer/testdata/syslog_settings.json
+++ b/cmd/zen-consumer/testdata/syslog_settings.json
@@ -1,0 +1,41 @@
+{
+  "nodes": [
+    {
+      "id": "54f27013-4371-4966-aadb-eacb4e130f9d",
+      "type": "inputNode",
+      "position": { "x": 150, "y": 210 },
+      "name": "Request"
+    },
+    {
+      "id": "9a96fde9-1d2f-4f42-b6e9-abfacb627cba",
+      "type": "decisionTableNode",
+      "position": { "x": 410, "y": 210 },
+      "name": "Message Classification",
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [
+          { "field": "short_message", "id": "fld_short_message", "name": "Short Message", "type": "expression" }
+        ],
+        "outputs": [
+          { "field": "event", "id": "fld_event", "name": "Event", "type": "expression" }
+        ],
+        "rules": [
+          { "_id": "810f8589-02de-4787-8f33-bbd4a9907a4d", "fld_short_message": "contains(short_message, 'Syslog Settings Mode setting')", "fld_event": "'mode_changed'" },
+          { "_id": "6d3d30cf-263c-4a47-b85f-4d07cd6e319b", "fld_short_message": "contains(short_message, 'Syslog Settings External Server setting')", "fld_event": "'external_server_changed'" },
+          { "_id": "9c0a323e-fec9-4a14-bd52-bbde8c7fcdc0", "fld_short_message": "contains(short_message, 'Syslog Settings CEF Logging setting')", "fld_event": "'cef_logging_changed'" },
+          { "_id": "8cca0067-ae52-437a-8b92-451eb1dc54f6", "fld_short_message": "", "fld_event": "'other'" }
+        ]
+      }
+    },
+    {
+      "id": "f439e3a0-6ddf-42a7-afc8-62e2fe19db4f",
+      "type": "outputNode",
+      "position": { "x": 660, "y": 210 },
+      "name": "Response"
+    }
+  ],
+  "edges": [
+    { "id": "8b65cdef-b881-452a-899b-863b829ee77c", "sourceId": "54f27013-4371-4966-aadb-eacb4e130f9d", "type": "edge", "targetId": "9a96fde9-1d2f-4f42-b6e9-abfacb627cba" },
+    { "id": "ce8f2a4f-8f9e-4bbc-94f6-bd15caeed0c4", "sourceId": "9a96fde9-1d2f-4f42-b6e9-abfacb627cba", "type": "edge", "targetId": "f439e3a0-6ddf-42a7-afc8-62e2fe19db4f" }
+  ]
+}


### PR DESCRIPTION
## Summary
- provide `syslog_settings.json` with decision table for syslog messages
- add `host_switch.json` showing switch node example

## Testing
- `make test` *(fails: TestStartAndStop in pkg/sync)*

------
https://chatgpt.com/codex/tasks/task_e_68503895e764832098a92acd17a3c4e6