### PR TITLE
Fix pagination forwarding in API query route

### DIFF
--- a/web/src/app/api/query/route.ts
+++ b/web/src/app/api/query/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
         const backendResponse = await fetch(`${apiUrl}/api/query`, {
             method: "POST",
             headers: headersToBackend,
-            body: JSON.stringify({ query }),
+            body: JSON.stringify(body),
             cache: "no-store",
         });
 


### PR DESCRIPTION
## Summary
- fix pagination in API Query Tool by forwarding all request params

## Testing
- `go test ./...`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856210c39708320babd8215e48b8e34