### PR TITLE
Move device publishing to sync

### DIFF
--- a/pkg/sync/integrations/armis/types.go
+++ b/pkg/sync/integrations/armis/types.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/carverauto/serviceradar/pkg/models"
 	"github.com/carverauto/serviceradar/proto"
-	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/grpc"
 )
 
@@ -42,9 +41,6 @@ type ArmisIntegration struct {
 	TokenProvider TokenProvider
 	DeviceFetcher DeviceFetcher
 	KVWriter      KVWriter
-
-	JS      jetstream.JetStream
-	Subject string
 
 	// Interfaces for querying sweep results and updating Armis devices
 	SweepQuerier SweepResultsQuerier

--- a/pkg/sync/integrations/integrations.go
+++ b/pkg/sync/integrations/integrations.go
@@ -27,7 +27,6 @@ import (
 	"github.com/carverauto/serviceradar/pkg/sync/integrations/armis"
 	"github.com/carverauto/serviceradar/pkg/sync/integrations/netbox"
 	"github.com/carverauto/serviceradar/proto"
-	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/grpc"
 )
 
@@ -38,8 +37,6 @@ func NewArmisIntegration(
 	kvClient proto.KVServiceClient,
 	grpcConn *grpc.ClientConn,
 	serverName string,
-	js jetstream.JetStream,
-	subject string,
 ) *armis.ArmisIntegration {
 	// Extract page size if specified
 	pageSize := 100 // default
@@ -121,8 +118,6 @@ func NewArmisIntegration(
 		SweeperConfig: defaultSweepCfg,
 		SweepQuerier:  sweepQuerier,
 		Updater:       armisUpdater,
-		JS:            js,
-		Subject:       subject,
 	}
 }
 

--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -35,16 +35,16 @@ var (
 )
 
 // Fetch retrieves devices from NetBox and generates sweep config.
-func (n *NetboxIntegration) Fetch(ctx context.Context) (map[string][]byte, error) {
+func (n *NetboxIntegration) Fetch(ctx context.Context) (map[string][]byte, []models.Device, error) {
 	resp, err := n.fetchDevices(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer n.closeResponse(resp)
 
 	deviceResp, err := n.decodeResponse(resp)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	data, ips := n.processDevices(deviceResp)
@@ -53,7 +53,7 @@ func (n *NetboxIntegration) Fetch(ctx context.Context) (map[string][]byte, error
 
 	n.writeSweepConfig(ctx, ips)
 
-	return data, nil
+	return data, nil, nil
 }
 
 // fetchDevices sends the HTTP request to the NetBox API.

--- a/pkg/sync/interfaces.go
+++ b/pkg/sync/interfaces.go
@@ -43,7 +43,7 @@ type GRPCClient interface {
 
 // Integration defines the interface for fetching data from external sources.
 type Integration interface {
-	Fetch(ctx context.Context) (map[string][]byte, error)
+	Fetch(ctx context.Context) (map[string][]byte, []models.Device, error)
 }
 
 // IntegrationFactory defines a function type for creating integrations.

--- a/pkg/sync/mock_sync.go
+++ b/pkg/sync/mock_sync.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	models "github.com/carverauto/serviceradar/pkg/models"
 	proto "github.com/carverauto/serviceradar/proto"
 	gomock "go.uber.org/mock/gomock"
 	grpc "google.golang.org/grpc"
@@ -200,12 +201,13 @@ func (m *MockIntegration) EXPECT() *MockIntegrationMockRecorder {
 }
 
 // Fetch mocks base method.
-func (m *MockIntegration) Fetch(ctx context.Context) (map[string][]byte, error) {
+func (m *MockIntegration) Fetch(ctx context.Context) (map[string][]byte, []models.Device, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", ctx)
 	ret0, _ := ret[0].(map[string][]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]models.Device)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Fetch indicates an expected call of Fetch.

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -125,7 +125,7 @@ func TestSync_Success(t *testing.T) {
 	}
 
 	data := map[string][]byte{"devices": []byte("data")}
-	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil)
+	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil)
 	mockKV.EXPECT().Put(gomock.Any(), &proto.PutRequest{
 		Key:   "armis/devices",
 		Value: []byte("data"),
@@ -179,7 +179,7 @@ func TestStartAndStop(t *testing.T) {
 
 	data := map[string][]byte{"devices": []byte("data")}
 
-	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil).Times(2) // Initial poll + 1 tick
+	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil).Times(2) // Initial poll + 1 tick
 	mockKV.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto.PutResponse{}, nil).Times(2)
 
 	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
@@ -278,7 +278,7 @@ func TestStart_ContextCancellation(t *testing.T) {
 
 	data := map[string][]byte{"devices": []byte("data")}
 
-	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil)
+	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil)
 	mockKV.EXPECT().Put(gomock.Any(), &proto.PutRequest{
 		Key:   "armis/devices",
 		Value: []byte("data"),
@@ -335,7 +335,7 @@ func TestSync_NetboxSuccess(t *testing.T) {
 	}
 
 	data := map[string][]byte{"1": []byte(`{"id":1,"name":"device1","primary_ip4":{"address":"192.168.1.1/24"}}`)}
-	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil)
+	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil)
 	mockKV.EXPECT().Put(gomock.Any(), &proto.PutRequest{
 		Key:   "netbox/1",
 		Value: []byte(`{"id":1,"name":"device1","primary_ip4":{"address":"192.168.1.1/24"}}`),


### PR DESCRIPTION
## Summary
- simplify Armis integration by removing direct JetStream handling
- add JetStream device publishing logic to the sync package
- update integration interfaces and implementations
- adapt tests to new signatures

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852fb27a1bc83208bbf75ff3fe5649e