### PR TITLE
Handle cloudevents in db-event-writer

### DIFF
--- a/pkg/consumers/db-event-writer/processor_test.go
+++ b/pkg/consumers/db-event-writer/processor_test.go
@@ -1,0 +1,21 @@
+package dbeventwriter
+
+import "testing"
+
+func TestParseCloudEvent(t *testing.T) {
+	msg := []byte(`{"specversion":"1.0","id":"1","type":"cef_severity","source":"nats://events/events.syslog","datacontenttype":"application/json","data":{"foo":"bar"}}`)
+	data, ok := parseCloudEvent(msg)
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if data != "{\"foo\":\"bar\"}" {
+		t.Fatalf("unexpected data: %s", data)
+	}
+}
+
+func TestParseCloudEventInvalid(t *testing.T) {
+	msg := []byte(`{"id":1}`)
+	if _, ok := parseCloudEvent(msg); ok {
+		t.Fatalf("expected failure")
+	}
+}


### PR DESCRIPTION
## Summary
- add CloudEvent parsing helper
- store CloudEvent `data` field in table
- unit tests for CloudEvent parsing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68584b2559308320a0d8090c1adc3c5a