### PR TITLE
Add subject filter to device consumer

### DIFF
--- a/packaging/device-manager/config/devices.json
+++ b/packaging/device-manager/config/devices.json
@@ -2,7 +2,8 @@
   "listen_addr": "0.0.0.0:50059",
   "nats_url": "nats://127.0.0.1:4222",
   "domain": "edge",
-  "stream_name": "devices",
+  "stream_name": "events",
+  "subject": "events.devices",
   "consumer_name": "device-db-writer",
   "database": {
     "addresses": [

--- a/pkg/consumers/devices/config.go
+++ b/pkg/consumers/devices/config.go
@@ -20,6 +20,7 @@ var (
 type DeviceConsumerConfig struct {
 	ListenAddr   string                 `json:"listen_addr"`
 	NATSURL      string                 `json:"nats_url"`
+	Subject      string                 `json:"subject"`
 	StreamName   string                 `json:"stream_name"`
 	ConsumerName string                 `json:"consumer_name"`
 	Domain       string                 `json:"domain"`

--- a/pkg/consumers/devices/consumer.go
+++ b/pkg/consumers/devices/consumer.go
@@ -16,7 +16,7 @@ type Consumer struct {
 	consumer     jetstream.Consumer
 }
 
-func NewConsumer(ctx context.Context, js jetstream.JetStream, streamName, consumerName string) (*Consumer, error) {
+func NewConsumer(ctx context.Context, js jetstream.JetStream, streamName, consumerName, subject string) (*Consumer, error) {
 	log.Printf("Creating/getting pull consumer: stream=%s, consumer=%s", streamName, consumerName)
 	consumer, err := js.Consumer(ctx, streamName, consumerName)
 	if err != nil {
@@ -26,6 +26,9 @@ func NewConsumer(ctx context.Context, js jetstream.JetStream, streamName, consum
 			AckWait:       30 * time.Second,
 			MaxDeliver:    3,
 			MaxAckPending: 1000,
+		}
+		if subject != "" {
+			cfg.FilterSubject = subject
 		}
 		consumer, err = js.CreateConsumer(ctx, streamName, cfg)
 		if err != nil {

--- a/pkg/consumers/devices/service.go
+++ b/pkg/consumers/devices/service.go
@@ -64,7 +64,7 @@ func (s *Service) Start(ctx context.Context) error {
 		nc.Close()
 		return fmt.Errorf("failed to get stream info: %w", err)
 	}
-	s.consumer, err = NewConsumer(ctx, js, s.cfg.StreamName, s.cfg.ConsumerName)
+	s.consumer, err = NewConsumer(ctx, js, s.cfg.StreamName, s.cfg.ConsumerName, s.cfg.Subject)
 	if err != nil {
 		nc.Close()
 		return err


### PR DESCRIPTION
## Summary
- support specifying a subject filter for the device consumer
- update example device consumer configuration

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68526b4714188320a7501e52033c42f2