### PR TITLE
Fix device ID generation to use partition

### DIFF
--- a/pkg/core/discovery.go
+++ b/pkg/core/discovery.go
@@ -67,7 +67,7 @@ func (s *Server) processSNMPDiscoveryResults(
 
 	// Process each type of discovery data
 	if len(payload.Devices) > 0 {
-		s.processDiscoveredDevices(ctx, payload.Devices, discoveryAgentID, discoveryInitiatorPollerID, reportingPollerID, timestamp)
+		s.processDiscoveredDevices(ctx, payload.Devices, discoveryAgentID, discoveryInitiatorPollerID, partition, reportingPollerID, timestamp)
 	}
 
 	if len(payload.Interfaces) > 0 {
@@ -87,6 +87,7 @@ func (s *Server) processDiscoveredDevices(
 	devices []*discoverypb.DiscoveredDevice,
 	discoveryAgentID string,
 	discoveryInitiatorPollerID string,
+	partition string,
 	reportingPollerID string,
 	timestamp time.Time,
 ) {
@@ -104,6 +105,7 @@ func (s *Server) processDiscoveredDevices(
 		sweepResult := &models.SweepResult{
 			AgentID:         discoveryAgentID,
 			PollerID:        discoveryInitiatorPollerID,
+			Partition:       partition,
 			DiscoverySource: "snmp_discovery",
 			IP:              protoDevice.Ip,
 			MAC:             &mac,

--- a/pkg/core/server_test.go
+++ b/pkg/core/server_test.go
@@ -366,7 +366,7 @@ func verifySweepTestCase(ctx context.Context, t *testing.T, server *Server, svc 
 	}, now time.Time) {
 	t.Helper()
 
-	err := server.processSweepData(ctx, svc, now)
+	err := server.processSweepData(ctx, svc, "default", now)
 	if tt.expectError {
 		assert.Error(t, err)
 		return

--- a/pkg/db/migrations/20250620100100_create_unified_device_pipeline.up.sql
+++ b/pkg/db/migrations/20250620100100_create_unified_device_pipeline.up.sql
@@ -6,6 +6,7 @@ DROP STREAM IF EXISTS devices;
 CREATE STREAM IF NOT EXISTS sweep_results (
     agent_id string,
     poller_id string,
+    partition string,
     discovery_source string,
     ip string,
     mac nullable(string),
@@ -34,7 +35,7 @@ SETTINGS mode='versioned_kv', version_column='_tp_time';
 CREATE MATERIALIZED VIEW IF NOT EXISTS unified_device_pipeline_mv
 INTO unified_devices
 AS SELECT
-    concat(ip, ':', agent_id, ':', poller_id) AS device_id,
+    concat(partition, ':', ip) AS device_id,
     ip,
     poller_id,
     hostname,

--- a/pkg/db/sweep.go
+++ b/pkg/db/sweep.go
@@ -61,6 +61,7 @@ func (db *DB) StoreSweepResults(ctx context.Context, results []*models.SweepResu
 		err = batch.Append(
 			result.AgentID,
 			result.PollerID,
+			result.Partition,
 			result.DiscoverySource,
 			result.IP,
 			result.MAC,

--- a/pkg/mapper/publisher.go
+++ b/pkg/mapper/publisher.go
@@ -66,6 +66,7 @@ func (p *ProtonPublisher) PublishDevice(ctx context.Context, device *DiscoveredD
 	result := &models.SweepResult{
 		AgentID:         p.config.AgentID,
 		PollerID:        p.config.PollerID,
+		Partition:       p.config.Partition,
 		DiscoverySource: "snmp_discovery",
 		IP:              device.IP,
 		MAC:             &device.MAC,
@@ -208,6 +209,7 @@ func (p *ProtonPublisher) PublishBatchDevices(ctx context.Context, devices []*Di
 		results[i] = &models.SweepResult{
 			AgentID:         p.config.AgentID,
 			PollerID:        p.config.PollerID,
+			Partition:       p.config.Partition,
 			DiscoverySource: "snmp_discovery",
 			IP:              device.IP,
 			MAC:             &mac,

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -243,6 +243,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			TopologyStream       string `json:"topology_stream"`
 			AgentID              string `json:"agent_id"`
 			PollerID             string `json:"poller_id"`
+			Partition            string `json:"partition"`
 			PublishBatchSize     int    `json:"publish_batch_size"`
 			PublishRetries       int    `json:"publish_retries"`
 			PublishRetryInterval string `json:"publish_retry_interval"`
@@ -328,6 +329,7 @@ type StreamConfig struct {
 	TopologyStream       string
 	AgentID              string
 	PollerID             string
+	Partition            string
 	PublishBatchSize     int
 	PublishRetries       int
 	PublishRetryInterval time.Duration

--- a/pkg/models/metrics.go
+++ b/pkg/models/metrics.go
@@ -167,6 +167,7 @@ type SNMPMetric struct {
 type SweepResult struct {
 	AgentID         string            `json:"agent_id"`
 	PollerID        string            `json:"poller_id"`
+	Partition       string            `json:"partition"`
 	DiscoverySource string            `json:"discovery_source"`
 	IP              string            `json:"ip"`
 	MAC             *string           `json:"mac,omitempty"`

--- a/pkg/models/sync.go
+++ b/pkg/models/sync.go
@@ -11,8 +11,9 @@ type SourceConfig struct {
 	// AgentID and PollerID allow assigning discovered devices to specific
 	// agents and pollers. When set, they override any global defaults for
 	// the Sync service.
-	AgentID  string `json:"agent_id,omitempty"`
-	PollerID string `json:"poller_id,omitempty"`
+	AgentID   string `json:"agent_id,omitempty"`
+	PollerID  string `json:"poller_id,omitempty"`
+	Partition string `json:"partition,omitempty"`
 }
 
 // QueryConfig represents a single labeled AQL/ASQ query.

--- a/pkg/sync/integrations/armis/devices.go
+++ b/pkg/sync/integrations/armis/devices.go
@@ -150,6 +150,7 @@ func (a *ArmisIntegration) convertToSweepResults(devices []Device) []*models.Swe
 		out = append(out, &models.SweepResult{
 			AgentID:         a.Config.AgentID,
 			PollerID:        a.Config.PollerID,
+			Partition:       a.Config.Partition,
 			DiscoverySource: "armis",
 			IP:              dev.IPAddress,
 			MAC:             &mac,

--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -123,6 +123,7 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 
 	agentID := n.Config.AgentID
 	pollerID := n.Config.PollerID
+	partition := n.Config.Partition
 	now := time.Now()
 
 	for i := range deviceResp.Results {
@@ -159,6 +160,7 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 		event := &models.SweepResult{
 			AgentID:         agentID,
 			PollerID:        pollerID,
+			Partition:       partition,
 			DiscoverySource: "netbox",
 			IP:              ipStr,
 			Hostname:        &hostname,


### PR DESCRIPTION
## Summary
- add partition column to sweep_results
- build `device_id` using `partition` and `ip`
- track partition in SweepResult model and integrations
- plumb partition through core server discovery logic

## Testing
- `go vet ./...` *(fails: unreachable code in generated parser)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854ee2dfa948320b2775955cc49e8e4