### PR TITLE
Package zen consumer with helper and rules

### DIFF
--- a/cmd/consumers/zen/Dockerfile
+++ b/cmd/consumers/zen/Dockerfile
@@ -31,6 +31,9 @@ RUN mkdir -p /output
 # Copy the binary from the builder stage to both /usr/local/bin and /output
 COPY --from=builder /usr/src/serviceradar-zen/target/x86_64-unknown-linux-gnu/release/serviceradar-zen /usr/local/bin/serviceradar-zen
 COPY --from=builder /usr/src/serviceradar-zen/target/x86_64-unknown-linux-gnu/release/serviceradar-zen /output/serviceradar-zen
+# Ship the zen-put-rule helper as well
+COPY --from=builder /usr/src/serviceradar-zen/target/x86_64-unknown-linux-gnu/release/zen-put-rule /usr/local/bin/zen-put-rule
+COPY --from=builder /usr/src/serviceradar-zen/target/x86_64-unknown-linux-gnu/release/zen-put-rule /output/zen-put-rule
 
 # Configuration and user setup
 WORKDIR /etc/serviceradar

--- a/docker/rpm/Dockerfile.rpm.rust.zen
+++ b/docker/rpm/Dockerfile.rpm.rust.zen
@@ -43,10 +43,8 @@ RUN sed -i "s/%{version}/${VERSION}/g" SPECS/serviceradar-${COMPONENT}.spec && \
     mkdir -p BUILD && \
     echo "Listing binary directory contents:" && \
     ls -la /src/${BINARY_PATH}/target/x86_64-unknown-linux-gnu/release/ && \
-    # Determine the correct binary name based on actual files
-    export BINARY_FILE=$(find /src/${BINARY_PATH}/target/x86_64-unknown-linux-gnu/release/ -type f -executable -not -name "*.d" | grep -v "\.so" | head -1) && \
-    echo "Found binary: ${BINARY_FILE}" && \
-    cp "${BINARY_FILE}" BUILD/serviceradar-${COMPONENT} && \
+    cp /src/${BINARY_PATH}/target/x86_64-unknown-linux-gnu/release/serviceradar-zen BUILD/serviceradar-zen && \
+    cp /src/${BINARY_PATH}/target/x86_64-unknown-linux-gnu/release/zen-put-rule BUILD/zen-put-rule && \
     rpmbuild -bb SPECS/serviceradar-${COMPONENT}.spec && \
     echo "Checking RPM build output:" && \
     find RPMS -type f -name "*.rpm" && \

--- a/packaging/components.json
+++ b/packaging/components.json
@@ -658,6 +658,18 @@
       {
         "source": "packaging/zen/config/zen-consumer.json",
         "dest": "/etc/serviceradar/consumers/zen-consumer.json"
+      },
+      {
+        "source": "packaging/zen/rules/cef_severity.json",
+        "dest": "/etc/serviceradar/zen/rules/cef_severity.json"
+      },
+      {
+        "source": "packaging/zen/rules/passthrough.json",
+        "dest": "/etc/serviceradar/zen/rules/passthrough.json"
+      },
+      {
+        "source": "packaging/zen/rules/strip_full_message.json",
+        "dest": "/etc/serviceradar/zen/rules/strip_full_message.json"
       }
     ],
     "systemd_service": {
@@ -671,10 +683,14 @@
       "source": "packaging/zen/scripts/preremove.sh"
     },
     "conffiles": [
-      "/etc/serviceradar/consumers/zen-consumer.json"
+      "/etc/serviceradar/consumers/zen-consumer.json",
+      "/etc/serviceradar/zen/rules/cef_severity.json",
+      "/etc/serviceradar/zen/rules/passthrough.json",
+      "/etc/serviceradar/zen/rules/strip_full_message.json"
     ],
     "additional_dirs": [
-      "/var/log/zen"
+      "/var/log/zen",
+      "/etc/serviceradar/zen/rules"
     ]
   },
   {

--- a/packaging/specs/serviceradar-zen.spec
+++ b/packaging/specs/serviceradar-zen.spec
@@ -16,19 +16,26 @@ This package provides the ServiceRadar Zen consumer service, which is responsibl
 mkdir -p %{buildroot}/usr/local/bin
 mkdir -p %{buildroot}/lib/systemd/system
 mkdir -p %{buildroot}/etc/serviceradar/consumers
+mkdir -p %{buildroot}/etc/serviceradar/zen/rules
 
 # Install the binary (assumes binary is built at /src/cmd/zen/target/release/serviceradar-zen)
 install -m 755 %{_builddir}/serviceradar-zen %{buildroot}/usr/local/bin/
+install -m 755 %{_builddir}/zen-put-rule %{buildroot}/usr/local/bin/
 
 # Install systemd service and config files from packaging directory
 install -m 644 %{_sourcedir}/zen/systemd/serviceradar-zen.service %{buildroot}/lib/systemd/system/
 install -m 644 %{_sourcedir}/zen/config/zen-consumer.json %{buildroot}/etc/serviceradar/consumers/
+install -m 644 %{_sourcedir}/zen/rules/*.json %{buildroot}/etc/serviceradar/zen/rules/
 
 %files
 %attr(0755, root, root) /usr/local/bin/serviceradar-zen
+%attr(0755, root, root) /usr/local/bin/zen-put-rule
 %config(noreplace) %attr(0644, serviceradar, serviceradar) /etc/serviceradar/consumers/zen-consumer.json
+%config(noreplace) %attr(0644, serviceradar, serviceradar) /etc/serviceradar/zen/rules/*.json
 %attr(0644, root, root) /lib/systemd/system/serviceradar-zen.service
 %dir %attr(0755, root, root) /etc/serviceradar
+%dir %attr(0755, root, root) /etc/serviceradar/zen
+%dir %attr(0755, root, root) /etc/serviceradar/zen/rules
 
 %pre
 # Create serviceradar user if it doesn't exist
@@ -40,6 +47,7 @@ fi
 %systemd_post serviceradar-zen.service
 chown -R serviceradar:serviceradar /etc/serviceradar
 chmod 755 /usr/local/bin/serviceradar-zen
+chmod 755 /usr/local/bin/zen-put-rule
 
 %preun
 %systemd_preun serviceradar-zen.service

--- a/packaging/zen/rules/cef_severity.json
+++ b/packaging/zen/rules/cef_severity.json
@@ -1,0 +1,29 @@
+{
+  "nodes": [
+    { "id": "inputNode", "type": "inputNode", "name": "Request", "position": {"x": 80, "y": 150} },
+    {
+      "id": "cefTable",
+      "type": "decisionTableNode",
+      "name": "CEF Severity",
+      "position": {"x": 300, "y": 150},
+      "content": {
+        "hitPolicy": "first",
+        "inputs": [ {"field": "short_message", "id": "fld_msg", "name": "Short", "type": "expression"} ],
+        "outputs": [ {"field": "severity", "id": "fld_sev", "name": "Severity", "type": "expression"} ],
+        "rules": [
+          {"_id": "r0", "fld_msg": "contains(short_message, '|0|') or contains(short_message, '|1|') or contains(short_message, '|2|') or contains(short_message, '|3|')", "fld_sev": "'Low'"},
+          {"_id": "r1", "fld_msg": "contains(short_message, '|4|') or contains(short_message, '|5|') or contains(short_message, '|6|')", "fld_sev": "'Medium'"},
+          {"_id": "r2", "fld_msg": "contains(short_message, '|7|') or contains(short_message, '|8|')", "fld_sev": "'High'"},
+          {"_id": "r3", "fld_msg": "contains(short_message, '|9|') or contains(short_message, '|10|')", "fld_sev": "'Very High'"},
+          {"_id": "r4", "fld_msg": "", "fld_sev": "'Unknown'"}
+        ]
+      }
+    },
+    { "id": "outputNode", "type": "outputNode", "name": "Response", "position": {"x": 560, "y": 150} }
+  ],
+  "edges": [
+    {"id": "e1", "sourceId": "inputNode", "targetId": "cefTable", "type": "edge"},
+    {"id": "e2", "sourceId": "cefTable", "targetId": "outputNode", "type": "edge"},
+    {"id": "e3", "sourceId": "inputNode", "targetId": "outputNode", "type": "edge"}
+  ]
+}

--- a/packaging/zen/rules/passthrough.json
+++ b/packaging/zen/rules/passthrough.json
@@ -1,0 +1,24 @@
+{
+  "nodes": [
+    {
+      "id": "inputNode",
+      "type": "inputNode",
+      "name": "Request",
+      "position": { "x": 80, "y": 150 }
+    },
+    {
+      "id": "outputNode",
+      "type": "outputNode",
+      "name": "Response",
+      "position": { "x": 300, "y": 150 }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge_1",
+      "sourceId": "inputNode",
+      "targetId": "outputNode",
+      "type": "edge"
+    }
+  ]
+}

--- a/packaging/zen/rules/strip_full_message.json
+++ b/packaging/zen/rules/strip_full_message.json
@@ -1,0 +1,22 @@
+{
+  "nodes": [
+    { "id": "inputNode", "type": "inputNode", "name": "Request", "position": { "x": 80, "y": 150 } },
+    {
+      "id": "stripFullMessage",
+      "type": "expressionNode",
+      "name": "Strip Full Message",
+      "position": { "x": 300, "y": 150 },
+      "content": {
+        "expressions": [
+          { "id": "expr1", "key": "full_message", "value": "null" }
+        ]
+      }
+    },
+    { "id": "outputNode", "type": "outputNode", "name": "Response", "position": { "x": 560, "y": 150 } }
+  ],
+  "edges": [
+    { "id": "e1", "sourceId": "inputNode", "targetId": "stripFullMessage", "type": "edge" },
+    { "id": "e2", "sourceId": "stripFullMessage", "targetId": "outputNode", "type": "edge" },
+    { "id": "e3", "sourceId": "inputNode", "targetId": "outputNode", "type": "edge" }
+  ]
+}

--- a/packaging/zen/scripts/postinstall.sh
+++ b/packaging/zen/scripts/postinstall.sh
@@ -31,12 +31,15 @@ fi
 mkdir -p /var/lib/serviceradar
 mkdir -p /etc/serviceradar/checkers
 mkdir -p /etc/serviceradar/consumers
+mkdir -p /etc/serviceradar/zen/rules
 
 # Set proper ownership and permissions
 chown -R serviceradar:serviceradar /etc/serviceradar/checkers
 chown -R serviceradar:serviceradar /etc/serviceradar/consumers
+chown -R serviceradar:serviceradar /etc/serviceradar/zen
 chown -R serviceradar:serviceradar /var/lib/serviceradar
 chmod 755 /usr/local/bin/serviceradar-zen
+chmod 755 /usr/local/bin/zen-put-rule
 chmod 644 /etc/serviceradar/consumers/zen-consumer.json
 
 # Enable and start the service

--- a/scripts/setup-package.sh
+++ b/scripts/setup-package.sh
@@ -299,6 +299,12 @@ build_component() {
             ls -l "${pkg_root}${output_path}" || { echo "Error: Binary not copied to package root"; exit 1; }
             test -s "${pkg_root}${output_path}" || { echo "Error: Binary is empty"; exit 1; }
 
+            # Copy zen-put-rule helper for zen component
+            if [ "$component" = "zen" ]; then
+                docker cp "${container_id}:/output/zen-put-rule" "${pkg_root}/usr/local/bin/zen-put-rule" || { echo "Error: Failed to copy zen-put-rule"; exit 1; }
+                ls -l "${pkg_root}/usr/local/bin/zen-put-rule" || { echo "Error: zen-put-rule not copied"; exit 1; }
+            fi
+
             # Copy ZFS binary for sysmon
             if [ "$component" = "sysmon" ]; then
                 zfs_output_path="/output/serviceradar-sysmon-checker-zfs"


### PR DESCRIPTION
## Summary
- ship zen-put-rule in zen consumer Dockerfile and RPM build
- include rules data in packaging and install to `/etc/serviceradar/zen/rules`
- update components.json for new files and directories
- adjust RPM spec and postinstall to handle helper and rules
- copy helper from Docker build in setup-package.sh

## Testing
- `go fmt ./...`

------
https://chatgpt.com/codex/tasks/task_e_685867b01d588320a1ce00b8d168723c