### PR TITLE
Add partition support for Flowgger NATS output

### DIFF
--- a/cmd/flowgger/flowgger.toml
+++ b/cmd/flowgger/flowgger.toml
@@ -9,6 +9,8 @@ format = "rfc3164"
 type = "nats"
 format = "gelf"
 framing = "noop" # NATS output handles its own framing
+# Partition for overlapping IP spaces
+partition = "default"
 
 # NATS JetStream specific settings
 nats_url = "nats://127.0.0.1:4222"

--- a/cmd/flowgger/src/flowgger/output/nats_output.rs
+++ b/cmd/flowgger/src/flowgger/output/nats_output.rs
@@ -1,12 +1,14 @@
 //! A Flowgger output that publishes every log record to a NATS JetStream subject.
 //! Enable with `--features nats-output`.
 
+#[cfg(all(feature = "nats-output", feature = "gelf"))]
+use serde_json::Value;
 #[cfg(feature = "nats-output")]
 use {
     super::Output,
     crate::flowgger::{config::Config, merger::Merger},
-    async_nats::{jetstream, Client, ConnectOptions},
     async_nats::jetstream::{context::PublishAckFuture, stream::StorageType},
+    async_nats::{jetstream, Client, ConnectOptions},
     std::{
         path::PathBuf,
         sync::{mpsc::Receiver, Arc, Mutex},
@@ -25,45 +27,70 @@ pub struct NATSOutput {
 #[cfg(feature = "nats-output")]
 #[derive(Clone)]
 struct NATSConfig {
-    url:      String,
-    subject:  String,
-    stream:   String,
-    timeout:  Duration,
+    url: String,
+    subject: String,
+    stream: String,
+    partition: String,
+    timeout: Duration,
     tls_cert: Option<PathBuf>,
-    tls_key:  Option<PathBuf>,
-    tls_ca:   Option<PathBuf>,
+    tls_key: Option<PathBuf>,
+    tls_ca: Option<PathBuf>,
 }
 
 #[cfg(feature = "nats-output")]
 impl NATSOutput {
     pub fn new(cfg: &Config) -> Self {
         // ---- mandatory ----
-        let url     = cfg.lookup("output.nats_url")
+        let url = cfg
+            .lookup("output.nats_url")
             .expect("output.nats_url is required")
-            .as_str().unwrap().to_owned();
-        let subject = cfg.lookup("output.nats_subject")
+            .as_str()
+            .unwrap()
+            .to_owned();
+        let subject = cfg
+            .lookup("output.nats_subject")
             .unwrap_or_else(|| panic!("output.nats_subject is required"))
-            .as_str().unwrap().to_owned();
+            .as_str()
+            .unwrap()
+            .to_owned();
 
         // ---- optional w/ sane defaults ----
-        let stream  = cfg.lookup("output.nats_stream")
+        let stream = cfg
+            .lookup("output.nats_stream")
             .map_or("events".into(), |v| v.as_str().unwrap().to_owned());
+        let partition = cfg
+            .lookup("output.partition")
+            .map_or("default".into(), |v| v.as_str().unwrap().to_owned());
         let timeout = Duration::from_millis(
             cfg.lookup("output.nats_timeout")
-                .map_or(30_000, |v| v.as_integer().unwrap() as u64));
+                .map_or(30_000, |v| v.as_integer().unwrap() as u64),
+        );
 
-        let tls_cert = cfg.lookup("output.nats_tls_cert")
+        let tls_cert = cfg
+            .lookup("output.nats_tls_cert")
             .and_then(|v| Some(PathBuf::from(v.as_str().unwrap())));
-        let tls_key  = cfg.lookup("output.nats_tls_key")
+        let tls_key = cfg
+            .lookup("output.nats_tls_key")
             .and_then(|v| Some(PathBuf::from(v.as_str().unwrap())));
-        let tls_ca   = cfg.lookup("output.nats_tls_ca_file")
+        let tls_ca = cfg
+            .lookup("output.nats_tls_ca_file")
             .and_then(|v| Some(PathBuf::from(v.as_str().unwrap())));
 
-        let workers  = cfg.lookup("output.nats_threads")
+        let workers = cfg
+            .lookup("output.nats_threads")
             .map_or(1, |v| v.as_integer().unwrap() as u32);
 
         Self {
-            cfg: NATSConfig { url, subject, stream, timeout, tls_cert, tls_key, tls_ca },
+            cfg: NATSConfig {
+                url,
+                subject,
+                stream,
+                partition,
+                timeout,
+                tls_cert,
+                tls_key,
+                tls_ca,
+            },
             workers,
         }
     }
@@ -75,7 +102,6 @@ struct NATSWorker {
     cfg: NATSConfig,
     merger: Option<Box<dyn Merger + Send>>,
 }
-
 
 #[cfg(feature = "nats-output")]
 impl NATSWorker {
@@ -99,9 +125,9 @@ impl NATSWorker {
 
         // Ensure the target stream exists.
         let stream_config = jetstream::stream::Config {
-            name:     self.cfg.stream.clone(),
+            name: self.cfg.stream.clone(),
             subjects: vec![self.cfg.subject.clone()],
-            storage:  StorageType::File,
+            storage: StorageType::File,
             ..Default::default()
         };
         let _ = js.get_or_create_stream(stream_config).await?;
@@ -119,7 +145,23 @@ impl NATSWorker {
                 Err(_) => return, // channel closed – shut the worker down
             };
 
-            if let Some(m) = &self.merger { m.frame(&mut bytes); }
+            #[cfg(feature = "gelf")]
+            {
+                if let Ok(mut v) = serde_json::from_slice::<Value>(&bytes) {
+                    if let Some(obj) = v.as_object_mut() {
+                        if let Some(addr_val) = obj.get_mut("_remote_addr") {
+                            if let Some(s) = addr_val.as_str() {
+                                *addr_val = Value::String(format!("{}:{}", self.cfg.partition, s));
+                            }
+                        }
+                        bytes = serde_json::to_vec(&v).unwrap_or(bytes);
+                    }
+                }
+            }
+
+            if let Some(m) = &self.merger {
+                m.frame(&mut bytes);
+            }
 
             // Fire-and-wait-for-ack with timeout so we can log failures.
             let ack: PublishAckFuture = js
@@ -135,14 +177,11 @@ impl NATSWorker {
 
 #[cfg(feature = "nats-output")]
 impl Output for NATSOutput {
-    fn start(&self,
-             arx: Arc<Mutex<Receiver<Vec<u8>>>>,
-             merger: Option<Box<dyn Merger>>) {
-
+    fn start(&self, arx: Arc<Mutex<Receiver<Vec<u8>>>>, merger: Option<Box<dyn Merger>>) {
         for _ in 0..self.workers {
-            let arx     = Arc::clone(&arx);
-            let cfg     = self.cfg.clone();
-            let merger  = merger.as_ref().map(|m| m.clone_boxed());
+            let arx = Arc::clone(&arx);
+            let cfg = self.cfg.clone();
+            let merger = merger.as_ref().map(|m| m.clone_boxed());
 
             thread::spawn(move || {
                 let rt = RtBuilder::new_current_thread()

--- a/packaging/flowgger/config/flowgger.toml
+++ b/packaging/flowgger/config/flowgger.toml
@@ -9,6 +9,8 @@ format = "rfc3164"
 type = "nats"
 format = "gelf"
 framing = "noop" # NATS output handles its own framing
+# Partition for overlapping IP spaces
+partition = "default"
 
 # NATS JetStream specific settings
 nats_url = "nats://127.0.0.1:4222"


### PR DESCRIPTION
## Summary
- extend `NATSOutput` with a `partition` config option
- prefix `_remote_addr` with the configured partition before publishing
- document the new setting in example configs

## Testing
- `cargo build --manifest-path cmd/flowgger/Cargo.toml --features nats-output --quiet`
- `cargo test --manifest-path cmd/flowgger/Cargo.toml --features nats-output --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68577552c86c8320a93b37a8df4c1d49