### PR TITLE
Enable TLS for JetStream connections

### DIFF
--- a/pkg/consumers/netflow/service.go
+++ b/pkg/consumers/netflow/service.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/carverauto/serviceradar/pkg/db"
 	"github.com/carverauto/serviceradar/pkg/lifecycle"
+	"github.com/carverauto/serviceradar/pkg/natsutil"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -63,9 +64,15 @@ func (s *Service) Start(ctx context.Context) error {
 	}
 
 	// Connect to NATS with mTLS
+	tlsConf, err := natsutil.TLSConfig(s.cfg.Security)
+	if err != nil {
+		return fmt.Errorf("failed to build NATS TLS config: %w", err)
+	}
+
 	nc, err := nats.Connect(s.cfg.NATSURL,
-		nats.ClientCert(s.cfg.Security.TLS.CertFile, s.cfg.Security.TLS.KeyFile),
+		nats.Secure(tlsConf),
 		nats.RootCAs(s.cfg.Security.TLS.CAFile),
+		nats.ClientCert(s.cfg.Security.TLS.CertFile, s.cfg.Security.TLS.KeyFile),
 	)
 	if err != nil {
 		return err

--- a/pkg/natsutil/tls.go
+++ b/pkg/natsutil/tls.go
@@ -1,0 +1,39 @@
+package natsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/carverauto/serviceradar/pkg/models"
+)
+
+// TLSConfig builds a tls.Config for connecting to NATS using mTLS.
+func TLSConfig(sec *models.SecurityConfig) (*tls.Config, error) {
+	if sec == nil || sec.Mode != "mtls" {
+		return nil, fmt.Errorf("mtls security required")
+	}
+
+	cert, err := tls.LoadX509KeyPair(sec.TLS.CertFile, sec.TLS.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
+	caCert, err := os.ReadFile(sec.TLS.CAFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caPool,
+		ServerName:   sec.ServerName,
+		MinVersion:   tls.VersionTLS13,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add `natsutil` package for constructing TLS configs
- secure NATS connections in sync, netflow and device consumers with `nats.Secure`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685304e0d1008320b442f93763ecf5ad