### PR TITLE
Add Armis device ID metadata

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -144,6 +144,7 @@ The Armis integration:
 - Fetches device information from Armis
 - Creates device records in the KV store
 - Automatically generates network sweep configurations for discovered devices
+- Stores the Armis device ID in each device's metadata for later correlation
 
 #### Armis-Specific Options
 

--- a/pkg/sync/integrations/armis/devices.go
+++ b/pkg/sync/integrations/armis/devices.go
@@ -257,8 +257,13 @@ func (*ArmisIntegration) processDevices(devices []Device) (data map[string][]byt
 	for i := range devices {
 		device := &devices[i] // Use a pointer to avoid copying the struct
 
-		// Marshal the device to JSON
-		value, err := json.Marshal(device)
+		enriched := DeviceWithMetadata{
+			Device:   *device,
+			Metadata: map[string]string{"armis_device_id": fmt.Sprintf("%d", device.ID)},
+		}
+
+		// Marshal the device with metadata to JSON
+		value, err := json.Marshal(enriched)
 		if err != nil {
 			log.Printf("Failed to marshal device %d: %v", device.ID, err)
 			continue

--- a/pkg/sync/integrations/armis/types.go
+++ b/pkg/sync/integrations/armis/types.go
@@ -90,6 +90,14 @@ type Device struct {
 	Site             interface{} `json:"site"`
 }
 
+// DeviceWithMetadata represents an Armis device along with ServiceRadar metadata.
+// The Metadata field is not provided by the Armis API but is used internally to
+// persist additional information such as the Armis device ID.
+type DeviceWithMetadata struct {
+	Device
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
 // DefaultArmisIntegration provides the default implementations for the interfaces.
 type DefaultArmisIntegration struct {
 	Config     *models.SourceConfig


### PR DESCRIPTION
## Summary
- include new `DeviceWithMetadata` type for Armis integration
- save the Armis device ID in metadata when storing devices
- document Armis device ID storage in sync docs

## Testing
- `go test ./...` *(fails: missing mock calls in `pkg/checker/snmp`)*

------
https://chatgpt.com/codex/tasks/task_e_6851d43e6d008320aa9a37f4bc2620a5