### PR TITLE
Return alternate IPs as metadata array

### DIFF
--- a/pkg/mapper/utils.go
+++ b/pkg/mapper/utils.go
@@ -18,6 +18,7 @@ package mapper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -363,9 +364,9 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
-// addAlternateIP stores an alternate IP in the given metadata map using
-// sequential keys (alternate_ip, alternate_ip_2, ...). The updated map is
-// returned for convenience.
+// addAlternateIP stores an alternate IP in the given metadata map under the
+// "alternate_ips" key as a JSON array. The updated map is returned for
+// convenience.
 func addAlternateIP(metadata map[string]string, ip string) map[string]string {
 	if ip == "" {
 		return metadata
@@ -374,17 +375,26 @@ func addAlternateIP(metadata map[string]string, ip string) map[string]string {
 		metadata = make(map[string]string)
 	}
 
-	index := 1
-	for {
-		key := "alternate_ip"
-		if index > 1 {
-			key = fmt.Sprintf("alternate_ip_%d", index)
+	const key = "alternate_ips"
+	var ips []string
+	if existing, ok := metadata[key]; ok && existing != "" {
+		// Attempt to decode existing JSON array. If it fails, treat the
+		// value as a single comma-separated string for backward
+		// compatibility.
+		if err := json.Unmarshal([]byte(existing), &ips); err != nil {
+			ips = strings.Split(existing, ",")
 		}
-		if _, exists := metadata[key]; !exists {
-			metadata[key] = ip
-			break
+	}
+
+	for _, existing := range ips {
+		if existing == ip {
+			return metadata
 		}
-		index++
+	}
+
+	ips = append(ips, ip)
+	if data, err := json.Marshal(ips); err == nil {
+		metadata[key] = string(data)
 	}
 
 	return metadata


### PR DESCRIPTION
## Summary
- roll back protobuf change and drop wrappers proto
- keep alternate IP addresses under a single `alternate_ips` metadata key
- store the metadata value as a JSON array when merging devices
- update polling logic and tests to use new helper

## Testing
- `go vet ./...` *(fails: unreachable code in generated parser files)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855f07579888320837069d2d5a82e4f