### PR TITLE
Add NATS TLS config to sync service

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -59,6 +59,30 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
       "client_ca_file": "root.pem"
     }
   },
+  "nats_security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "server_name": "nats-serviceradar",
+    "role": "poller",
+    "tls": {
+      "cert_file": "sync.pem",
+      "key_file": "sync-key.pem",
+      "ca_file": "root.pem",
+      "client_ca_file": "root.pem"
+    }
+  },
+  "nats_security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "server_name": "nats-serviceradar",
+    "role": "poller",
+    "tls": {
+      "cert_file": "sync.pem",
+      "key_file": "sync-key.pem",
+      "ca_file": "root.pem",
+      "client_ca_file": "root.pem"
+    }
+  },
   "sources": {
     "netbox": {
       "type": "netbox",
@@ -82,7 +106,8 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
 | `listen_addr` | Address and port for the Sync service to listen on | N/A | Yes |
 | `poll_interval` | How often to fetch and update data | `30m` | No |
 | `nats_url` | URL for connecting to the NATS Server | `nats://127.0.0.1:4222` | No |
-| `security` | mTLS security settings | N/A | Yes |
+| `security` | mTLS security settings for gRPC/KV | N/A | Yes |
+| `nats_security` | mTLS security settings for NATS | (uses `security` if omitted) | No |
 
 ### Source Configuration
 
@@ -423,6 +448,18 @@ Here's a comprehensive example that includes multiple data sources:
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",
     "server_name": "192.168.2.23",
+    "role": "poller",
+    "tls": {
+      "cert_file": "sync.pem",
+      "key_file": "sync-key.pem",
+      "ca_file": "root.pem",
+      "client_ca_file": "root.pem"
+    }
+  },
+  "nats_security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "server_name": "nats-serviceradar",
     "role": "poller",
     "tls": {
       "cert_file": "sync.pem",

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -15,6 +15,18 @@
       "client_ca_file": "root.pem"
     }
   },
+  "nats_security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "server_name": "nats-serviceradar",
+    "role": "poller",
+    "tls": {
+      "cert_file": "sync.pem",
+      "key_file": "sync-key.pem",
+      "ca_file": "root.pem",
+      "client_ca_file": "root.pem"
+    }
+  },
   "sources": {
     "armis": {
       "type": "armis",
@@ -25,10 +37,12 @@
         "boundary": "Corporate",
         "page_size": "100"
       },
-      "queries": [{
-        "label": "all_devices",
-        "query": "in:devices orderBy=id boundaries:\"Corporate\""
-      }]
+      "queries": [
+        {
+          "label": "all_devices",
+          "query": "in:devices orderBy=id boundaries:\"Corporate\""
+        }
+      ]
     }
   }
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -136,16 +136,21 @@ func defaultIntegrationRegistry(
 // NewWithGRPC sets up the gRPC client for production use with default integrations.
 func NewWithGRPC(ctx context.Context, config *Config) (*SyncPoller, error) {
 	var natsOpts []nats.Option
-	if config.Security != nil {
-		tlsConf, err := natsutil.TLSConfig(config.Security)
+	natsSec := config.Security
+	if config.NATSSecurity != nil {
+		natsSec = config.NATSSecurity
+	}
+
+	if natsSec != nil {
+		tlsConf, err := natsutil.TLSConfig(natsSec)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build NATS TLS config: %w", err)
 		}
 
 		natsOpts = append(natsOpts,
 			nats.Secure(tlsConf),
-			nats.RootCAs(config.Security.TLS.CAFile),
-			nats.ClientCert(config.Security.TLS.CertFile, config.Security.TLS.KeyFile),
+			nats.RootCAs(natsSec.TLS.CAFile),
+			nats.ClientCert(natsSec.TLS.CertFile, natsSec.TLS.KeyFile),
 		)
 	}
 


### PR DESCRIPTION
## Summary
- allow `serviceradar-sync` to specify a separate TLS block for NATS
- document new `nats_security` field and provide example

## Testing
- `go test ./...` *(fails: missing call(s) in snmp service tests)*

------
https://chatgpt.com/codex/tasks/task_e_68530bdd463483208db7cfae638229cf