### PR TITLE
Capture source address in Flowgger

### DIFF
--- a/cmd/flowgger/src/flowgger/decoder/gelf_decoder.rs
+++ b/cmd/flowgger/src/flowgger/decoder/gelf_decoder.rs
@@ -108,6 +108,7 @@ impl Decoder for GelfDecoder {
         let record = Record {
             ts: ts.unwrap_or_else(|| utils::PreciseTimestamp::now().as_f64()),
             hostname: hostname.ok_or("Missing hostname")?,
+            remote_addr: None,
             facility: None,
             severity,
             appname: None,

--- a/cmd/flowgger/src/flowgger/decoder/ltsv_decoder.rs
+++ b/cmd/flowgger/src/flowgger/decoder/ltsv_decoder.rs
@@ -204,6 +204,7 @@ impl Decoder for LTSVDecoder {
         let record = Record {
             ts: ts.ok_or("Missing timestamp")?,
             hostname: hostname.ok_or("Missing hostname")?,
+            remote_addr: None,
             facility: None,
             severity,
             appname: None,

--- a/cmd/flowgger/src/flowgger/decoder/rfc3164_decoder.rs
+++ b/cmd/flowgger/src/flowgger/decoder/rfc3164_decoder.rs
@@ -71,6 +71,7 @@ fn decode_rfc_standard(pri: &Pri, msg: &str, line: &str) -> Result<Record, &'sta
         let record = Record {
             ts,
             hostname: _hostname.to_owned(),
+            remote_addr: None,
             facility: pri.facility,
             severity: pri.severity,
             appname: None,
@@ -106,6 +107,7 @@ fn decode_rfc_custom(pri: &Pri, msg: &str, line: &str) -> Result<Record, &'stati
         let record = Record {
             ts,
             hostname: _hostname.to_owned(),
+            remote_addr: None,
             facility: pri.facility,
             severity: pri.severity,
             appname: None,

--- a/cmd/flowgger/src/flowgger/decoder/rfc5424_decoder.rs
+++ b/cmd/flowgger/src/flowgger/decoder/rfc5424_decoder.rs
@@ -32,6 +32,7 @@ impl Decoder for RFC5424Decoder {
         let record = Record {
             ts,
             hostname: hostname.to_owned(),
+            remote_addr: None,
             facility: Some(pri_version.facility),
             severity: Some(pri_version.severity),
             appname: Some(appname.to_owned()),

--- a/cmd/flowgger/src/flowgger/encoder/capnp_encoder.rs
+++ b/cmd/flowgger/src/flowgger/encoder/capnp_encoder.rs
@@ -125,6 +125,7 @@ mod tests {
         let record = Record {
             ts: 1385053862.3072,
             hostname: "example.org".to_string(),
+            remote_addr: None,
             facility: None,
             severity: Some(1),
             appname: Some("appname".to_string()),
@@ -157,6 +158,7 @@ mod tests {
         let record = Record {
             ts: 1385053862.3072,
             hostname: "example.org".to_string(),
+            remote_addr: None,
             facility: None,
             severity: Some(1),
             appname: Some("appname".to_string()),
@@ -191,6 +193,7 @@ mod tests {
         let record = Record {
             ts: 1385053862.3072,
             hostname: "example.org".to_string(),
+            remote_addr: None,
             facility: None,
             severity: Some(1),
             appname: Some("appname".to_string()),

--- a/cmd/flowgger/src/flowgger/encoder/ltsv_encoder.rs
+++ b/cmd/flowgger/src/flowgger/encoder/ltsv_encoder.rs
@@ -141,6 +141,7 @@ fn test_ltsv_full_encode_no_sd() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(2),
         severity: Some(7),
         appname: Some("appname".to_string()),
@@ -166,6 +167,7 @@ fn test_ltsv_full_encode_multiple_sd() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(2),
         severity: Some(7),
         appname: Some("appname".to_string()),

--- a/cmd/flowgger/src/flowgger/encoder/passthrough_encoder.rs
+++ b/cmd/flowgger/src/flowgger/encoder/passthrough_encoder.rs
@@ -58,6 +58,7 @@ fn test_passthrough_encode() {
     let record = Record {
         ts: 1.2,
         hostname: "abcd".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,
@@ -93,6 +94,7 @@ fn test_passthrough_encode_with_prepend() {
     let record = Record {
         ts: 1.2,
         hostname: "abcd".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,
@@ -128,6 +130,7 @@ fn test_passthrough_encode_no_msg() {
     let record = Record {
         ts: 1.2,
         hostname: "abcd".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,

--- a/cmd/flowgger/src/flowgger/encoder/rfc3164_encoder.rs
+++ b/cmd/flowgger/src/flowgger/encoder/rfc3164_encoder.rs
@@ -113,6 +113,7 @@ fn test_rfc3164_encode() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,
@@ -137,6 +138,7 @@ fn test_rfc3164_withpri_encode() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(2),
         severity: Some(7),
         appname: None,
@@ -172,6 +174,7 @@ fn test_rfc3164_encode_with_prepend() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,
@@ -204,6 +207,7 @@ fn test_rfc3164_full_encode() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(2),
         severity: Some(7),
         appname: Some("appname".to_string()),
@@ -234,6 +238,7 @@ fn test_rfc3164_full_encode_multiple_sd() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(2),
         severity: Some(7),
         appname: Some("appname".to_string()),

--- a/cmd/flowgger/src/flowgger/encoder/rfc5424_encoder.rs
+++ b/cmd/flowgger/src/flowgger/encoder/rfc5424_encoder.rs
@@ -109,6 +109,7 @@ fn test_rfc5424_encode() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: None,
         severity: None,
         appname: None,
@@ -133,6 +134,7 @@ fn test_rfc5424_full_encode() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(3),
         severity: Some(1),
         appname: Some("appname".to_string()),
@@ -169,6 +171,7 @@ fn test_rfc5424_full_encode_multiple_sd() {
     let record = Record {
         ts,
         hostname: "testhostname".to_string(),
+        remote_addr: None,
         facility: Some(3),
         severity: Some(1),
         appname: Some("appname".to_string()),

--- a/cmd/flowgger/src/flowgger/record.rs
+++ b/cmd/flowgger/src/flowgger/record.rs
@@ -71,6 +71,8 @@ impl fmt::Display for StructuredData {
 pub struct Record {
     pub ts: f64,
     pub hostname: String,
+    /// Optional source IP address of the client that sent the log.
+    pub remote_addr: Option<String>,
     pub facility: Option<u8>,
     pub severity: Option<u8>,
     pub appname: Option<String>,
@@ -114,10 +116,11 @@ fn test_structured_data_display() {
 
 #[test]
 fn test_record_display() {
-    let expected_debug = r#"Record { ts: 123.456, hostname: "hostname", facility: Some(3), severity: Some(8), appname: Some("app"), procid: Some("123"), msgid: None, msg: Some("msg"), full_msg: None, sd: None }"#;
+    let expected_debug = r#"Record { ts: 123.456, hostname: "hostname", remote_addr: None, facility: Some(3), severity: Some(8), appname: Some("app"), procid: Some("123"), msgid: None, msg: Some("msg"), full_msg: None, sd: None }"#;
     let record = Record {
         ts: 123.456,
         hostname: "hostname".to_string(),
+        remote_addr: None,
         facility: Some(3),
         severity: Some(8),
         appname: Some("app".to_string()),

--- a/cmd/flowgger/src/flowgger/splitter/capnp_splitter.rs
+++ b/cmd/flowgger/src/flowgger/splitter/capnp_splitter.rs
@@ -155,6 +155,7 @@ fn handle_message(message: record_capnp::record::Reader) -> Result<Record, &'sta
     Ok(Record {
         ts,
         hostname,
+        remote_addr: None,
         facility,
         severity,
         appname,
@@ -179,6 +180,7 @@ mod tests {
         let expected = Record {
             ts: 1385053862.3072,
             hostname: "example.org".to_string(),
+            remote_addr: None,
             facility: None,
             severity: Some(1),
             appname: Some("appname".to_string()),

--- a/cmd/flowgger/src/flowgger/test_fuzzer.rs
+++ b/cmd/flowgger/src/flowgger/test_fuzzer.rs
@@ -14,7 +14,7 @@
 ///
 /// This function will return an error if the default config does not exists, is unreadable, or is not valid
 /// toml format
-#[cfg(test)]
+#[cfg(all(test, feature = "file"))]
 mod tests {
     extern crate quickcheck;
     extern crate tempdir;
@@ -37,6 +37,7 @@ mod tests {
     use flowgger::get_decoder_rfc3164;
     use flowgger::get_encoder_rfc3164;
     use flowgger::get_output_file;
+    use flowgger::output::Output;
     use flowgger::input::udp_input::handle_record_maybe_compressed;
     use flowgger::merger;
 
@@ -182,7 +183,7 @@ mod tests {
                 x.as_str().expect("output.format must be a string")
             });
 
-        let output = get_output_file(&config);
+        let output: Box<dyn Output> = get_output_file(&config);
         let output_type = config
             .lookup("output.type")
             .map_or(DEFAULT_OUTPUT_TYPE, |x| {
@@ -222,8 +223,13 @@ mod tests {
             let sync_sender: &mut SyncSender<Vec<u8>> = &mut context.sync_sender;
             let encoder: &mut Box<dyn Encoder> = &mut context.encoder;
             let decoder: &mut Box<dyn Decoder> = &mut context.decoder;
-            let _result =
-                handle_record_maybe_compressed(data.as_bytes(), &sync_sender, &decoder, &encoder);
+            let _result = handle_record_maybe_compressed(
+                data.as_bytes(),
+                "127.0.0.1:12345".parse().unwrap(),
+                &sync_sender,
+                &decoder,
+                &encoder,
+            );
 
             drop(guard);
         }


### PR DESCRIPTION
## Summary
- support `remote_addr` in Flowgger log records
- include `_remote_addr` in GELF output
- store peer IP for UDP messages
- update encoders and tests

## Testing
- `cargo test --manifest-path cmd/flowgger/Cargo.toml`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857666bb30c832093b0c16db102bde8