### PR TITLE
Add DB event writer consumer

### DIFF
--- a/cmd/consumers/db-event-writer/main.go
+++ b/cmd/consumers/db-event-writer/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/carverauto/serviceradar/pkg/config"
+	dbeventwriter "github.com/carverauto/serviceradar/pkg/consumers/db-event-writer"
+	"github.com/carverauto/serviceradar/pkg/db"
+	"github.com/carverauto/serviceradar/pkg/lifecycle"
+	"github.com/carverauto/serviceradar/pkg/models"
+)
+
+func main() {
+	ctx := context.Background()
+	cfgLoader := config.NewConfig()
+	configPath := "/etc/serviceradar/consumers/db-event-writer.json"
+
+	var cfg dbeventwriter.DBEventWriterConfig
+	if err := cfgLoader.LoadAndValidate(ctx, configPath, &cfg); err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("DB event writer config validation failed: %v", err)
+	}
+
+	dbSecurity := cfg.Security
+	if cfg.DBSecurity != nil {
+		dbSecurity = cfg.DBSecurity
+	}
+
+	dbConfig := &models.DBConfig{
+		DBAddr:   cfg.Database.Addresses[0],
+		DBName:   cfg.Database.Name,
+		DBUser:   cfg.Database.Username,
+		DBPass:   cfg.Database.Password,
+		Database: cfg.Database,
+		Security: dbSecurity,
+	}
+
+	dbService, err := db.New(ctx, dbConfig)
+	if err != nil {
+		log.Fatalf("Failed to initialize database service: %v", err)
+	}
+
+	svc, err := dbeventwriter.NewService(&cfg, dbService)
+	if err != nil {
+		log.Fatalf("Failed to initialize event writer service: %v", err)
+	}
+
+	opts := &lifecycle.ServerOptions{
+		ListenAddr:        cfg.ListenAddr,
+		ServiceName:       "db-event-writer",
+		Service:           svc,
+		EnableHealthCheck: true,
+		Security:          cfg.Security,
+	}
+
+	if err := lifecycle.RunServer(ctx, opts); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
+}

--- a/pkg/consumers/db-event-writer/config.go
+++ b/pkg/consumers/db-event-writer/config.go
@@ -1,0 +1,85 @@
+package dbeventwriter
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/carverauto/serviceradar/pkg/config"
+	"github.com/carverauto/serviceradar/pkg/models"
+)
+
+var (
+	ErrMissingListenAddr     = errors.New("listen_addr is required")
+	ErrMissingNATSURL        = errors.New("nats_url is required")
+	ErrMissingStreamName     = errors.New("stream_name is required")
+	ErrMissingConsumerName   = errors.New("consumer_name is required")
+	ErrMissingTableName      = errors.New("table is required")
+	ErrMissingDatabaseConfig = errors.New("database configuration is required")
+	ErrInvalidJSON           = errors.New("failed to unmarshal JSON configuration")
+)
+
+// DBEventWriterConfig holds configuration for the DB event writer consumer.
+type DBEventWriterConfig struct {
+	ListenAddr   string                 `json:"listen_addr"`
+	NATSURL      string                 `json:"nats_url"`
+	Subject      string                 `json:"subject"`
+	StreamName   string                 `json:"stream_name"`
+	ConsumerName string                 `json:"consumer_name"`
+	Domain       string                 `json:"domain"`
+	Table        string                 `json:"table"`
+	Security     *models.SecurityConfig `json:"security"`
+	DBSecurity   *models.SecurityConfig `json:"db_security"`
+	Database     models.ProtonDatabase  `json:"database"`
+}
+
+// UnmarshalJSON ensures TLS paths are normalized.
+func (c *DBEventWriterConfig) UnmarshalJSON(data []byte) error {
+	type Alias DBEventWriterConfig
+	var alias struct{ Alias }
+	alias.Alias = Alias{}
+
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return errors.Join(ErrInvalidJSON, err)
+	}
+
+	*c = DBEventWriterConfig(alias.Alias)
+
+	if c.Security != nil && c.Security.CertDir != "" {
+		config.NormalizeTLSPaths(&c.Security.TLS, c.Security.CertDir)
+	}
+
+	if c.DBSecurity != nil && c.DBSecurity.CertDir != "" {
+		config.NormalizeTLSPaths(&c.DBSecurity.TLS, c.DBSecurity.CertDir)
+	}
+
+	return nil
+}
+
+// Validate checks the configuration for required fields.
+func (c *DBEventWriterConfig) Validate() error {
+	var errs []error
+
+	if c.ListenAddr == "" {
+		errs = append(errs, ErrMissingListenAddr)
+	}
+	if c.NATSURL == "" {
+		errs = append(errs, ErrMissingNATSURL)
+	}
+	if c.StreamName == "" {
+		errs = append(errs, ErrMissingStreamName)
+	}
+	if c.ConsumerName == "" {
+		errs = append(errs, ErrMissingConsumerName)
+	}
+	if c.Table == "" {
+		errs = append(errs, ErrMissingTableName)
+	}
+	if c.Database.Name == "" || len(c.Database.Addresses) == 0 {
+		errs = append(errs, ErrMissingDatabaseConfig)
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}

--- a/pkg/consumers/db-event-writer/consumer.go
+++ b/pkg/consumers/db-event-writer/consumer.go
@@ -1,0 +1,107 @@
+package dbeventwriter
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Consumer wraps a JetStream pull consumer.
+type Consumer struct {
+	js           jetstream.JetStream
+	streamName   string
+	consumerName string
+	consumer     jetstream.Consumer
+}
+
+// NewConsumer creates or retrieves a pull consumer for the given stream.
+func NewConsumer(ctx context.Context, js jetstream.JetStream, streamName, consumerName, subject string) (*Consumer, error) {
+	log.Printf("Creating/getting pull consumer: stream=%s, consumer=%s", streamName, consumerName)
+
+	consumer, err := js.Consumer(ctx, streamName, consumerName)
+	if err != nil {
+		cfg := jetstream.ConsumerConfig{
+			Durable:       consumerName,
+			AckPolicy:     jetstream.AckExplicitPolicy,
+			AckWait:       30 * time.Second,
+			MaxDeliver:    3,
+			MaxAckPending: 1000,
+		}
+
+		if subject != "" {
+			cfg.FilterSubject = subject
+		}
+
+		consumer, err = js.CreateConsumer(ctx, streamName, cfg)
+		if err != nil {
+			log.Printf("Failed to create consumer: stream=%s, consumer=%s, err=%v", streamName, consumerName, err)
+			return nil, fmt.Errorf("failed to create consumer: %w", err)
+		}
+	}
+
+	return &Consumer{js: js, streamName: streamName, consumerName: consumerName, consumer: consumer}, nil
+}
+
+const (
+	defaultMaxPullMessages = 50
+	defaultPullExpiry      = 30 * time.Second
+	defaultMaxRetries      = 3
+)
+
+func (*Consumer) handleBatch(ctx context.Context, msgs []jetstream.Msg, processor *Processor) {
+	processed, err := processor.ProcessBatch(ctx, msgs)
+	if err != nil {
+		log.Printf("Failed to process message batch: %v", err)
+
+		for _, msg := range processed {
+			metadata, _ := msg.Metadata()
+			if metadata.NumDelivered >= defaultMaxRetries {
+				_ = msg.Ack()
+			} else {
+				_ = msg.Nak()
+			}
+		}
+
+		return
+	}
+
+	for _, msg := range processed {
+		_ = msg.Ack()
+	}
+}
+
+// ProcessMessages continuously fetches and processes messages.
+func (c *Consumer) ProcessMessages(ctx context.Context, processor *Processor) {
+	log.Printf("Starting pull consumer for stream %s, consumer %s", c.streamName, c.consumerName)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Stopping message processing due to context cancellation")
+			return
+		default:
+			msgs, err := c.consumer.Fetch(defaultMaxPullMessages, jetstream.FetchMaxWait(defaultPullExpiry))
+			if err != nil {
+				log.Printf("Failed to fetch messages: %v", err)
+				time.Sleep(time.Second)
+				continue
+			}
+
+			batch := make([]jetstream.Msg, 0, defaultMaxPullMessages)
+			for msg := range msgs.Messages() {
+				batch = append(batch, msg)
+			}
+
+			if len(batch) > 0 {
+				c.handleBatch(ctx, batch, processor)
+			}
+
+			if fetchErr := msgs.Error(); fetchErr != nil {
+				log.Printf("Fetch error: %v", fetchErr)
+			}
+		}
+	}
+}

--- a/pkg/consumers/db-event-writer/errors.go
+++ b/pkg/consumers/db-event-writer/errors.go
@@ -1,0 +1,7 @@
+package dbeventwriter
+
+import "errors"
+
+var (
+	errDBServiceNotDB = errors.New("db.Service is not *db.DB")
+)

--- a/pkg/consumers/db-event-writer/processor.go
+++ b/pkg/consumers/db-event-writer/processor.go
@@ -1,0 +1,54 @@
+package dbeventwriter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/carverauto/serviceradar/pkg/db"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/timeplus-io/proton-go-driver/v2"
+)
+
+// Processor writes JetStream messages to a Proton table.
+type Processor struct {
+	conn  proton.Conn
+	table string
+}
+
+// NewProcessor creates a Processor using the provided db.Service.
+func NewProcessor(dbService db.Service, table string) (*Processor, error) {
+	dbImpl, ok := dbService.(*db.DB)
+	if !ok {
+		return nil, errDBServiceNotDB
+	}
+
+	return &Processor{conn: dbImpl.Conn, table: table}, nil
+}
+
+// ProcessBatch writes a batch of messages to the table and returns the processed messages.
+func (p *Processor) ProcessBatch(ctx context.Context, msgs []jetstream.Msg) ([]jetstream.Msg, error) {
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s (message) VALUES (?)", p.table)
+	batch, err := p.conn.PrepareBatch(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	processed := make([]jetstream.Msg, 0, len(msgs))
+
+	for _, msg := range msgs {
+		if err := batch.Append(string(msg.Data())); err != nil {
+			return processed, err
+		}
+		processed = append(processed, msg)
+	}
+
+	if err := batch.Send(); err != nil {
+		return processed, err
+	}
+
+	return processed, nil
+}

--- a/pkg/consumers/db-event-writer/service.go
+++ b/pkg/consumers/db-event-writer/service.go
@@ -1,0 +1,151 @@
+package dbeventwriter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/carverauto/serviceradar/pkg/db"
+	"github.com/carverauto/serviceradar/pkg/lifecycle"
+	"github.com/carverauto/serviceradar/pkg/natsutil"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Service implements lifecycle.Service for the DB event writer.
+type Service struct {
+	cfg       *DBEventWriterConfig
+	nc        *nats.Conn
+	js        jetstream.JetStream
+	consumer  *Consumer
+	processor *Processor
+	wg        sync.WaitGroup
+	db        db.Service
+}
+
+// NewService initializes the service.
+func NewService(cfg *DBEventWriterConfig, dbService db.Service) (*Service, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	proc, err := NewProcessor(dbService, cfg.Table)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := &Service{cfg: cfg, processor: proc, db: dbService}
+	return svc, nil
+}
+
+func (s *Service) initSchema(ctx context.Context) error {
+	dbImpl, ok := s.db.(*db.DB)
+	if !ok {
+		return errDBServiceNotDB
+	}
+
+	query := fmt.Sprintf(`CREATE STREAM IF NOT EXISTS %s (
+        message string,
+        _tp_time DateTime64(3) DEFAULT now64(3)
+    )`, s.cfg.Table)
+
+	return dbImpl.Conn.Exec(ctx, query)
+}
+
+// Start connects to NATS and begins processing messages.
+func (s *Service) Start(ctx context.Context) error {
+	if err := s.initSchema(ctx); err != nil {
+		return fmt.Errorf("failed to initialize schema: %w", err)
+	}
+
+	var opts []nats.Option
+	if s.cfg.Security != nil {
+		tlsConf, err := natsutil.TLSConfig(s.cfg.Security)
+		if err != nil {
+			return fmt.Errorf("failed to build NATS TLS config: %w", err)
+		}
+		opts = append(opts,
+			nats.Secure(tlsConf),
+			nats.RootCAs(s.cfg.Security.TLS.CAFile),
+			nats.ClientCert(s.cfg.Security.TLS.CertFile, s.cfg.Security.TLS.KeyFile),
+		)
+	}
+
+	nc, err := nats.Connect(s.cfg.NATSURL, opts...)
+	if err != nil {
+		return err
+	}
+	s.nc = nc
+
+	var js jetstream.JetStream
+	if s.cfg.Domain != "" {
+		js, err = jetstream.NewWithDomain(nc, s.cfg.Domain)
+	} else {
+		js, err = jetstream.New(nc)
+	}
+	if err != nil {
+		nc.Close()
+		return err
+	}
+	s.js = js
+
+	stream, err := js.Stream(ctx, s.cfg.StreamName)
+	if errors.Is(err, jetstream.ErrStreamNotFound) {
+		sc := jetstream.StreamConfig{Name: s.cfg.StreamName}
+		if s.cfg.Subject != "" {
+			sc.Subjects = []string{s.cfg.Subject}
+		}
+		stream, err = js.CreateOrUpdateStream(ctx, sc)
+		if err != nil {
+			nc.Close()
+			return fmt.Errorf("failed to create stream %s: %w", s.cfg.StreamName, err)
+		}
+	} else if err != nil {
+		nc.Close()
+		return fmt.Errorf("failed to get stream %s: %w", s.cfg.StreamName, err)
+	}
+
+	if _, err = stream.Info(ctx); err != nil {
+		nc.Close()
+		return fmt.Errorf("failed to get stream info: %w", err)
+	}
+
+	s.consumer, err = NewConsumer(ctx, js, s.cfg.StreamName, s.cfg.ConsumerName, s.cfg.Subject)
+	if err != nil {
+		nc.Close()
+		return err
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.consumer.ProcessMessages(ctx, s.processor)
+	}()
+
+	log.Printf("DB event writer started for stream %s, consumer %s", s.cfg.StreamName, s.cfg.ConsumerName)
+	return nil
+}
+
+const shutdownTimeout = 10 * time.Second
+
+// Stop shuts down the service.
+func (s *Service) Stop(ctx context.Context) error {
+	_, cancel := context.WithTimeout(ctx, shutdownTimeout)
+	defer cancel()
+
+	if s.db != nil {
+		_ = s.db.Close()
+	}
+	if s.nc != nil {
+		s.nc.Close()
+	}
+
+	s.wg.Wait()
+	log.Println("DB event writer stopped")
+	return nil
+}
+
+var _ lifecycle.Service = (*Service)(nil)


### PR DESCRIPTION
## Summary
- add new db-event-writer consumer package for JetStream messages
- create command to run the consumer

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858488c98b08320b1baafe548076690