### PR TITLE
Ensure agent and poller IDs on device records

### DIFF
--- a/packaging/device-mgr/config/devices.json
+++ b/packaging/device-mgr/config/devices.json
@@ -5,6 +5,8 @@
   "stream_name": "devices",
   "subject": "discover.devices.>",
   "consumer_name": "device-db-writer",
+  "agent_id": "agent-default",
+  "poller_id": "poller-default",
   "database": {
     "addresses": [
       "127.0.0.1:9440"

--- a/pkg/consumers/devices/config.go
+++ b/pkg/consumers/devices/config.go
@@ -24,6 +24,8 @@ type DeviceConsumerConfig struct {
 	StreamName   string                 `json:"stream_name"`
 	ConsumerName string                 `json:"consumer_name"`
 	Domain       string                 `json:"domain"`
+	AgentID      string                 `json:"agent_id"`
+	PollerID     string                 `json:"poller_id"`
 	Security     *models.SecurityConfig `json:"security"`
 	DBSecurity   *models.SecurityConfig `json:"db_security"`
 	Database     models.ProtonDatabase  `json:"database"`

--- a/pkg/consumers/devices/processor.go
+++ b/pkg/consumers/devices/processor.go
@@ -19,11 +19,13 @@ var (
 )
 
 type Processor struct {
-	db db.Service
+	db       db.Service
+	agentID  string
+	pollerID string
 }
 
-func NewProcessor(dbService db.Service) *Processor {
-	return &Processor{db: dbService}
+func NewProcessor(agentID, pollerID string, dbService db.Service) *Processor {
+	return &Processor{db: dbService, agentID: agentID, pollerID: pollerID}
 }
 
 func (p *Processor) Process(ctx context.Context, msg jetstream.Msg) error {
@@ -35,6 +37,12 @@ func (p *Processor) Process(ctx context.Context, msg jetstream.Msg) error {
 	if err := json.Unmarshal(data, &device); err != nil {
 		log.Printf("Failed to unmarshal device: %v", err)
 		return ErrUnmarshal
+	}
+	if device.AgentID == "" {
+		device.AgentID = p.agentID
+	}
+	if device.PollerID == "" {
+		device.PollerID = p.pollerID
 	}
 	if device.FirstSeen.IsZero() {
 		device.FirstSeen = time.Now()

--- a/pkg/consumers/devices/service.go
+++ b/pkg/consumers/devices/service.go
@@ -28,7 +28,7 @@ func NewService(cfg *DeviceConsumerConfig, dbService db.Service) (*Service, erro
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	svc := &Service{cfg: cfg, processor: NewProcessor(dbService), db: dbService}
+	svc := &Service{cfg: cfg, processor: NewProcessor(cfg.AgentID, cfg.PollerID, dbService), db: dbService}
 	return svc, nil
 }
 


### PR DESCRIPTION
## Summary
- include `agent_id` and `poller_id` in device consumer config
- populate those IDs when writing devices to Proton
- expose the new fields in service wiring
- add defaults to device manager example config

## Testing
- `go test ./...` *(fails: TestSNMPService in pkg/checker/snmp)*

------
https://chatgpt.com/codex/tasks/task_e_6853599115d08320a5a6b432ddf2ffdb