### PR TITLE
Fix device_id format for discovery integrations

### DIFF
--- a/pkg/sync/integrations/armis/armis_test.go
+++ b/pkg/sync/integrations/armis/armis_test.go
@@ -162,10 +162,11 @@ func setupArmisIntegration(t *testing.T) (*ArmisIntegration, *armisMocks) {
 
 	return &ArmisIntegration{
 		Config: &models.SourceConfig{
-			Endpoint: "https://armis.example.com",
-			Prefix:   "armis/",
-			AgentID:  "test-agent",
-			PollerID: "test-poller",
+			Endpoint:  "https://armis.example.com",
+			Prefix:    "armis/",
+			AgentID:   "test-agent",
+			PollerID:  "test-poller",
+			Partition: "test-partition",
 			Credentials: map[string]string{
 				"secret_key": "test-secret-key",
 				"boundary":   "Corporate",
@@ -279,7 +280,7 @@ func verifyArmisResults(t *testing.T, result map[string][]byte, events []*models
 				continue
 			}
 
-			key := fmt.Sprintf("%s:test-agent:test-poller", ip)
+			key := fmt.Sprintf("test-partition:%s", ip)
 			deviceData, exists := result[key]
 
 			require.True(t, exists, "device with key %s should exist", key)
@@ -310,10 +311,11 @@ func TestArmisIntegration_FetchWithMultiplePages(t *testing.T) {
 
 	integration := &ArmisIntegration{
 		Config: &models.SourceConfig{
-			Endpoint: "https://armis.example.com",
-			Prefix:   "armis/",
-			AgentID:  "test-agent",
-			PollerID: "test-poller",
+			Endpoint:  "https://armis.example.com",
+			Prefix:    "armis/",
+			AgentID:   "test-agent",
+			PollerID:  "test-poller",
+			Partition: "test-partition",
 			Credentials: map[string]string{
 				"secret_key": "test-secret-key",
 			},
@@ -369,7 +371,7 @@ func TestArmisIntegration_FetchWithMultiplePages(t *testing.T) {
 	assert.Len(t, result, 8)
 
 	for i := 1; i <= 4; i++ {
-		key := fmt.Sprintf("192.168.1.%d:test-agent:test-poller", i)
+		key := fmt.Sprintf("test-partition:192.168.1.%d", i)
 		_, exists := result[key]
 		assert.True(t, exists, "Device with key %s should exist in results", key)
 	}

--- a/pkg/sync/integrations/armis/devices.go
+++ b/pkg/sync/integrations/armis/devices.go
@@ -291,7 +291,6 @@ func (a *ArmisIntegration) processDevices(devices []Device) (data map[string][]b
 	data = make(map[string][]byte)
 	ips = make([]string, 0, len(devices))
 
-	agentID := a.Config.AgentID
 	pollerID := a.Config.PollerID
 
 	for i := range devices {
@@ -320,7 +319,7 @@ func (a *ArmisIntegration) processDevices(devices []Device) (data map[string][]b
 				continue
 			}
 
-			deviceID := fmt.Sprintf("%s:%s:%s", ip, agentID, pollerID)
+			deviceID := fmt.Sprintf("%s:%s", a.Config.Partition, ip)
 
 			metadata := map[string]interface{}{
 				"armis_id":     fmt.Sprintf("%d", d.ID),

--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -147,7 +147,7 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 			ips = append(ips, fmt.Sprintf("%s/32", ipStr))
 		}
 
-		kvKey := fmt.Sprintf("%s:%s", partition, ipStr)
+               kvKey := fmt.Sprintf("%s/%s", agentID, ipStr)
 
 		metadata := map[string]interface{}{
 			"netbox_device_id": fmt.Sprintf("%d", device.ID),

--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -147,7 +147,7 @@ func (n *NetboxIntegration) processDevices(deviceResp DeviceResponse) (data map[
 			ips = append(ips, fmt.Sprintf("%s/32", ipStr))
 		}
 
-		kvKey := fmt.Sprintf("%s/%s", agentID, ipStr)
+		kvKey := fmt.Sprintf("%s:%s", partition, ipStr)
 
 		metadata := map[string]interface{}{
 			"netbox_device_id": fmt.Sprintf("%d", device.ID),

--- a/pkg/sync/integrations/netbox/netbox_test.go
+++ b/pkg/sync/integrations/netbox/netbox_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProcessDevices_UsesIDs(t *testing.T) {
-	integ := &NetboxIntegration{Config: &models.SourceConfig{AgentID: "agent", PollerID: "poller"}}
+	integ := &NetboxIntegration{Config: &models.SourceConfig{AgentID: "agent", PollerID: "poller", Partition: "test-partition"}}
 
 	resp := DeviceResponse{Results: []Device{
 		{
@@ -35,7 +35,7 @@ func TestProcessDevices_UsesIDs(t *testing.T) {
 	require.Equal(t, "10.0.0.1/32", ips[0])
 	require.Len(t, data, 1)
 
-	b, ok := data["agent/10.0.0.1"]
+	b, ok := data["test-partition:10.0.0.1"]
 	require.True(t, ok)
 
 	var event models.SweepResult
@@ -44,9 +44,11 @@ func TestProcessDevices_UsesIDs(t *testing.T) {
 
 	require.Equal(t, "poller", event.PollerID)
 	require.Equal(t, "10.0.0.1", event.IP)
+	require.Equal(t, "test-partition", event.Partition)
 
 	require.Len(t, events, 1)
 	require.Equal(t, "10.0.0.1", events[0].IP)
 	require.Equal(t, "poller", events[0].PollerID)
 	require.Equal(t, "netbox", events[0].DiscoverySource)
+	require.Equal(t, "test-partition", events[0].Partition)
 }

--- a/pkg/sync/integrations/netbox/netbox_test.go
+++ b/pkg/sync/integrations/netbox/netbox_test.go
@@ -35,7 +35,7 @@ func TestProcessDevices_UsesIDs(t *testing.T) {
 	require.Equal(t, "10.0.0.1/32", ips[0])
 	require.Len(t, data, 1)
 
-	b, ok := data["test-partition:10.0.0.1"]
+       b, ok := data["agent/10.0.0.1"]
 	require.True(t, ok)
 
 	var event models.SweepResult


### PR DESCRIPTION
## Summary
- ensure Armis integration creates device IDs in `partition:ip` format
- update Netbox integration to use `partition:ip` device IDs
- adjust integration tests for new format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854f66f9fc88320a138fd023df1e3c0