### PR TITLE
Handle CloudEvent fields in event writer

### DIFF
--- a/pkg/consumers/db-event-writer/processor.go
+++ b/pkg/consumers/db-event-writer/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/carverauto/serviceradar/pkg/db"
 	"github.com/nats-io/nats.go/jetstream"
@@ -14,6 +15,24 @@ import (
 type Processor struct {
 	conn  proton.Conn
 	table string
+}
+
+// eventRow represents a single row in the events stream.
+type eventRow struct {
+	SpecVersion     string
+	ID              string
+	Source          string
+	Type            string
+	DataContentType string
+	Subject         string
+	RemoteAddr      string
+	Host            string
+	Level           int32
+	Severity        string
+	ShortMessage    string
+	EventTimestamp  time.Time
+	Version         string
+	RawData         string
 }
 
 // parseCloudEvent attempts to extract the `data` field from a CloudEvent.
@@ -35,6 +54,65 @@ func parseCloudEvent(b []byte) (string, bool) {
 	return string(tmp.Data), true
 }
 
+// buildEventRow parses a CloudEvent payload and returns an eventRow.
+// If parsing fails, the returned row will contain only the raw data and subject.
+func buildEventRow(b []byte, subject string) eventRow {
+	var ce struct {
+		SpecVersion     string          `json:"specversion"`
+		ID              string          `json:"id"`
+		Source          string          `json:"source"`
+		Type            string          `json:"type"`
+		DataContentType string          `json:"datacontenttype"`
+		Subject         string          `json:"subject"`
+		Data            json.RawMessage `json:"data"`
+	}
+
+	if err := json.Unmarshal(b, &ce); err != nil {
+		return eventRow{RawData: string(b), Subject: subject}
+	}
+
+	if ce.Subject == "" {
+		ce.Subject = subject
+	}
+
+	var payload struct {
+		RemoteAddr   string  `json:"_remote_addr"`
+		Host         string  `json:"host"`
+		Level        int32   `json:"level"`
+		Severity     string  `json:"severity"`
+		ShortMessage string  `json:"short_message"`
+		Timestamp    float64 `json:"timestamp"`
+		Version      string  `json:"version"`
+	}
+
+	if len(ce.Data) > 0 {
+		if err := json.Unmarshal(ce.Data, &payload); err != nil {
+			return eventRow{RawData: string(b), Subject: ce.Subject}
+		}
+	}
+
+	sec := int64(payload.Timestamp)
+	nsec := int64((payload.Timestamp - float64(sec)) * float64(time.Second))
+	ts := time.Unix(sec, nsec)
+
+	return eventRow{
+		SpecVersion:     ce.SpecVersion,
+		ID:              ce.ID,
+		Source:          ce.Source,
+		Type:            ce.Type,
+		DataContentType: ce.DataContentType,
+		Subject:         ce.Subject,
+		RemoteAddr:      payload.RemoteAddr,
+		Host:            payload.Host,
+		Level:           payload.Level,
+		Severity:        payload.Severity,
+		ShortMessage:    payload.ShortMessage,
+		EventTimestamp:  ts,
+		Version:         payload.Version,
+		RawData:         string(b),
+	}
+}
+
 // NewProcessor creates a Processor using the provided db.Service.
 func NewProcessor(dbService db.Service, table string) (*Processor, error) {
 	dbImpl, ok := dbService.(*db.DB)
@@ -51,7 +129,7 @@ func (p *Processor) ProcessBatch(ctx context.Context, msgs []jetstream.Msg) ([]j
 		return nil, nil
 	}
 
-	query := fmt.Sprintf("INSERT INTO %s (message) VALUES (?)", p.table)
+	query := fmt.Sprintf("INSERT INTO %s (specversion, id, source, type, datacontenttype, subject, remote_addr, host, level, severity, short_message, event_timestamp, version, raw_data) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", p.table)
 
 	batch, err := p.conn.PrepareBatch(ctx, query)
 	if err != nil {
@@ -61,13 +139,24 @@ func (p *Processor) ProcessBatch(ctx context.Context, msgs []jetstream.Msg) ([]j
 	processed := make([]jetstream.Msg, 0, len(msgs))
 
 	for _, msg := range msgs {
-		data := msg.Data()
+		row := buildEventRow(msg.Data(), msg.Subject())
 
-		if ceData, ok := parseCloudEvent(data); ok {
-			data = []byte(ceData)
-		}
-
-		if err := batch.Append(string(data)); err != nil {
+		if err := batch.Append(
+			row.SpecVersion,
+			row.ID,
+			row.Source,
+			row.Type,
+			row.DataContentType,
+			row.Subject,
+			row.RemoteAddr,
+			row.Host,
+			row.Level,
+			row.Severity,
+			row.ShortMessage,
+			row.EventTimestamp,
+			row.Version,
+			row.RawData,
+		); err != nil {
 			return processed, err
 		}
 


### PR DESCRIPTION
## Summary
- parse CloudEvent JSON into an event row
- insert all event fields into the events stream

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68588c4f841c8320835cd5cecc0b73b4