### PR TITLE
Fix netbox source defaults

### DIFF
--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/carverauto/serviceradar/pkg/models"
 	"github.com/carverauto/serviceradar/proto"
@@ -117,33 +118,58 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 	data = make(map[string][]byte)
 	ips = make([]string, 0, len(deviceResp.Results))
 
+	agentID := n.Config.AgentID
+	pollerID := n.Config.PollerID
+	now := time.Now()
+
 	for i := range deviceResp.Results {
 		device := &deviceResp.Results[i]
 
-		value, err := json.Marshal(device)
+		if device.PrimaryIP4.Address == "" {
+			continue
+		}
+
+		ip, _, err := net.ParseCIDR(device.PrimaryIP4.Address)
+		if err != nil {
+			log.Printf("Failed to parse IP %s: %v", device.PrimaryIP4.Address, err)
+			continue
+		}
+
+		ipStr := ip.String()
+
+		if n.ExpandSubnets {
+			ips = append(ips, device.PrimaryIP4.Address)
+		} else {
+			ips = append(ips, fmt.Sprintf("%s/32", ipStr))
+		}
+
+		deviceID := fmt.Sprintf("%s:%s:%s", ipStr, agentID, pollerID)
+
+		metadata := map[string]interface{}{
+			"netbox_device_id": fmt.Sprintf("%d", device.ID),
+			"role":             device.Role.Name,
+			"site":             device.Site.Name,
+		}
+
+		modelDevice := &models.Device{
+			DeviceID:        deviceID,
+			PollerID:        pollerID,
+			DiscoverySource: "netbox",
+			IP:              ipStr,
+			Hostname:        device.Name,
+			FirstSeen:       now,
+			LastSeen:        now,
+			IsAvailable:     true,
+			Metadata:        metadata,
+		}
+
+		value, err := json.Marshal(modelDevice)
 		if err != nil {
 			log.Printf("Failed to marshal device %d: %v", device.ID, err)
 			continue
 		}
 
-		data[fmt.Sprintf("%d", device.ID)] = value
-
-		if device.PrimaryIP4.Address != "" {
-			if n.ExpandSubnets {
-				ips = append(ips, device.PrimaryIP4.Address) // Keep /24 if desired
-			} else {
-				ip, _, err := net.ParseCIDR(device.PrimaryIP4.Address)
-				if err != nil {
-					log.Printf("Failed to parse IP %s: %v", device.PrimaryIP4.Address, err)
-					continue
-				}
-
-				// add /32 to the IP address
-				newIPAddress := fmt.Sprintf("%s/32", ip.String())
-
-				ips = append(ips, newIPAddress)
-			}
-		}
+		data[deviceID] = value
 	}
 
 	return data, ips

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -155,8 +155,19 @@ func (s *SyncPoller) initializeIntegrations(ctx context.Context) {
 }
 
 // createIntegration constructs an integration instance based on source type.
-func (*SyncPoller) createIntegration(ctx context.Context, src *models.SourceConfig, factory IntegrationFactory) Integration {
-	return factory(ctx, src)
+func (s *SyncPoller) createIntegration(ctx context.Context, src *models.SourceConfig, factory IntegrationFactory) Integration {
+	// Apply global defaults for AgentID and PollerID if not explicitly set
+	cfgCopy := *src
+
+	if cfgCopy.AgentID == "" {
+		cfgCopy.AgentID = s.config.AgentID
+	}
+
+	if cfgCopy.PollerID == "" {
+		cfgCopy.PollerID = s.config.PollerID
+	}
+
+	return factory(ctx, &cfgCopy)
 }
 
 // Start delegates to poller.Poller.Start, using PollFunc for syncing.

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -349,3 +349,86 @@ func TestSync_NetboxSuccess(t *testing.T) {
 	err = syncer.Sync(context.Background())
 	assert.NoError(t, err)
 }
+
+func TestCreateIntegrationAppliesDefaults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKV := NewMockKVClient(ctrl)
+	mockGRPC := NewMockGRPCClient(ctrl)
+	mockClock := poller.NewMockClock(ctrl)
+
+	mockGRPC.EXPECT().GetConnection().Return(nil).AnyTimes()
+
+	var gotAgent, gotPoller string
+
+	registry := map[string]IntegrationFactory{
+		"netbox": func(_ context.Context, cfg *models.SourceConfig) Integration {
+			gotAgent = cfg.AgentID
+			gotPoller = cfg.PollerID
+			return NewMockIntegration(ctrl)
+		},
+	}
+
+	c := &Config{
+		AgentID:      "global-agent",
+		PollerID:     "global-poller",
+		KVAddress:    "localhost:50051",
+		PollInterval: models.Duration(1 * time.Second),
+		Sources: map[string]*models.SourceConfig{
+			"netbox": {
+				Type:     "netbox",
+				Endpoint: "https://netbox.example.com",
+				Prefix:   "netbox/",
+				AgentID:  "source-agent",
+				PollerID: "source-poller",
+			},
+		},
+	}
+
+	_, err := New(context.Background(), c, mockKV, mockGRPC, registry, mockClock)
+	require.NoError(t, err)
+
+	assert.Equal(t, "source-agent", gotAgent)
+	assert.Equal(t, "source-poller", gotPoller)
+}
+
+func TestCreateIntegrationUsesGlobalDefaults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKV := NewMockKVClient(ctrl)
+	mockGRPC := NewMockGRPCClient(ctrl)
+
+	mockGRPC.EXPECT().GetConnection().Return(nil).AnyTimes()
+
+	var gotAgent, gotPoller string
+
+	registry := map[string]IntegrationFactory{
+		"netbox": func(_ context.Context, cfg *models.SourceConfig) Integration {
+			gotAgent = cfg.AgentID
+			gotPoller = cfg.PollerID
+			return NewMockIntegration(ctrl)
+		},
+	}
+
+	c := &Config{
+		AgentID:      "global-agent",
+		PollerID:     "global-poller",
+		KVAddress:    "localhost:50051",
+		PollInterval: models.Duration(1 * time.Second),
+		Sources: map[string]*models.SourceConfig{
+			"netbox": {
+				Type:     "netbox",
+				Endpoint: "https://netbox.example.com",
+				Prefix:   "netbox/",
+			},
+		},
+	}
+
+	_, err := New(context.Background(), c, mockKV, mockGRPC, registry, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "global-agent", gotAgent)
+	assert.Equal(t, "global-poller", gotPoller)
+}


### PR DESCRIPTION
## Summary
- respect source-level agent_id & poller_id in sync
- include defaults when creating integrations
- emit devices from netbox with correct IDs and metadata
- test default resolution for integrations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6853ae55d8708320aad7186160e717a4