### PR TITLE
Add domain config for Sync JetStream

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -47,6 +47,7 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
   "listen_addr": "192.168.2.23:50058",
   "poll_interval": "5m",
   "nats_url": "tls://192.168.2.23:4222",
+  "domain": "edge",
   "security": {
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",
@@ -106,6 +107,7 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
 | `listen_addr` | Address and port for the Sync service to listen on | N/A | Yes |
 | `poll_interval` | How often to fetch and update data | `30m` | No |
 | `nats_url` | URL for connecting to the NATS Server | `nats://127.0.0.1:4222` | No |
+| `domain` | JetStream domain for the NATS server | N/A | No |
 | `security` | mTLS security settings for gRPC/KV | N/A | Yes |
 | `nats_security` | mTLS security settings for NATS | (uses `security` if omitted) | No |
 

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -3,6 +3,7 @@
   "listen_addr": ":50058",
   "poll_interval": "30m",
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "security": {
     "mode": "mtls",
     "cert_dir": "/etc/serviceradar/certs",

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Sources      map[string]*models.SourceConfig `json:"sources"`       // e.g., "armis": {...}, "netbox": {...}
 	KVAddress    string                          `json:"kv_address"`    // KV gRPC server address (optional)
 	NATSURL      string                          `json:"nats_url"`      // NATS server URL for JetStream
+	Domain       string                          `json:"domain"`        // JetStream domain (optional)
 	PollInterval models.Duration                 `json:"poll_interval"` // Polling interval
 	Security     *models.SecurityConfig          `json:"security"`      // mTLS config for gRPC/KV
 	NATSSecurity *models.SecurityConfig          `json:"nats_security"` // Optional mTLS config for NATS

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -159,7 +159,12 @@ func NewWithGRPC(ctx context.Context, config *Config) (*SyncPoller, error) {
 		return nil, err
 	}
 
-	js, err := jetstream.New(nc)
+	var js jetstream.JetStream
+	if config.Domain != "" {
+		js, err = jetstream.NewWithDomain(nc, config.Domain)
+	} else {
+		js, err = jetstream.New(nc)
+	}
 	if err != nil {
 		nc.Close()
 		return nil, err


### PR DESCRIPTION
## Summary
- add `domain` to sync configuration
- use domain when creating JetStream context
- document the new option
- update default config with domain

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685311db2a2483208de3647744825ae3