### PR TITLE
Fix device_id generation for unified devices

### DIFF
--- a/migrations/20250620100100_create_unified_devices_mv.up.sql
+++ b/migrations/20250620100100_create_unified_devices_mv.up.sql
@@ -4,7 +4,7 @@ DROP MATERIALIZED VIEW IF EXISTS unified_devices_mv;
 
 CREATE VIEW IF NOT EXISTS device_updates_stream AS
 SELECT
-    device_id,
+    concat(ip, ':', agent_id, ':', poller_id) AS device_id,
     ip,
     poller_id,
     hostname,
@@ -19,7 +19,7 @@ SELECT
 FROM devices
 UNION ALL
 SELECT
-    concat(ip, ':', poller_id) AS device_id,
+    concat(ip, ':', agent_id, ':', poller_id) AS device_id,
     ip,
     poller_id,
     hostname,

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -371,7 +371,7 @@ func getMaterializedViewStatements() []string {
 		// View that unions device updates from the devices stream and sweep_results.
 		`CREATE VIEW IF NOT EXISTS device_updates_stream AS
         SELECT
-            device_id,
+            concat(ip, ':', agent_id, ':', poller_id) AS device_id,
             ip,
             poller_id,
             hostname,
@@ -386,7 +386,7 @@ func getMaterializedViewStatements() []string {
         FROM devices
         UNION ALL
         SELECT
-            concat(ip, ':', poller_id) AS device_id,
+            concat(ip, ':', agent_id, ':', poller_id) AS device_id,
             ip,
             poller_id,
             hostname,


### PR DESCRIPTION
## Summary
- use IP and agent ID when building `device_id` from devices stream
- keep sweep results using the same format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6853a77e22dc83209aac2907a4770910