### PR TITLE
Allow configurable sweep interval

### DIFF
--- a/docs/docs/sync.md
+++ b/docs/docs/sync.md
@@ -174,8 +174,9 @@ The NetBox integration:
 "armis": {
   "type": "armis",
   "endpoint": "https://api.armis.com/api/v1/devices",
-  "prefix": "armis/",
-  "agent_id": "agent-prod-dc1",
+    "prefix": "armis/",
+    "sweep_interval": "10m",
+    "agent_id": "agent-prod-dc1",
   "poller_id": "poller-prod-dc1",
   "credentials": {
     "api_key": "your_armis_api_key"
@@ -489,8 +490,9 @@ Here's a comprehensive example that includes multiple data sources:
     "netbox": {
       "type": "netbox",
       "endpoint": "https://192.168.2.73",
-      "prefix": "netbox/",
-      "agent_id": "agent-lab-west",
+    "prefix": "netbox/",
+    "sweep_interval": "5m",
+    "agent_id": "agent-lab-west",
       "poller_id": "poller-lab-west",
       "credentials": {
         "api_token": "72d72b0ddddddd3f7951051cd78cd7c",

--- a/packaging/sync/config/sync.json
+++ b/packaging/sync/config/sync.json
@@ -36,8 +36,9 @@
     "armis": {
       "type": "armis",
       "endpoint": "https://api.armis.example.com",
-      "prefix": "armis/",
-      "agent_id": "agent-prod-dc1",
+    "prefix": "armis/",
+    "sweep_interval": "10m",
+    "agent_id": "agent-prod-dc1",
       "poller_id": "poller-prod-dc1",
       "credentials": {
         "secret_key": "your-armis-secret-key-here",

--- a/pkg/models/sync.go
+++ b/pkg/models/sync.go
@@ -14,6 +14,11 @@ type SourceConfig struct {
 	AgentID   string `json:"agent_id,omitempty"`
 	PollerID  string `json:"poller_id,omitempty"`
 	Partition string `json:"partition,omitempty"`
+
+	// SweepInterval allows configuring how often agents should sweep the
+	// networks discovered by this source. If empty, a sensible default is
+	// used by each integration.
+	SweepInterval string `json:"sweep_interval,omitempty"`
 }
 
 // QueryConfig represents a single labeled AQL/ASQ query.

--- a/pkg/sync/integrations/README.md
+++ b/pkg/sync/integrations/README.md
@@ -86,6 +86,8 @@ Each entry in the `sources` map defines a connection to an external system.
 | `insecure_skip_verify` | `boolean` | If `true`, the HTTP client will skip TLS certificate verification. Use with caution.                                                                                                                              | No       |
 | `credentials`          | `object`  | A map of strings containing authentication tokens, keys, and other integration-specific settings.                                                                                                                | **Yes**  |
 | `queries`              | `array`   | (Armis only) An array of AQL queries to run against the Armis API to fetch devices.                                                                                                                               | **Yes**  |
+| `sweep_interval`       | `string`  | How often agents should sweep discovered networks. Uses Go duration format (e.g., "5m").
+        | No |
 
 ---
 

--- a/pkg/sync/integrations/integrations.go
+++ b/pkg/sync/integrations/integrations.go
@@ -64,10 +64,15 @@ func NewArmisIntegration(
 		ServerName: serverName,
 	}
 
+	interval := config.SweepInterval
+	if interval == "" {
+		interval = "10m"
+	}
+
 	defaultSweepCfg := &models.SweepConfig{
 		Ports:         []int{22, 80, 443, 3389, 445, 5985, 5986, 8080},
 		SweepModes:    []string{"icmp", "tcp"},
-		Interval:      "10m",
+		Interval:      interval,
 		Concurrency:   100,
 		Timeout:       "15s",
 		IcmpCount:     1,

--- a/pkg/sync/integrations/netbox/netbox.go
+++ b/pkg/sync/integrations/netbox/netbox.go
@@ -209,11 +209,16 @@ func (n *NetboxIntegration) writeSweepConfig(ctx context.Context, ips []string) 
 		return // Or simply return to avoid writing a config with an unpredictable key
 	}
 
+	interval := n.Config.SweepInterval
+	if interval == "" {
+		interval = "5m"
+	}
+
 	sweepConfig := models.SweepConfig{
 		Networks:      ips,
 		Ports:         []int{22, 80, 443, 3389, 445, 8080},
 		SweepModes:    []string{"icmp", "tcp"},
-		Interval:      "5m",
+		Interval:      interval,
 		Concurrency:   50,
 		Timeout:       "10s",
 		IcmpCount:     1,


### PR DESCRIPTION
## Summary
- make sweep interval configurable per integration via `sweep_interval`
- use the new interval when constructing Armis and Netbox sweep configs
- document the new setting and show examples
- update sample sync.json configuration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685625b5653c8320996da55be51a763c