### PR TITLE
Add agent and poller ids to serviceradar-sync

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -46,6 +46,8 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
   "kv_address": "192.168.2.23:50057",
   "listen_addr": "192.168.2.23:50058",
   "poll_interval": "5m",
+  "agent_id": "default-agent",
+  "poller_id": "default-poller",
   "nats_url": "tls://192.168.2.23:4222",
   "stream_name": "devices",
   "subject": "discovery.devices",
@@ -108,6 +110,8 @@ The Sync service is configured via `/etc/serviceradar/sync.json`:
 | `kv_address` | Address and port of the KV service | N/A | Yes |
 | `listen_addr` | Address and port for the Sync service to listen on | N/A | Yes |
 | `poll_interval` | How often to fetch and update data | `30m` | No |
+| `agent_id` | Agent ID to assign to published devices | N/A | Yes |
+| `poller_id` | Poller ID to assign to published devices | N/A | Yes |
 | `nats_url` | URL for connecting to the NATS Server | `nats://127.0.0.1:4222` | No |
 | `stream_name` | JetStream stream for device messages | `devices` | Yes |
 | `subject` | Base subject for published devices | `discovery.devices` | No |

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -2,6 +2,8 @@
   "kv_address": "localhost:50057",
   "listen_addr": ":50058",
   "poll_interval": "30m",
+  "agent_id": "default-agent",
+  "poller_id": "default-poller",
   "nats_url": "nats://127.0.0.1:4222",
   "stream_name": "devices",
   "subject": "discovery.devices",

--- a/pkg/db/devices.go
+++ b/pkg/db/devices.go
@@ -19,9 +19,9 @@ var (
 
 // GetDevicesByIP retrieves devices with a specific IP address.
 func (db *DB) GetDevicesByIP(ctx context.Context, ip string) ([]*models.Device, error) {
-	query := `SELECT 
-        device_id, poller_id, discovery_source, ip, mac, hostname, 
-        first_seen, last_seen, is_available, metadata 
+	query := `SELECT
+        device_id, agent_id, poller_id, discovery_source, ip, mac, hostname,
+        first_seen, last_seen, is_available, metadata
     FROM table(devices)
     WHERE ip = ?`
 
@@ -40,6 +40,7 @@ func (db *DB) GetDevicesByIP(ctx context.Context, ip string) ([]*models.Device, 
 
 		err := rows.Scan(
 			&d.DeviceID,
+			&d.AgentID,
 			&d.PollerID,
 			&d.DiscoverySource,
 			&d.IP,
@@ -72,11 +73,11 @@ func (db *DB) GetDevicesByIP(ctx context.Context, ip string) ([]*models.Device, 
 
 // GetDeviceByID retrieves a device by its ID.
 func (db *DB) GetDeviceByID(ctx context.Context, deviceID string) (*models.Device, error) {
-	query := `SELECT 
-        device_id, poller_id, discovery_source, ip, mac, hostname, 
-        first_seen, last_seen, is_available, metadata 
+	query := `SELECT
+        device_id, agent_id, poller_id, discovery_source, ip, mac, hostname,
+        first_seen, last_seen, is_available, metadata
     FROM table(devices)
-    WHERE device_id = ? 
+    WHERE device_id = ?
     LIMIT 1`
 
 	rows, err := db.Conn.Query(ctx, query, deviceID)
@@ -95,6 +96,7 @@ func (db *DB) GetDeviceByID(ctx context.Context, deviceID string) (*models.Devic
 
 	err = rows.Scan(
 		&d.DeviceID,
+		&d.AgentID,
 		&d.PollerID,
 		&d.DiscoverySource,
 		&d.IP,
@@ -137,6 +139,7 @@ func (db *DB) StoreDevices(ctx context.Context, devices []*models.Device) error 
 
 		if err := batch.Append(
 			d.DeviceID,
+			d.AgentID,
 			d.PollerID,
 			d.DiscoverySource,
 			d.IP,

--- a/pkg/models/device.go
+++ b/pkg/models/device.go
@@ -7,6 +7,7 @@ import (
 // Device represents a network device.
 type Device struct {
 	DeviceID        string                 `json:"device_id"`
+	AgentID         string                 `json:"agent_id"`
 	PollerID        string                 `json:"poller_id"`
 	DiscoverySource string                 `json:"discovery_source"`
 	IP              string                 `json:"ip"`

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	StreamName   string                          `json:"stream_name"`   // JetStream stream name
 	Subject      string                          `json:"subject"`       // Subject prefix for device publishes
 	PollInterval models.Duration                 `json:"poll_interval"` // Polling interval
+	AgentID      string                          `json:"agent_id"`      // Agent ID for device records
+	PollerID     string                          `json:"poller_id"`     // Poller ID for device records
 	Security     *models.SecurityConfig          `json:"security"`      // mTLS config for gRPC/KV
 	NATSSecurity *models.SecurityConfig          `json:"nats_security"` // Optional mTLS config for NATS
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -343,6 +343,8 @@ func (s *SyncPoller) publishDevices(ctx context.Context, sourceType string, devi
 	log.Printf("Publishing to subject: %s", subject)
 
 	for _, dev := range devices {
+		dev.AgentID = s.config.AgentID
+		dev.PollerID = s.config.PollerID
 		payload, err := json.Marshal(dev)
 		if err != nil {
 			log.Printf("Failed to marshal device %s: %v", dev.DeviceID, err)


### PR DESCRIPTION
## Summary
- include `agent_id` in Device model and DB queries
- read `agent_id` and `poller_id` from sync config
- attach agent and poller IDs before publishing device messages
- update example config and docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685355c5b94c8320bd17ae9fc1e51d48