### PR TITLE
Fix TLS client auth for device manager

### DIFF
--- a/packaging/device-manager/config/devices.json
+++ b/packaging/device-manager/config/devices.json
@@ -13,11 +13,11 @@
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",
     "server_name": "127.0.0.1",
-    "role": "client",
+    "role": "core",
     "tls": {
-      "cert_file": "/etc/nats/certs/nats-server.pem",
-      "key_file": "/etc/nats/certs/nats-server-key.pem",
-      "ca_file": "/etc/nats/certs/root.pem"
+      "cert_file": "/etc/serviceradar/certs/core.pem",
+      "key_file": "/etc/serviceradar/certs/core-key.pem",
+      "ca_file": "/etc/serviceradar/certs/root.pem"
     }
   },
   "db_security": {

--- a/packaging/nats/config/nats-server.conf
+++ b/packaging/nats/config/nats-server.conf
@@ -31,6 +31,24 @@ tls {
   verify_and_map: true
 }
 
+# Map the client certificate's Common Name (CN) to a NATS user so that
+# components using certificates (e.g., core services) can authenticate.
+authorization {
+  users: [
+    {
+      user: "CN=core.serviceradar,O=ServiceRadar"
+      permissions: {
+        publish: {
+          allow: [">"]
+        }
+        subscribe: {
+          allow: [">"]
+        }
+      }
+    }
+  ]
+}
+
 # Logging settings
 logfile: "/var/log/nats/nats.log"
 debug: true


### PR DESCRIPTION
## Summary
- allow core services to authenticate using CN=core.serviceradar in NATS

## Testing
- `make lint` *(fails: can't load config)*
- `make test` *(fails: TestBaseProcessor_MemoryManagement)*

------
https://chatgpt.com/codex/tasks/task_e_68525bcc212883208b55ad869c1636d6