### PR TITLE
Fix unified_devices migration

### DIFF
--- a/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
+++ b/pkg/db/migrations/20250622120000_add_discovery_sources_to_unified_devices.up.sql
@@ -24,6 +24,10 @@ DROP VIEW IF EXISTS unified_device_pipeline_mv;
 ALTER STREAM unified_devices
     ADD COLUMN IF NOT EXISTS discovery_sources array(string) DEFAULT [] AFTER mac;
 
+-- Ensure old discovery_source column exists so we can migrate its values
+ALTER STREAM unified_devices
+    ADD COLUMN IF NOT EXISTS discovery_source string;
+
 -- Populate array column from existing discovery_source values
 ALTER STREAM unified_devices
     UPDATE discovery_sources = [discovery_source]


### PR DESCRIPTION
## Summary
- ensure `discovery_source` column exists before populating new `discovery_sources` array
- keep `discovery_source` column long enough to migrate existing data

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855b5e2727c832086cdb1065907bb86