### PR TITLE
Handle batch append errors correctly

### DIFF
--- a/pkg/db/devices.go
+++ b/pkg/db/devices.go
@@ -126,7 +126,7 @@ func (db *DB) StoreDevices(ctx context.Context, devices []*models.Device) error 
 		return nil
 	}
 
-	batch, err := db.Conn.PrepareBatch(ctx, "INSERT INTO devices (* except _tp_time)")
+	batch, err := db.Conn.PrepareBatch(ctx, "INSERT INTO devices (device_id, agent_id, poller_id, discovery_source, ip, mac, hostname, first_seen, last_seen, is_available, metadata)")
 	if err != nil {
 		return fmt.Errorf("failed to prepare batch: %w", err)
 	}
@@ -150,7 +150,8 @@ func (db *DB) StoreDevices(ctx context.Context, devices []*models.Device) error 
 			d.IsAvailable,
 			meta,
 		); err != nil {
-			log.Printf("Failed to append device %s: %v", d.DeviceID, err)
+			batch.Abort()
+			return fmt.Errorf("failed to append device %s: %w", d.DeviceID, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix device batch insertion logic to abort and return errors when append fails
- explicitly define columns for device insert to avoid argument mismatch

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68535cf6f9d08320ab2837b6cbb1ab39