### PR TITLE
Fix Armis availability and update tests

### DIFF
--- a/pkg/sync/integrations/armis/armis_test.go
+++ b/pkg/sync/integrations/armis/armis_test.go
@@ -103,7 +103,7 @@ func TestArmisIntegration_Fetch_WithUpdaterAndCorrelation(t *testing.T) {
 		}).Return(nil)
 
 	// 3. Execute the method under test
-	result, devices, err := integration.Fetch(context.Background())
+	result, _, err := integration.Fetch(context.Background())
 
 	// 4. Assert the results
 	require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestArmisIntegration_FetchWithMultiplePages(t *testing.T) {
 	integration.KVWriter.(*MockKVWriter).
 		EXPECT().WriteSweepConfig(gomock.Any(), expectedSweepConfig).Return(nil)
 
-	result, devices, err := integration.Fetch(context.Background())
+	result, _, err := integration.Fetch(context.Background())
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -392,7 +392,7 @@ func TestArmisIntegration_FetchErrorHandling(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMocks(integration)
 
-			result, devices, err := integration.Fetch(context.Background())
+			result, _, err := integration.Fetch(context.Background())
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectedError)
@@ -428,7 +428,7 @@ func TestArmisIntegration_FetchNoQueries(t *testing.T) {
 		KVWriter:      NewMockKVWriter(ctrl),
 	}
 
-	result, devices, err := integration.Fetch(context.Background())
+	result, _, err := integration.Fetch(context.Background())
 
 	assert.Nil(t, result)
 	require.Error(t, err)

--- a/pkg/sync/integrations/armis/armis_updater.go
+++ b/pkg/sync/integrations/armis/armis_updater.go
@@ -78,7 +78,7 @@ func extractFirstIP(ipList string) string {
 // GetDeviceAvailabilityReport generates a report of device availability
 func (a *ArmisIntegration) GetDeviceAvailabilityReport(ctx context.Context) (*AvailabilityReport, error) {
 	// Fetch current devices from Armis
-	data, err := a.Fetch(ctx)
+	data, _, err := a.Fetch(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch devices: %w", err)
 	}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -73,7 +73,7 @@ func TestNew_ValidConfig(t *testing.T) {
 		},
 	}
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
 	require.NoError(t, err)
 	assert.NotNil(t, syncer)
 	assert.NotNil(t, syncer.poller)
@@ -131,7 +131,7 @@ func TestSync_Success(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())
@@ -182,7 +182,7 @@ func TestStartAndStop(t *testing.T) {
 	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil).Times(2) // Initial poll + 1 tick
 	mockKV.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto.PutResponse{}, nil).Times(2)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -284,7 +284,7 @@ func TestStart_ContextCancellation(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -341,7 +341,7 @@ func TestSync_NetboxSuccess(t *testing.T) {
 		Value: []byte(`{"id":1,"name":"device1","primary_ip4":{"address":"192.168.1.1/24"}}`),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())


### PR DESCRIPTION
## Summary
- use new Fetch signature when generating availability reports
- adjust unit tests for Armis integration and sync poller

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852ff227c8c8320bb8dceafc5badfdf