### PR TITLE
Update sync docs for NATS TLS

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -46,6 +46,7 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
   "kv_address": "192.168.2.23:50057",
   "listen_addr": "192.168.2.23:50058",
   "poll_interval": "5m",
+  "nats_url": "tls://192.168.2.23:4222",
   "security": {
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",
@@ -80,6 +81,7 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
 | `kv_address` | Address and port of the KV service | N/A | Yes |
 | `listen_addr` | Address and port for the Sync service to listen on | N/A | Yes |
 | `poll_interval` | How often to fetch and update data | `30m` | No |
+| `nats_url` | URL for connecting to the NATS Server | `nats://127.0.0.1:4222` | No |
 | `security` | mTLS security settings | N/A | Yes |
 
 ### Source Configuration
@@ -416,6 +418,7 @@ Here's a comprehensive example that includes multiple data sources:
   "kv_address": "192.168.2.23:50057",
   "listen_addr": "192.168.2.23:50058",
   "poll_interval": "5m",
+  "nats_url": "tls://192.168.2.23:4222",
   "security": {
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -2,6 +2,7 @@
   "kv_address": "localhost:50057",
   "listen_addr": ":50058",
   "poll_interval": "30m",
+  "nats_url": "nats://127.0.0.1:4222",
   "security": {
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",
@@ -24,6 +25,10 @@
         "boundary": "Corporate",
         "page_size": "100"
       },
-      "queries": [{"label": "all_devices", "query": "in:devices orderBy=id boundaries:\"Corporate\""}]}
+      "queries": [{
+        "label": "all_devices",
+        "query": "in:devices orderBy=id boundaries:\"Corporate\""
+      }]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- document nats_url in sync service config
- include default nats_url in packaged sync.json

## Testing
- `make test` *(fails: TestStartAndStop missing mock calls)*

------
https://chatgpt.com/codex/tasks/task_e_68530813624c83208ff6e5dabc332fdd