### PR TITLE
Batch device inserts for device manager

### DIFF
--- a/pkg/consumers/devices/processor.go
+++ b/pkg/consumers/devices/processor.go
@@ -28,29 +28,86 @@ func NewProcessor(agentID, pollerID string, dbService db.Service) *Processor {
 	return &Processor{db: dbService, agentID: agentID, pollerID: pollerID}
 }
 
-func (p *Processor) Process(ctx context.Context, msg jetstream.Msg) error {
+// prepareDevice converts a JetStream message into a Device model.
+func (p *Processor) prepareDevice(msg jetstream.Msg) (*models.Device, error) {
 	data := msg.Data()
 	if len(data) == 0 {
-		return ErrEmptyMessage
+		return nil, ErrEmptyMessage
 	}
+
 	var device models.Device
 	if err := json.Unmarshal(data, &device); err != nil {
 		log.Printf("Failed to unmarshal device: %v", err)
-		return ErrUnmarshal
+		return nil, ErrUnmarshal
 	}
+
 	if device.AgentID == "" {
 		device.AgentID = p.agentID
 	}
+
 	if device.PollerID == "" {
 		device.PollerID = p.pollerID
 	}
+
 	if device.FirstSeen.IsZero() {
 		device.FirstSeen = time.Now()
 	}
+
 	device.LastSeen = time.Now()
-	if err := p.db.StoreDevices(ctx, []*models.Device{&device}); err != nil {
-		log.Printf("Failed to store device %s: %v", device.DeviceID, err)
+
+	return &device, nil
+}
+
+// storeBatch persists a slice of devices using the DB service.
+func (p *Processor) storeBatch(ctx context.Context, devices []*models.Device) error {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	if err := p.db.StoreDevices(ctx, devices); err != nil {
 		return ErrStoreDevice
 	}
+
 	return nil
+}
+
+// Process converts and stores a single JetStream message.
+func (p *Processor) Process(ctx context.Context, msg jetstream.Msg) error {
+	device, err := p.prepareDevice(msg)
+	if err != nil {
+		return err
+	}
+
+	if err := p.storeBatch(ctx, []*models.Device{device}); err != nil {
+		log.Printf("Failed to store device %s: %v", device.DeviceID, err)
+		return err
+	}
+
+	return nil
+}
+
+// ProcessBatch processes multiple JetStream messages in one database batch.
+func (p *Processor) ProcessBatch(ctx context.Context, msgs []jetstream.Msg) ([]jetstream.Msg, error) {
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+
+	devices := make([]*models.Device, 0, len(msgs))
+	processed := make([]jetstream.Msg, 0, len(msgs))
+
+	for _, msg := range msgs {
+		device, err := p.prepareDevice(msg)
+		if err != nil {
+			return processed, err
+		}
+
+		devices = append(devices, device)
+		processed = append(processed, msg)
+	}
+
+	if err := p.storeBatch(ctx, devices); err != nil {
+		return processed, err
+	}
+
+	return processed, nil
 }


### PR DESCRIPTION
## Summary
- batch device processing to avoid excessive inserts
- extend device processor with helpers and batch method

## Testing
- `go test ./...` *(fails: missing call(s) to *snmp.MockCollector.GetResults)*

------
https://chatgpt.com/codex/tasks/task_e_685374fcfd70832090d6f491acc8613b