### PR TITLE
Ensure unified_devices stream exists in migration

### DIFF
--- a/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
+++ b/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
@@ -1,5 +1,22 @@
 -- Add discovery_sources array to unified_devices and update the materialized view
 
+-- Ensure the unified_devices stream exists in case the previous migration
+-- failed to create it (e.g. on older clusters)
+CREATE STREAM IF NOT EXISTS unified_devices (
+    device_id string,
+    ip string,
+    poller_id string,
+    hostname nullable(string),
+    mac nullable(string),
+    discovery_source string,
+    is_available boolean,
+    first_seen DateTime64(3),
+    last_seen DateTime64(3),
+    metadata map(string, string),
+    agent_id string
+) PRIMARY KEY (device_id)
+SETTINGS mode='versioned_kv', version_column='_tp_time';
+
 -- Drop existing materialized view
 DROP VIEW IF EXISTS unified_device_pipeline_mv;
 


### PR DESCRIPTION
## Summary
- check for missing `unified_devices` stream before altering it

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855a9e937fc8320b4b5690168ab3449