### PR TITLE
Fix migration column already exists

### DIFF
--- a/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
+++ b/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
@@ -22,7 +22,7 @@ DROP VIEW IF EXISTS unified_device_pipeline_mv;
 
 -- Add new array column with an empty array default
 ALTER STREAM unified_devices
-    ADD COLUMN discovery_sources array(string) DEFAULT [] AFTER mac;
+    ADD COLUMN IF NOT EXISTS discovery_sources array(string) DEFAULT [] AFTER mac;
 
 -- Populate array column from existing discovery_source values
 ALTER STREAM unified_devices
@@ -30,7 +30,7 @@ ALTER STREAM unified_devices
     WHERE discovery_source IS NOT NULL;
 
 -- Remove old discovery_source column
-ALTER STREAM unified_devices DROP COLUMN discovery_source;
+ALTER STREAM unified_devices DROP COLUMN IF EXISTS discovery_source;
 
 -- Recreate materialized view with array merge logic
 CREATE MATERIALIZED VIEW unified_device_pipeline_mv


### PR DESCRIPTION
## Summary
- avoid failure if `discovery_sources` column already exists when migrating

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855b2c9d2f483208d8a87969d240797