### PR TITLE
Add multi-rule support to zen consumer

### DIFF
--- a/cmd/consumers/zen/Cargo.lock
+++ b/cmd/consumers/zen/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -423,6 +424,25 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "cloudevents-sdk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d48721bdd20fbaa008c5180469dc76363776cb68ace437064e916044dd2d92a"
+dependencies = [
+ "base64",
+ "bitflags",
+ "chrono",
+ "delegate-attr",
+ "hostname",
+ "serde",
+ "serde_json",
+ "snafu",
+ "url",
+ "uuid",
+ "web-sys",
+]
 
 [[package]]
 name = "colorchoice"
@@ -526,6 +546,17 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "delegate-attr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "der"
@@ -886,6 +917,17 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hostname"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -2283,12 +2325,15 @@ dependencies = [
  "anyhow",
  "async-nats",
  "clap",
+ "cloudevents-sdk",
  "env_logger",
  "futures",
  "log",
  "serde",
  "serde_json",
  "tokio",
+ "url",
+ "uuid",
  "zen-engine",
 ]
 
@@ -2363,6 +2408,27 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
 
 [[package]]
 name = "socket2"
@@ -2803,6 +2869,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2823,6 +2890,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/cmd/consumers/zen/Cargo.toml
+++ b/cmd/consumers/zen/Cargo.toml
@@ -17,6 +17,9 @@ serde_json = "1.0"
 tokio = { version = "1.44", features = ["full"] }
 zen-engine = "0.47"
 futures = "0.3"
+cloudevents-sdk = "0.8"
+uuid = { version = "1", features = ["v4"] }
+url = "2"
 
 [[bin]]
 name = "zen-put-rule"

--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -12,12 +12,15 @@ Create a JSON file with the following fields:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_key": "example-decision",
+  "decision_keys": ["example-decision"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed"
 }
 ```
+
+`decision_keys` accepts multiple rule names allowing a single consumer to
+evaluate several rules for each incoming event.
 
 Decision rules are loaded from the KV store using the following key pattern:
 
@@ -38,7 +41,7 @@ Optionally add TLS settings:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_key": "example-decision",
+  "decision_keys": ["example-decision"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",

--- a/cmd/consumers/zen/data/cef_severity.json
+++ b/cmd/consumers/zen/data/cef_severity.json
@@ -1,0 +1,28 @@
+{
+  "nodes": [
+    { "id": "inputNode", "type": "inputNode", "name": "Request", "position": {"x": 80, "y": 150} },
+    {
+      "id": "cefTable",
+      "type": "decisionTableNode",
+      "name": "CEF Severity",
+      "position": {"x": 300, "y": 150},
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [ {"field": "short_message", "id": "fld_msg", "name": "Short", "type": "expression"} ],
+        "outputs": [ {"field": "severity", "id": "fld_sev", "name": "Severity", "type": "expression"} ],
+        "rules": [
+          {"_id": "r0", "fld_msg": "contains(short_message, '|0|') or contains(short_message, '|1|') or contains(short_message, '|2|') or contains(short_message, '|3|')", "fld_sev": "'Low'"},
+          {"_id": "r1", "fld_msg": "contains(short_message, '|4|') or contains(short_message, '|5|') or contains(short_message, '|6|')", "fld_sev": "'Medium'"},
+          {"_id": "r2", "fld_msg": "contains(short_message, '|7|') or contains(short_message, '|8|')", "fld_sev": "'High'"},
+          {"_id": "r3", "fld_msg": "contains(short_message, '|9|') or contains(short_message, '|10|')", "fld_sev": "'Very High'"},
+          {"_id": "r4", "fld_msg": "", "fld_sev": "'Unknown'"}
+        ]
+      }
+    },
+    { "id": "outputNode", "type": "outputNode", "name": "Response", "position": {"x": 560, "y": 150} }
+  ],
+  "edges": [
+    {"id": "e1", "sourceId": "inputNode", "targetId": "cefTable", "type": "edge"},
+    {"id": "e2", "sourceId": "cefTable", "targetId": "outputNode", "type": "edge"}
+  ]
+}

--- a/cmd/consumers/zen/src/kv_loader.rs
+++ b/cmd/consumers/zen/src/kv_loader.rs
@@ -25,8 +25,8 @@ impl KvLoader {
         };
         match self.store.get(full_key).await {
             Ok(Some(bytes)) => {
-                let content: DecisionContent = serde_json::from_slice(&bytes)
-                    .map_err(|e| LoaderError::Internal {
+                let content: DecisionContent =
+                    serde_json::from_slice(&bytes).map_err(|e| LoaderError::Internal {
                         key: key.to_string(),
                         source: e.into(),
                     })?;
@@ -47,4 +47,3 @@ impl DecisionLoader for KvLoader {
         async move { self.load_from_kv(key).await }
     }
 }
-

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -3,7 +3,7 @@
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_key": "example-decision",
+  "decision_keys": ["example-decision"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",


### PR DESCRIPTION
## Summary
- allow specifying `decision_keys` so multiple rules can be evaluated
- output results as CloudEvents
- watch new rules correctly
- let `zen-put-rule` specify a rule name when inserting
- document new options and provide example CEF rule

## Testing
- `cargo test --manifest-path cmd/consumers/zen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685642a4f1688320a26f8010aaefd7d9