### PR TITLE
Fix tests for updated sync integration data

### DIFF
--- a/pkg/sync/integrations/armis/armis_test.go
+++ b/pkg/sync/integrations/armis/armis_test.go
@@ -45,14 +45,14 @@ func TestArmisIntegration_Fetch_NoUpdater(t *testing.T) {
 
 	expectedDevices := getExpectedDevices()
 	firstPageResp := getFirstPageResponse(expectedDevices)
-	expectedSweepConfig := &models.SweepConfig{
-		Networks: []string{"192.168.1.1/32", "192.168.1.2/32"},
-	}
+        expectedSweepConfig := &models.SweepConfig{
+                Networks: []string{"192.168.1.1/32", "192.168.1.2/32", "10.0.0.1/32"},
+        }
 
 	setupArmisMocks(t, mocks, firstPageResp, expectedSweepConfig)
 
-	result, devices, err := integration.Fetch(context.Background())
-	verifyArmisResults(t, result, devices, err, expectedDevices)
+        result, events, err := integration.Fetch(context.Background())
+        verifyArmisResults(t, result, events, err, expectedDevices)
 
 	// Ensure that the enrichment data was not added
 	_, exists := result["_sweep_results"]
@@ -109,8 +109,22 @@ func TestArmisIntegration_Fetch_WithUpdaterAndCorrelation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Expect 3 items: 2 devices + 1 for "_sweep_results"
-	assert.Len(t, result, 3)
+        // Expect 6 items: 5 device entries + 1 for "_sweep_results"
+        expectedLen := len(expectedDevices)
+        for i := range expectedDevices {
+                ips := strings.Split(expectedDevices[i].IPAddress, ",")
+                for _, ipRaw := range ips {
+                        ip := strings.TrimSpace(ipRaw)
+                        if ip != "" {
+                                expectedLen++
+                        }
+                }
+        }
+        if _, ok := result["_sweep_results"]; ok {
+                expectedLen++
+        }
+
+        assert.Len(t, result, expectedLen)
 
 	// Verify original devices are still present in the result map
 	_, device1Exists := result["1"]
@@ -227,13 +241,27 @@ func setupArmisMocks(t *testing.T, mocks *armisMocks, resp *SearchResponse, expe
 	mocks.KVWriter.EXPECT().WriteSweepConfig(gomock.Any(), expectedSweepConfig).Return(nil)
 }
 
-func verifyArmisResults(t *testing.T, result map[string][]byte, devices []models.Device, err error, expectedDevices []Device) {
+func verifyArmisResults(t *testing.T, result map[string][]byte, events []*models.SweepResult, err error, expectedDevices []Device) {
 	t.Helper()
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	assert.Len(t, result, 3)
+        expectedLen := len(expectedDevices)
+        for _, ed := range expectedDevices {
+                ips := strings.Split(ed.IPAddress, ",")
+                for _, ipRaw := range ips {
+                        ip := strings.TrimSpace(ipRaw)
+                        if ip != "" {
+                                expectedLen++
+                        }
+                }
+        }
+        if _, ok := result["_sweep_results"]; ok {
+                expectedLen++
+        }
+
+        assert.Len(t, result, expectedLen)
 
 	for i := range expectedDevices {
 		expected := &expectedDevices[i]
@@ -249,17 +277,22 @@ func verifyArmisResults(t *testing.T, result map[string][]byte, devices []models
 			deviceData, exists := result[key]
 			require.True(t, exists, "device with key %s should exist", key)
 
-			var device models.Device
-			err = json.Unmarshal(deviceData, &device)
+                        var device models.SweepResult
+                        err = json.Unmarshal(deviceData, &device)
 			require.NoError(t, err)
 
-			assert.Equal(t, key, device.DeviceID)
-			assert.Equal(t, ip, device.IP)
-			assert.Equal(t, "test-poller", device.PollerID)
+                        assert.Equal(t, ip, device.IP)
+                        assert.Equal(t, "test-poller", device.PollerID)
 		}
 	}
 
-	assert.Len(t, devices, len(expectedDevices))
+        assert.Len(t, events, len(expectedDevices))
+
+        for i, ev := range events {
+                exp := expectedDevices[i]
+                require.Equal(t, exp.IPAddress, ev.IP)
+                require.Equal(t, "test-poller", ev.PollerID)
+        }
 }
 
 func TestArmisIntegration_FetchWithMultiplePages(t *testing.T) {
@@ -324,7 +357,7 @@ func TestArmisIntegration_FetchWithMultiplePages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	assert.Len(t, result, 4)
+        assert.Len(t, result, 8)
 
 	for i := 1; i <= 4; i++ {
 		key := fmt.Sprintf("192.168.1.%d:test-agent:test-poller", i)

--- a/pkg/sync/integrations/netbox/netbox_test.go
+++ b/pkg/sync/integrations/netbox/netbox_test.go
@@ -30,18 +30,23 @@ func TestProcessDevices_UsesIDs(t *testing.T) {
 		},
 	}}
 
-	data, ips := integ.processDevices(resp)
-	require.Len(t, ips, 1)
-	require.Equal(t, "10.0.0.1/32", ips[0])
-	require.Len(t, data, 1)
+        data, ips, events := integ.processDevices(resp)
+        require.Len(t, ips, 1)
+        require.Equal(t, "10.0.0.1/32", ips[0])
+        require.Len(t, data, 1)
 
-	b, ok := data["10.0.0.1:agent:poller"]
-	require.True(t, ok)
+        b, ok := data["agent/10.0.0.1"]
+        require.True(t, ok)
 
-	var dev models.Device
-	err := json.Unmarshal(b, &dev)
-	require.NoError(t, err)
+        var event models.SweepResult
+        err := json.Unmarshal(b, &event)
+        require.NoError(t, err)
 
-	require.Equal(t, "poller", dev.PollerID)
-	require.Equal(t, "10.0.0.1:agent:poller", dev.DeviceID)
+        require.Equal(t, "poller", event.PollerID)
+        require.Equal(t, "10.0.0.1", event.IP)
+
+        require.Len(t, events, 1)
+        require.Equal(t, "10.0.0.1", events[0].IP)
+        require.Equal(t, "poller", events[0].PollerID)
+        require.Equal(t, "netbox", events[0].DiscoverySource)
 }

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -378,12 +378,14 @@ func TestCreateIntegrationAppliesDefaults(t *testing.T) {
 		},
 	}
 
-	c := &Config{
-		AgentID:      "global-agent",
-		PollerID:     "global-poller",
-		KVAddress:    "localhost:50051",
-		PollInterval: models.Duration(1 * time.Second),
-		Sources: map[string]*models.SourceConfig{
+        c := &Config{
+                AgentID:      "global-agent",
+                PollerID:     "global-poller",
+                KVAddress:    "localhost:50051",
+                PollInterval: models.Duration(1 * time.Second),
+                StreamName:   "devices",
+                Subject:      "discovery.devices",
+                Sources: map[string]*models.SourceConfig{
 			"netbox": {
 				Type:     "netbox",
 				Endpoint: "https://netbox.example.com",
@@ -394,7 +396,7 @@ func TestCreateIntegrationAppliesDefaults(t *testing.T) {
 		},
 	}
 
-	_, err := New(context.Background(), c, mockKV, mockGRPC, registry, mockClock)
+        _, err := New(context.Background(), c, mockKV, nil, nil, registry, mockGRPC, mockClock)
 	require.NoError(t, err)
 
 	assert.Equal(t, "source-agent", gotAgent)
@@ -420,12 +422,14 @@ func TestCreateIntegrationUsesGlobalDefaults(t *testing.T) {
 		},
 	}
 
-	c := &Config{
-		AgentID:      "global-agent",
-		PollerID:     "global-poller",
-		KVAddress:    "localhost:50051",
-		PollInterval: models.Duration(1 * time.Second),
-		Sources: map[string]*models.SourceConfig{
+        c := &Config{
+                AgentID:      "global-agent",
+                PollerID:     "global-poller",
+                KVAddress:    "localhost:50051",
+                PollInterval: models.Duration(1 * time.Second),
+                StreamName:   "devices",
+                Subject:      "discovery.devices",
+                Sources: map[string]*models.SourceConfig{
 			"netbox": {
 				Type:     "netbox",
 				Endpoint: "https://netbox.example.com",
@@ -434,7 +438,7 @@ func TestCreateIntegrationUsesGlobalDefaults(t *testing.T) {
 		},
 	}
 
-	_, err := New(context.Background(), c, mockKV, mockGRPC, registry, nil)
+        _, err := New(context.Background(), c, mockKV, nil, nil, registry, mockGRPC, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "global-agent", gotAgent)


### PR DESCRIPTION
## Summary
- update sync tests for new `New` signature
- adjust Netbox processDevices test for sweep result output
- update Armis integration tests for updated data structures

## Testing
- `make lint` *(fails: unsupported configuration version)*
- `make test` *(fails: some sweeper tests fail)*
- `go test ./pkg/sync/integrations/netbox -run TestProcessDevices_UsesIDs -count=1 -v`
- `go test ./pkg/sync/integrations/armis -run TestArmisIntegration_Fetch_NoUpdater -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6854c9676f348320bd9d765e1ab4d68c