### PR TITLE
Add strip_full_message rule and sequential rule execution

### DIFF
--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -11,18 +11,21 @@ Create a JSON file with the following fields:
   "nats_url": "nats://127.0.0.1:4222",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
-  "subjects": ["events.syslog"],
+  "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
       "order": 1,
-      "name": "pre_process",
+      "name": "syslog",
+      "subjects": ["events.syslog"],
       "rules": [
-        {"order": 1, "key": "strip_full_message"}
+        {"order": 1, "key": "strip_full_message"},
+        {"order": 2, "key": "cef_severity"}
       ]
     },
     {
       "order": 2,
-      "name": "classification",
+      "name": "snmp",
+      "subjects": ["events.snmp"],
       "rules": [
         {"order": 1, "key": "cef_severity"}
       ]
@@ -34,10 +37,11 @@ Create a JSON file with the following fields:
 }
 ```
 
-`decision_groups` allows rules to be organized into ordered groups. Each group
-and rule has an explicit `order` field so execution does not rely on the JSON
-array layout. Rules within a group are processed sequentially with the output of
-one rule becoming the input for the next, then the next group is evaluated.
+`decision_groups` allows rules to be organized into ordered, named groups.
+Each group can specify a list of `subjects` it applies to and has an explicit
+`order` field. Rules within a group are processed sequentially with the output of
+one rule becoming the input for the next. Only groups matching the incoming
+message subject are evaluated in order.
 
 If a rule is missing from the key-value bucket it will be skipped and the
 consumer will continue evaluating the remaining keys.
@@ -60,18 +64,21 @@ Optionally add TLS settings:
   "nats_url": "nats://127.0.0.1:4222",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
-  "subjects": ["events.syslog"],
+  "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
       "order": 1,
-      "name": "pre_process",
+      "name": "syslog",
+      "subjects": ["events.syslog"],
       "rules": [
-        {"order": 1, "key": "strip_full_message"}
+        {"order": 1, "key": "strip_full_message"},
+        {"order": 2, "key": "cef_severity"}
       ]
     },
     {
       "order": 2,
-      "name": "classification",
+      "name": "snmp",
+      "subjects": ["events.snmp"],
       "rules": [
         {"order": 1, "key": "cef_severity"}
       ]

--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -14,7 +14,6 @@ Create a JSON file with the following fields:
   "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
-      "order": 1,
       "name": "syslog",
       "subjects": ["events.syslog"],
       "rules": [
@@ -23,7 +22,6 @@ Create a JSON file with the following fields:
       ]
     },
     {
-      "order": 2,
       "name": "snmp",
       "subjects": ["events.snmp"],
       "rules": [
@@ -37,11 +35,11 @@ Create a JSON file with the following fields:
 }
 ```
 
-`decision_groups` allows rules to be organized into ordered, named groups.
-Each group can specify a list of `subjects` it applies to and has an explicit
-`order` field. Rules within a group are processed sequentially with the output of
-one rule becoming the input for the next. Only groups matching the incoming
-message subject are evaluated in order.
+`decision_groups` allows rules to be organized into named groups.
+Each group can specify a list of `subjects` it applies to. When a message
+arrives, the first group matching its subject is selected and its rules are
+processed sequentially, with the output of one rule becoming the input for the
+next.
 
 If a rule is missing from the key-value bucket it will be skipped and the
 consumer will continue evaluating the remaining keys.
@@ -67,7 +65,6 @@ Optionally add TLS settings:
   "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
-      "order": 1,
       "name": "syslog",
       "subjects": ["events.syslog"],
       "rules": [
@@ -76,7 +73,6 @@ Optionally add TLS settings:
       ]
     },
     {
-      "order": 2,
       "name": "snmp",
       "subjects": ["events.snmp"],
       "rules": [

--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -12,7 +12,7 @@ Create a JSON file with the following fields:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["example-decision"],
+  "decision_keys": ["strip_full_message", "cef_severity"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed"
@@ -20,7 +20,9 @@ Create a JSON file with the following fields:
 ```
 
 `decision_keys` accepts multiple rule names allowing a single consumer to
-evaluate several rules for each incoming event.
+evaluate several rules for each incoming event. Rules are executed sequentially
+in the order they are listed, with the output of each rule becoming the input
+for the next.
 
 If a rule is missing from the key-value bucket it will be skipped and the
 consumer will continue evaluating the remaining keys.
@@ -44,7 +46,7 @@ Optionally add TLS settings:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["example-decision"],
+  "decision_keys": ["strip_full_message", "cef_severity"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",

--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -12,17 +12,32 @@ Create a JSON file with the following fields:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["strip_full_message", "cef_severity"],
+  "decision_groups": [
+    {
+      "order": 1,
+      "name": "pre_process",
+      "rules": [
+        {"order": 1, "key": "strip_full_message"}
+      ]
+    },
+    {
+      "order": 2,
+      "name": "classification",
+      "rules": [
+        {"order": 1, "key": "cef_severity"}
+      ]
+    }
+  ],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed"
 }
 ```
 
-`decision_keys` accepts multiple rule names allowing a single consumer to
-evaluate several rules for each incoming event. Rules are executed sequentially
-in the order they are listed, with the output of each rule becoming the input
-for the next.
+`decision_groups` allows rules to be organized into ordered groups. Each group
+and rule has an explicit `order` field so execution does not rely on the JSON
+array layout. Rules within a group are processed sequentially with the output of
+one rule becoming the input for the next, then the next group is evaluated.
 
 If a rule is missing from the key-value bucket it will be skipped and the
 consumer will continue evaluating the remaining keys.
@@ -46,7 +61,22 @@ Optionally add TLS settings:
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["strip_full_message", "cef_severity"],
+  "decision_groups": [
+    {
+      "order": 1,
+      "name": "pre_process",
+      "rules": [
+        {"order": 1, "key": "strip_full_message"}
+      ]
+    },
+    {
+      "order": 2,
+      "name": "classification",
+      "rules": [
+        {"order": 1, "key": "cef_severity"}
+      ]
+    }
+  ],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",

--- a/cmd/consumers/zen/data/strip_full_message.json
+++ b/cmd/consumers/zen/data/strip_full_message.json
@@ -1,0 +1,21 @@
+{
+  "nodes": [
+    { "id": "inputNode", "type": "inputNode", "name": "Request", "position": { "x": 80, "y": 150 } },
+    {
+      "id": "stripFullMessage",
+      "type": "expressionNode",
+      "name": "Strip Full Message",
+      "position": { "x": 300, "y": 150 },
+      "content": {
+        "expressions": [
+          { "id": "expr1", "key": "full_message", "value": "null" }
+        ]
+      }
+    },
+    { "id": "outputNode", "type": "outputNode", "name": "Response", "position": { "x": 560, "y": 150 } }
+  ],
+  "edges": [
+    { "id": "e1", "sourceId": "inputNode", "targetId": "stripFullMessage", "type": "edge" },
+    { "id": "e2", "sourceId": "stripFullMessage", "targetId": "outputNode", "type": "edge" }
+  ]
+}

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -3,7 +3,22 @@
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["strip_full_message", "cef_severity"],
+  "decision_groups": [
+    {
+      "order": 1,
+      "name": "pre_process",
+      "rules": [
+        {"order": 1, "key": "strip_full_message"}
+      ]
+    },
+    {
+      "order": 2,
+      "name": "classification",
+      "rules": [
+        {"order": 1, "key": "cef_severity"}
+      ]
+    }
+  ],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -5,7 +5,6 @@
   "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
-      "order": 1,
       "name": "syslog",
       "subjects": ["events.syslog"],
       "rules": [
@@ -14,7 +13,6 @@
       ]
     },
     {
-      "order": 2,
       "name": "snmp",
       "subjects": ["events.snmp"],
       "rules": [

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -2,18 +2,21 @@
   "nats_url": "nats://127.0.0.1:4222",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
-  "subjects": ["events.syslog"],
+  "subjects": ["events.syslog", "events.snmp"],
   "decision_groups": [
     {
       "order": 1,
-      "name": "pre_process",
+      "name": "syslog",
+      "subjects": ["events.syslog"],
       "rules": [
-        {"order": 1, "key": "strip_full_message"}
+        {"order": 1, "key": "strip_full_message"},
+        {"order": 2, "key": "cef_severity"}
       ]
     },
     {
       "order": 2,
-      "name": "classification",
+      "name": "snmp",
+      "subjects": ["events.snmp"],
       "rules": [
         {"order": 1, "key": "cef_severity"}
       ]

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -3,7 +3,7 @@
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog"],
-  "decision_keys": ["example-decision"],
+  "decision_keys": ["strip_full_message", "cef_severity"],
   "agent_id": "agent-01",
   "kv_bucket": "serviceradar-kv",
   "result_subject_suffix": ".processed",


### PR DESCRIPTION
## Summary
- add `strip_full_message` rule for zen consumer
- execute rules sequentially so earlier rules modify input for later rules
- document rule ordering and update examples

## Testing
- `cargo test --manifest-path cmd/consumers/zen/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68572c368c3483208b36eafe88d4eb62