### PR TITLE
Fix netbox sweep config crash

### DIFF
--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -151,6 +151,11 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 
 // writeSweepConfig generates and writes the sweep Config to KV.
 func (n *NetboxIntegration) writeSweepConfig(ctx context.Context, ips []string) {
+	if n.KvClient == nil {
+		log.Print("KV client not configured; skipping sweep config write")
+
+		return
+	}
 	sweepConfig := models.SweepConfig{
 		Networks:      ips,
 		Ports:         []int{22, 80, 443, 3389, 445, 8080},


### PR DESCRIPTION
## Summary
- check KvClient in netbox integration before writing sweep config

## Testing
- `go test ./pkg/sync/...`
- `go test ./...` *(fails: TestSNMPService missing call)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef01b6188320aff86924429aa92e