### PR TITLE
Allow device consumer to use separate Proton TLS

### DIFF
--- a/cmd/consumers/device/main.go
+++ b/cmd/consumers/device/main.go
@@ -25,13 +25,18 @@ func main() {
 		log.Fatalf("Device consumer config validation failed: %v", err)
 	}
 
+	dbSecurity := devCfg.Security
+	if devCfg.DBSecurity != nil {
+		dbSecurity = devCfg.DBSecurity
+	}
+
 	dbConfig := &models.DBConfig{
 		DBAddr:   devCfg.Database.Addresses[0],
 		DBName:   devCfg.Database.Name,
 		DBUser:   devCfg.Database.Username,
 		DBPass:   devCfg.Database.Password,
 		Database: devCfg.Database,
-		Security: devCfg.Security,
+		Security: dbSecurity,
 	}
 
 	dbService, err := db.New(ctx, dbConfig)

--- a/packaging/device-manager/config/devices.json
+++ b/packaging/device-manager/config/devices.json
@@ -19,5 +19,16 @@
       "key_file": "/etc/nats/certs/nats-server-key.pem",
       "ca_file": "/etc/nats/certs/root.pem"
     }
+  },
+  "db_security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "server_name": "127.0.0.1",
+    "role": "client",
+    "tls": {
+      "cert_file": "/etc/serviceradar/certs/core.pem",
+      "key_file": "/etc/serviceradar/certs/core-key.pem",
+      "ca_file": "/etc/serviceradar/certs/root.pem"
+    }
   }
 }

--- a/pkg/consumers/devices/config.go
+++ b/pkg/consumers/devices/config.go
@@ -23,6 +23,7 @@ type DeviceConsumerConfig struct {
 	StreamName   string                 `json:"stream_name"`
 	ConsumerName string                 `json:"consumer_name"`
 	Security     *models.SecurityConfig `json:"security"`
+	DBSecurity   *models.SecurityConfig `json:"db_security"`
 	Database     models.ProtonDatabase  `json:"database"`
 }
 
@@ -38,6 +39,9 @@ func (c *DeviceConsumerConfig) UnmarshalJSON(data []byte) error {
 	*c = DeviceConsumerConfig(alias.Alias)
 	if c.Security != nil && c.Security.CertDir != "" {
 		config.NormalizeTLSPaths(&c.Security.TLS, c.Security.CertDir)
+	}
+	if c.DBSecurity != nil && c.DBSecurity.CertDir != "" {
+		config.NormalizeTLSPaths(&c.DBSecurity.TLS, c.DBSecurity.CertDir)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- support `db_security` in device consumer config for Proton
- use alternate TLS options when connecting to Proton
- update default devices.json with `db_security` section

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685258435acc8320a8a0a69e2bf2acea