### PR TITLE
Fix sweep_results default filter

### DIFF
--- a/pkg/srql/parser/translator.go
+++ b/pkg/srql/parser/translator.go
@@ -23,6 +23,43 @@ type Translator struct {
 	DBType DatabaseType
 }
 
+// applyDefaultFilters adds implicit conditions for certain entities when the
+// user query omits them. Currently this ensures `sweep_results` only returns
+// records with `discovery_source = 'sweep'` unless another discovery_source
+// condition is specified.
+func (t *Translator) applyDefaultFilters(q *models.Query) {
+	if q == nil {
+		return
+	}
+
+	switch q.Entity {
+	case models.SweepResults:
+		if !hasDiscoverySourceCondition(q.Conditions) {
+			cond := models.Condition{
+				Field:    "discovery_source",
+				Operator: models.Equals,
+				Value:    "sweep",
+			}
+			if len(q.Conditions) > 0 {
+				cond.LogicalOp = models.And
+			}
+			q.Conditions = append(q.Conditions, cond)
+		}
+	}
+}
+
+// hasDiscoverySourceCondition checks if a condition on discovery_source already
+// exists in the provided slice. Nested conditions are not inspected to keep the
+// check simple.
+func hasDiscoverySourceCondition(conds []models.Condition) bool {
+	for _, c := range conds {
+		if strings.EqualFold(c.Field, "discovery_source") {
+			return true
+		}
+	}
+	return false
+}
+
 // NewTranslator creates a new Translator
 func NewTranslator(dbType DatabaseType) *Translator {
 	return &Translator{
@@ -35,6 +72,9 @@ func (t *Translator) Translate(query *models.Query) (string, error) {
 	if query == nil {
 		return "", errCannotTranslateNilQuery
 	}
+
+	// Apply any implicit filters based on the entity type
+	t.applyDefaultFilters(query)
 
 	switch t.DBType {
 	case Proton:

--- a/pkg/srql/srql_test.go
+++ b/pkg/srql/srql_test.go
@@ -118,6 +118,25 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 				assert.Nil(t, query)
 			},
 		},
+		{
+			name:  "Show sweep_results defaults to sweep discovery source",
+			query: "show sweep_results",
+			validate: func(t *testing.T, query *models.Query, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Equal(t, models.SweepResults, query.Entity)
+				assert.Empty(t, query.Conditions)
+
+				sqlP, errP := protonTranslator.Translate(query)
+				require.NoError(t, errP)
+				assert.Equal(t, "SELECT * FROM table(sweep_results) WHERE discovery_source = 'sweep'", sqlP)
+
+				sqlCH, errCH := clickhouseTranslator.Translate(query)
+				require.NoError(t, errCH)
+				assert.Equal(t, "SELECT * FROM sweep_results WHERE discovery_source = 'sweep'", sqlCH)
+			},
+		},
 		// --- New Test Cases for sweep_results and date functions ---
 		{
 			name:  "Show sweep_results for TODAY and available",
@@ -147,13 +166,13 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 				sqlP, errP := protonTranslator.Translate(query)
 				require.NoError(t, errP)
 				assert.Equal(t, "SELECT * FROM table(sweep_results) "+
-					"WHERE to_date(timestamp) = today() AND available = true", sqlP)
+					"WHERE to_date(timestamp) = today() AND available = true AND discovery_source = 'sweep'", sqlP)
 
 				// Test ClickHouse translation
 				sqlCH, errCH := clickhouseTranslator.Translate(query)
 				require.NoError(t, errCH)
 				assert.Equal(t, "SELECT * FROM sweep_results WHERE "+
-					"toDate(timestamp) = today() AND available = true", sqlCH) // Assuming toDate for CH
+					"toDate(timestamp) = today() AND available = true AND discovery_source = 'sweep'", sqlCH) // Assuming toDate for CH
 
 				// Test ArangoDB translation
 				aql, errA := arangoTranslator.Translate(query)
@@ -161,7 +180,7 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 				todayDateStr := time.Now().Format("2006-01-02")
 				// Assuming SUBSTRING for Arango if timestamp is string, or DATE_TRUNC if native date
 				expectedAQL := fmt.Sprintf("FOR doc IN sweep_results\n  "+
-					"FILTER SUBSTRING(doc.timestamp, 0, 10) == '%s' AND doc.available == true\n  "+
+					"FILTER SUBSTRING(doc.timestamp, 0, 10) == '%s' AND doc.available == true AND doc.discovery_source == 'sweep'\n  "+
 					"RETURN doc", todayDateStr)
 				assert.Equal(t, expectedAQL, aql)
 			},
@@ -183,19 +202,19 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 				// Proton
 				sqlP, _ := protonTranslator.Translate(query)
 				assert.Equal(t, "SELECT * FROM table(sweep_results) "+
-					"WHERE to_date(timestamp) = yesterday() AND available = false", sqlP)
+					"WHERE to_date(timestamp) = yesterday() AND available = false AND discovery_source = 'sweep'", sqlP)
 
 				// ClickHouse
 				sqlCH, _ := clickhouseTranslator.Translate(query)
 				assert.Equal(t, "SELECT * FROM sweep_results WHERE toDate(timestamp) = yesterday() "+
-					"AND available = false", sqlCH)
+					"AND available = false AND discovery_source = 'sweep'", sqlCH)
 
 				// ArangoDB
 				aql, _ := arangoTranslator.Translate(query)
 				yesterdayDateStr := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
 				expectedAQL := fmt.Sprintf(
 					"FOR doc IN sweep_results\n  FILTER SUBSTRING(doc.timestamp, 0, 10) == '%s' "+
-						"AND doc.available == false\n  RETURN doc", yesterdayDateStr)
+						"AND doc.available == false AND doc.discovery_source == 'sweep'\n  RETURN doc", yesterdayDateStr)
 				assert.Equal(t, expectedAQL, aql)
 			},
 		},
@@ -213,15 +232,15 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 
 				// Proton
 				sqlP, _ := protonTranslator.Translate(query)
-				assert.Equal(t, "SELECT * FROM table(sweep_results) WHERE to_date(timestamp) = '2023-10-20'", sqlP)
+				assert.Equal(t, "SELECT * FROM table(sweep_results) WHERE to_date(timestamp) = '2023-10-20' AND discovery_source = 'sweep'", sqlP)
 
 				// ClickHouse
 				sqlCH, _ := clickhouseTranslator.Translate(query)
-				assert.Equal(t, "SELECT * FROM sweep_results WHERE toDate(timestamp) = '2023-10-20'", sqlCH)
+				assert.Equal(t, "SELECT * FROM sweep_results WHERE toDate(timestamp) = '2023-10-20' AND discovery_source = 'sweep'", sqlCH)
 
 				// ArangoDB
 				aql, _ := arangoTranslator.Translate(query)
-				expectedAQL := "FOR doc IN sweep_results\n  FILTER SUBSTRING(doc.timestamp, 0, 10) == '2023-10-20'\n  RETURN doc"
+				expectedAQL := "FOR doc IN sweep_results\n  FILTER SUBSTRING(doc.timestamp, 0, 10) == '2023-10-20' AND doc.discovery_source == 'sweep'\n  RETURN doc"
 				assert.Equal(t, expectedAQL, aql)
 			},
 		},
@@ -240,7 +259,7 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 
 				// Proton
 				sqlP, _ := protonTranslator.Translate(query)
-				assert.Equal(t, "SELECT COUNT(*) FROM table(sweep_results) WHERE to_date(timestamp) = today()", sqlP)
+				assert.Equal(t, "SELECT COUNT(*) FROM table(sweep_results) WHERE to_date(timestamp) = today() AND discovery_source = 'sweep'", sqlP)
 			},
 		},
 		{
@@ -254,7 +273,7 @@ func TestSRQLParsingAndTranslation(t *testing.T) { // Renamed for clarity
 				assert.Equal(t, "TODAY", query.Conditions[0].Value)           // Visitor should normalize keyword
 
 				sqlP, _ := protonTranslator.Translate(query)
-				assert.Equal(t, "SELECT * FROM table(sweep_results) WHERE to_date(timestamp) = today()", sqlP)
+				assert.Equal(t, "SELECT * FROM table(sweep_results) WHERE to_date(timestamp) = today() AND discovery_source = 'sweep'", sqlP)
 			},
 		},
 		// Add more tests:


### PR DESCRIPTION
## Summary
- add implicit `discovery_source = 'sweep'` filter when querying `sweep_results`
- update tests for translator to expect the filter
- add regression test for implicit filter

## Testing
- `go test ./pkg/srql -run TestSRQLParsingAndTranslation -count=1`
- `go test ./pkg/srql -run TestSRQLParsingAndTranslation -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6854bbd9f56c8320911fe6c2fecd05fa