### PR TITLE
Add configurable NATS stream for Sync

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -47,6 +47,8 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
   "listen_addr": "192.168.2.23:50058",
   "poll_interval": "5m",
   "nats_url": "tls://192.168.2.23:4222",
+  "stream_name": "devices",
+  "subject": "discovery.devices",
   "domain": "edge",
   "security": {
     "mode": "mtls",
@@ -107,6 +109,8 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
 | `listen_addr` | Address and port for the Sync service to listen on | N/A | Yes |
 | `poll_interval` | How often to fetch and update data | `30m` | No |
 | `nats_url` | URL for connecting to the NATS Server | `nats://127.0.0.1:4222` | No |
+| `stream_name` | JetStream stream for device messages | `devices` | Yes |
+| `subject` | Base subject for published devices | `discovery.devices` | No |
 | `domain` | JetStream domain for the NATS server | N/A | No |
 | `security` | mTLS security settings for gRPC/KV | N/A | Yes |
 | `nats_security` | mTLS security settings for NATS | (uses `security` if omitted) | No |

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -3,6 +3,8 @@
   "listen_addr": ":50058",
   "poll_interval": "30m",
   "nats_url": "nats://127.0.0.1:4222",
+  "stream_name": "devices",
+  "subject": "discovery.devices",
   "domain": "edge",
   "security": {
     "mode": "mtls",

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -33,6 +33,7 @@ var (
 	errMissingSources = errors.New("at least one source must be defined")
 	errMissingNATS    = errors.New("nats_url is required")
 	errMissingFields  = errors.New("source missing required fields (type, endpoint, prefix)")
+	errMissingStream  = errors.New("stream_name is required")
 )
 
 type Config struct {
@@ -40,6 +41,8 @@ type Config struct {
 	KVAddress    string                          `json:"kv_address"`    // KV gRPC server address (optional)
 	NATSURL      string                          `json:"nats_url"`      // NATS server URL for JetStream
 	Domain       string                          `json:"domain"`        // JetStream domain (optional)
+	StreamName   string                          `json:"stream_name"`   // JetStream stream name
+	Subject      string                          `json:"subject"`       // Subject prefix for device publishes
 	PollInterval models.Duration                 `json:"poll_interval"` // Polling interval
 	Security     *models.SecurityConfig          `json:"security"`      // mTLS config for gRPC/KV
 	NATSSecurity *models.SecurityConfig          `json:"nats_security"` // Optional mTLS config for NATS
@@ -52,6 +55,14 @@ func (c *Config) Validate() error {
 
 	if c.NATSURL == "" {
 		c.NATSURL = "nats://localhost:4222"
+	}
+
+	if c.StreamName == "" {
+		return errMissingStream
+	}
+
+	if c.Subject == "" {
+		c.Subject = "discovery.devices"
 	}
 
 	if time.Duration(c.PollInterval) == 0 {

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -51,6 +51,8 @@ func TestNew_ValidConfig(t *testing.T) {
 		},
 		KVAddress:    "localhost:50051",
 		PollInterval: models.Duration(1 * time.Second),
+		StreamName:   "devices",
+		Subject:      "discovery.devices",
 		Security: &models.SecurityConfig{
 			Mode: "mtls",
 			Role: models.RolePoller,
@@ -73,7 +75,7 @@ func TestNew_ValidConfig(t *testing.T) {
 		},
 	}
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 	assert.NotNil(t, syncer)
 	assert.NotNil(t, syncer.poller)
@@ -102,6 +104,8 @@ func TestSync_Success(t *testing.T) {
 		},
 		KVAddress:    "localhost:50051",
 		PollInterval: models.Duration(1 * time.Second),
+		StreamName:   "devices",
+		Subject:      "discovery.devices",
 		Security: &models.SecurityConfig{
 			Mode: "mtls",
 			Role: models.RolePoller,
@@ -131,7 +135,7 @@ func TestSync_Success(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())
@@ -161,6 +165,8 @@ func TestStartAndStop(t *testing.T) {
 		},
 		KVAddress:    "localhost:50051",
 		PollInterval: models.Duration(500 * time.Millisecond),
+		StreamName:   "devices",
+		Subject:      "discovery.devices",
 		Security:     &models.SecurityConfig{},
 	}
 
@@ -182,7 +188,7 @@ func TestStartAndStop(t *testing.T) {
 	mockInteg.EXPECT().Fetch(gomock.Any()).Return(data, nil, nil).Times(2) // Initial poll + 1 tick
 	mockKV.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto.PutResponse{}, nil).Times(2)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -247,6 +253,8 @@ func TestStart_ContextCancellation(t *testing.T) {
 		},
 		KVAddress:    "localhost:50051",
 		PollInterval: models.Duration(1 * time.Second),
+		StreamName:   "devices",
+		Subject:      "discovery.devices",
 		Security: &models.SecurityConfig{
 			Mode: "mtls",
 			Role: models.RolePoller,
@@ -284,7 +292,7 @@ func TestStart_ContextCancellation(t *testing.T) {
 		Value: []byte("data"),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -326,6 +334,8 @@ func TestSync_NetboxSuccess(t *testing.T) {
 		},
 		KVAddress:    "localhost:50051",
 		PollInterval: models.Duration(1 * time.Second),
+		StreamName:   "devices",
+		Subject:      "discovery.devices",
 	}
 
 	registry := map[string]IntegrationFactory{
@@ -341,7 +351,7 @@ func TestSync_NetboxSuccess(t *testing.T) {
 		Value: []byte(`{"id":1,"name":"device1","primary_ip4":{"address":"192.168.1.1/24"}}`),
 	}, gomock.Any()).Return(&proto.PutResponse{}, nil)
 
-	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, "", mockClock)
+	syncer, err := New(context.Background(), c, mockKV, nil, nil, registry, nil, mockClock)
 	require.NoError(t, err)
 
 	err = syncer.Sync(context.Background())


### PR DESCRIPTION
## Summary
- allow Sync to specify `stream_name` and `subject` in config
- validate new options and use them when creating JetStream context
- prefix domain on publish if set
- update default config and docs
- adjust unit tests for new fields

## Testing
- `go test ./pkg/sync -run Test`


------
https://chatgpt.com/codex/tasks/task_e_685315a0e77c83208b8d61f8c748216d