### PR TITLE
Fix RPM build context for zen service

### DIFF
--- a/packaging/components.json
+++ b/packaging/components.json
@@ -688,10 +688,11 @@
       "dockerfile": "docker/rpm/Dockerfile.rpm.rust.zen",
       "release": "1"
     },
-    "binary": {
-      "build_method": "rust",
-      "output_path": "/usr/local/bin/serviceradar-zen"
-    },
+      "binary": {
+        "build_method": "rust",
+        "source_path": "cmd/consumers/zen",
+        "output_path": "/usr/local/bin/serviceradar-zen"
+      },
     "config_files": [
       {
         "source": "packaging/zen/config/zen-consumer.json",


### PR DESCRIPTION
## Summary
- specify Rust source path for `zen` in packaging config

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685974daa4448320883ec1c8402dc501