### PR TITLE
Fix alternate_ip metadata keys

### DIFF
--- a/pkg/mapper/discovery.go
+++ b/pkg/mapper/discovery.go
@@ -999,13 +999,7 @@ func (*DiscoveryEngine) copyMetadataToDevice(targetDevice, sourceDevice *Discove
 func (*DiscoveryEngine) addAlternateIPs(device *DiscoveredDevice, ips map[string]struct{}) {
 	for ip := range ips {
 		if ip != device.IP {
-			altIPKey := fmt.Sprintf("alternate_ip_%s", ip)
-
-			if device.Metadata == nil {
-				device.Metadata = make(map[string]string)
-			}
-
-			device.Metadata[altIPKey] = ip
+			device.Metadata = addAlternateIP(device.Metadata, ip)
 		}
 	}
 }
@@ -1036,13 +1030,7 @@ func (e *DiscoveryEngine) addOrUpdateDeviceToResults(job *DiscoveryJob, newDevic
 			e.updateExistingDevice(job, i, newDevice)
 
 			if existingDevice.IP != newDevice.IP {
-				altIPKey := fmt.Sprintf("alternate_ip_%s", newDevice.IP)
-
-				if existingDevice.Metadata == nil {
-					existingDevice.Metadata = make(map[string]string)
-				}
-
-				existingDevice.Metadata[altIPKey] = newDevice.IP
+				existingDevice.Metadata = addAlternateIP(existingDevice.Metadata, newDevice.IP)
 
 				log.Printf("Job %s: Device %s (MAC: %s, DeviceID: %s) updated with alternate IP %s "+
 					"(primary: %s, source: %s)",

--- a/pkg/mapper/ubnt_poller.go
+++ b/pkg/mapper/ubnt_poller.go
@@ -570,7 +570,7 @@ func (e *DiscoveryEngine) queryUniFiDevices(
 					log.Printf("Job %s: Device with MAC %s already seen with IP %s, skipping IP %s",
 						job.ID, device.MAC, primaryIP, device.IP)
 
-					device.Metadata["alternate_ip_"+device.IP] = device.IP
+					device.Metadata = addAlternateIP(device.Metadata, device.IP)
 
 					continue
 				}

--- a/pkg/mapper/utils.go
+++ b/pkg/mapper/utils.go
@@ -362,3 +362,30 @@ func contains(slice []string, item string) bool {
 
 	return false
 }
+
+// addAlternateIP stores an alternate IP in the given metadata map using
+// sequential keys (alternate_ip, alternate_ip_2, ...). The updated map is
+// returned for convenience.
+func addAlternateIP(metadata map[string]string, ip string) map[string]string {
+	if ip == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]string)
+	}
+
+	index := 1
+	for {
+		key := "alternate_ip"
+		if index > 1 {
+			key = fmt.Sprintf("alternate_ip_%d", index)
+		}
+		if _, exists := metadata[key]; !exists {
+			metadata[key] = ip
+			break
+		}
+		index++
+	}
+
+	return metadata
+}


### PR DESCRIPTION
## Summary
- store alternate IPs using sequential keys instead of embedding the IP address in the key
- provide helper `addAlternateIP` to manage alternate IP metadata
- update UniFi polling and discovery logic to use the helper

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6855cf3729148320b365c83eeb4339c3