### PR TITLE
Ensure JetStream used for zen-consumer results

### DIFF
--- a/cmd/zen-consumer/README.md
+++ b/cmd/zen-consumer/README.md
@@ -25,6 +25,10 @@ Decision rules are loaded from the KV store using the following key pattern:
 agents/<agent-id>/<stream-name>/<subject>/<decision_key>.json
 ```
 
+Ensure the subject specified in `result_subject` is part of a JetStream stream
+so processed results are persisted. For example, create a stream that includes
+`events.processed` before running the consumer.
+
 Optionally add TLS settings:
 
 ```json


### PR DESCRIPTION
## Summary
- update zen-consumer to publish evaluation results via JetStream
- update sample configuration test
- note JetStream requirement for `result_subject`

## Testing
- `cargo test --locked --quiet`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68510cdacb30832082cc9f5345bdf880