### PR TITLE
Add JetStream domain option to zen consumer

### DIFF
--- a/cmd/consumers/zen/README.md
+++ b/cmd/consumers/zen/README.md
@@ -9,6 +9,7 @@ Create a JSON file with the following fields:
 ```json
 {
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog", "events.snmp"],
@@ -60,6 +61,7 @@ Optionally add TLS settings:
 ```json
 {
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog", "events.snmp"],

--- a/cmd/consumers/zen/src/bin/put_rule.rs
+++ b/cmd/consumers/zen/src/bin/put_rule.rs
@@ -34,6 +34,8 @@ struct SecurityConfig {
 #[derive(Debug, Deserialize, Clone)]
 struct Config {
     nats_url: String,
+    #[serde(default)]
+    domain: Option<String>,
     stream_name: String,
     consumer_name: String,
     #[serde(default)]
@@ -69,7 +71,12 @@ async fn connect_nats(cfg: &Config) -> Result<jetstream::Context> {
         }
     }
     let client = opts.connect(&cfg.nats_url).await?;
-    Ok(jetstream::new(client))
+    let js = if let Some(domain) = &cfg.domain {
+        jetstream::with_domain(client, domain)
+    } else {
+        jetstream::new(client)
+    };
+    Ok(js)
 }
 
 #[tokio::main]

--- a/cmd/consumers/zen/zen-consumer.json
+++ b/cmd/consumers/zen/zen-consumer.json
@@ -1,5 +1,6 @@
 {
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog", "events.snmp"],

--- a/packaging/zen/config/zen-consumer.json
+++ b/packaging/zen/config/zen-consumer.json
@@ -1,5 +1,6 @@
 {
   "nats_url": "nats://127.0.0.1:4222",
+  "domain": "edge",
   "stream_name": "events",
   "consumer_name": "zen-consumer",
   "subjects": ["events.syslog", "events.snmp"],


### PR DESCRIPTION
## Summary
- allow specifying JetStream domain in zen-consumer config
- update zen consumer code and put-rule helper to use the optional domain
- document new field and update sample configs

## Testing
- `cargo test --manifest-path cmd/consumers/zen/Cargo.toml`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68585c4b93788320b54523f0d02ecbdb