### PR TITLE
Fix sweep metadata overwrite

### DIFF
--- a/pkg/db/migrations/20250625100000_update_sweep_to_unified_mv.up.sql
+++ b/pkg/db/migrations/20250625100000_update_sweep_to_unified_mv.up.sql
@@ -1,0 +1,20 @@
+DROP VIEW IF EXISTS sweep_to_unified_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sweep_to_unified_mv
+INTO unified_devices AS
+SELECT
+    concat(s.ip, ':', s.agent_id, ':', s.poller_id) AS device_id,
+    s.ip,
+    s.poller_id,
+    coalesce(d.hostname, s.hostname) AS hostname,
+    coalesce(d.mac, s.mac) AS mac,
+    s.discovery_source,
+    s.available AS is_available,
+    coalesce(d.first_seen, s.timestamp) AS first_seen,
+    s.timestamp AS last_seen,
+    if(d.metadata != map(), mapMerge(d.metadata, s.metadata), s.metadata) AS metadata,
+    s.agent_id,
+    now64(3) AS _tp_time
+FROM sweep_results s
+LEFT JOIN devices d
+    ON d.device_id = concat(s.ip, ':', s.agent_id, ':', s.poller_id);

--- a/sr-architecture-and-design/adr/ADR-02.md
+++ b/sr-architecture-and-design/adr/ADR-02.md
@@ -174,7 +174,7 @@ ArangoDB will be the primary master for detailed device attributes, interface in
 
 4. **Core Service & Proton:**
     - Receives data and writes to respective Proton streams.
-    - `unified_devices_mv` updates the `unified_devices` stream.
+    - `unified_devices_mv` merges sweep results with existing device metadata and updates the `unified_devices` stream.
 
 5. **ArangoDB Sync Service (New):**
     - Subscribes to relevant Proton streams:


### PR DESCRIPTION
## Summary
- prevent network sweep materialized view from overwriting metadata
- document new merging behavior in ADR 2

## Testing
- `go test ./...` *(fails: TestArmisIntegration_Fetch_NoUpdater)*

------
https://chatgpt.com/codex/tasks/task_e_68547562800c8320a98fe8e84cae0d10