### PR TITLE
Handle missing Zen rules gracefully

### DIFF
--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -22,6 +22,9 @@ Create a JSON file with the following fields:
 `decision_keys` accepts multiple rule names allowing a single consumer to
 evaluate several rules for each incoming event.
 
+If a rule is missing from the key-value bucket it will be skipped and the
+consumer will continue evaluating the remaining keys.
+
 Decision rules are loaded from the KV store using the following key pattern:
 
 ```


### PR DESCRIPTION
## Summary
- skip missing rules when evaluating zen decisions
- document skipping missing rules

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68572900c2e48320b4f0160a129b3176