### PR TITLE
Listen to device stream via JetStream domain

### DIFF
--- a/packaging/device-manager/config/devices.json
+++ b/packaging/device-manager/config/devices.json
@@ -1,10 +1,13 @@
 {
   "listen_addr": "0.0.0.0:50059",
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "stream_name": "devices",
   "consumer_name": "device-db-writer",
   "database": {
-    "addresses": ["127.0.0.1:9440"],
+    "addresses": [
+      "127.0.0.1:9440"
+    ],
     "name": "default",
     "username": "default",
     "password": "changeme"

--- a/pkg/consumers/devices/config.go
+++ b/pkg/consumers/devices/config.go
@@ -22,6 +22,7 @@ type DeviceConsumerConfig struct {
 	NATSURL      string                 `json:"nats_url"`
 	StreamName   string                 `json:"stream_name"`
 	ConsumerName string                 `json:"consumer_name"`
+	Domain       string                 `json:"domain"`
 	Security     *models.SecurityConfig `json:"security"`
 	DBSecurity   *models.SecurityConfig `json:"db_security"`
 	Database     models.ProtonDatabase  `json:"database"`

--- a/pkg/consumers/devices/service.go
+++ b/pkg/consumers/devices/service.go
@@ -44,7 +44,12 @@ func (s *Service) Start(ctx context.Context) error {
 		return err
 	}
 	s.nc = nc
-	js, err := jetstream.New(nc)
+	var js jetstream.JetStream
+	if s.cfg.Domain != "" {
+		js, err = jetstream.NewWithDomain(nc, s.cfg.Domain)
+	} else {
+		js, err = jetstream.New(nc)
+	}
 	if err != nil {
 		nc.Close()
 		return err


### PR DESCRIPTION
## Summary
- allow device manager to set a JetStream domain
- open JetStream using NewWithDomain when `domain` is configured
- add `domain` option in device manager example config

## Testing
- `go vet ./...` *(fails: unreachable code in generated files)*

------
https://chatgpt.com/codex/tasks/task_e_685268a9fed883209aee3c40b24661cc