### PR TITLE
Fix RPM builds for rust components

### DIFF
--- a/docker/rpm/Dockerfile.rpm.rust
+++ b/docker/rpm/Dockerfile.rpm.rust
@@ -22,8 +22,6 @@ COPY ${BINARY_PATH}/Cargo.toml .
 COPY ${BINARY_PATH}/Cargo.lock .
 COPY ${BINARY_PATH}/src ./src/
 COPY ${BINARY_PATH}/build.rs .
-COPY ${BINARY_PATH}/monitoring_descriptor.bin .
-COPY ${BINARY_PATH}/rperf_descriptor.bin .
 
 # Create proto directory
 RUN mkdir -p ../proto

--- a/docker/rpm/Dockerfile.rpm.rust.zen
+++ b/docker/rpm/Dockerfile.rpm.rust.zen
@@ -24,8 +24,6 @@ COPY ${BINARY_PATH}/Cargo.toml .
 COPY ${BINARY_PATH}/Cargo.lock .
 COPY ${BINARY_PATH}/src ./src/
 COPY ${BINARY_PATH}/build.rs .
-COPY ${BINARY_PATH}/monitoring_descriptor.bin .
-COPY ${BINARY_PATH}/rperf_descriptor.bin .
 
 # Build the Rust binary
 RUN echo "Building Rust binary..." && \


### PR DESCRIPTION
## Summary
- remove references to non-existent descriptor artifacts in Rust RPM Dockerfiles

## Testing
- `make test` *(fails: github.com/carverauto/serviceradar/pkg/sweeper)*

------
https://chatgpt.com/codex/tasks/task_e_6859771c55f883208ec8f24a1f1aed4b