### PR TITLE
Fix nil kv client in sync service

### DIFF
--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -73,7 +73,7 @@ func TestNew_ValidConfig(t *testing.T) {
 		},
 	}
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 	assert.NotNil(t, syncer)
 	assert.NotNil(t, syncer.poller)
@@ -131,7 +131,7 @@ func TestSync_Success(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())
@@ -182,7 +182,7 @@ func TestStartAndStop(t *testing.T) {
 	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil).Times(2) // Initial poll + 1 tick
 	mockKV.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto.PutResponse{}, nil).Times(2)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -284,7 +284,7 @@ func TestStart_ContextCancellation(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -341,7 +341,7 @@ func TestSync_NetboxSuccess(t *testing.T) {
 		Value: []byte(`{"id":1,"name":"device1","primary_ip4":{"address":"192.168.1.1/24"}}`),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())


### PR DESCRIPTION
## Summary
- connect to KV in `sync.NewWithGRPC`
- store and close the KV gRPC client
- update tests for new parameter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852f17e36c88320b5c4b9ba50a05566