### PR TITLE
Adjust write path for new device ID

### DIFF
--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -407,8 +407,19 @@ func (s *SyncPoller) writeToKV(ctx context.Context, sourceName string, data map[
 	for key, value := range data {
 		fullKey := prefix + "/" + key
 
-		if part, ip, ok := parseDeviceID(key); ok {
-			fullKey = fmt.Sprintf("%s/%s/%s", prefix, part, ip)
+		if _, ip, ok := parseDeviceID(key); ok {
+			srcCfg := s.config.Sources[sourceName]
+			agentID := srcCfg.AgentID
+			if agentID == "" {
+				agentID = s.config.AgentID
+			}
+
+			pollerID := srcCfg.PollerID
+			if pollerID == "" {
+				pollerID = s.config.PollerID
+			}
+
+			fullKey = fmt.Sprintf("%s/%s/%s/%s", prefix, agentID, pollerID, ip)
 		}
 
 		_, err := s.kvClient.Put(ctx, &proto.PutRequest{

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -452,14 +452,22 @@ func TestWriteToKVTransformsDeviceID(t *testing.T) {
 	mockKV := NewMockKVClient(ctrl)
 
 	s := &SyncPoller{
-		config: Config{Sources: map[string]*models.SourceConfig{
-			"netbox": {Prefix: "netbox/"},
-		}},
+		config: Config{
+			Sources: map[string]*models.SourceConfig{
+				"netbox": {
+					Prefix:   "netbox/",
+					AgentID:  "agent1",
+					PollerID: "poller1",
+				},
+			},
+			AgentID:  "agent1",
+			PollerID: "poller1",
+		},
 		kvClient: mockKV,
 	}
 
 	data := map[string][]byte{
-		"10.0.0.1:agent1:poller1": []byte("val"),
+		"partition1:10.0.0.1": []byte("val"),
 	}
 
 	mockKV.EXPECT().Put(gomock.Any(), &proto.PutRequest{


### PR DESCRIPTION
## Summary
- support `partition:ip` device ID format when writing to KV
- adapt writeToKV test for new format

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854e9481ba08320b845bc16fc9b0048