### PR TITLE
Fix Zen RPM build

### DIFF
--- a/cmd/consumers/zen/build.rs
+++ b/cmd/consumers/zen/build.rs
@@ -4,11 +4,22 @@ use std::path::Path;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var("OUT_DIR").unwrap();
     let descriptor_path = Path::new(&out_dir).join("monitoring_descriptor.bin");
+
+    // Allow building both within the repository and in isolated packaging
+    // contexts by falling back to the repository-level proto directory when a
+    // local proto directory is not present.
+    let proto_path = if Path::new("proto/monitoring.proto").exists() {
+        "proto/monitoring.proto"
+    } else {
+        "../../../proto/monitoring.proto"
+    };
+    let proto_dir = Path::new(proto_path).parent().unwrap();
+
     tonic_build::configure()
         .build_server(true)
         .build_client(false)
         .file_descriptor_set_path(&descriptor_path)
-        .compile(&["proto/monitoring.proto"], &["proto"])?;
-    println!("cargo:rerun-if-changed=proto/monitoring.proto");
+        .compile(&[proto_path], &[proto_dir])?;
+    println!("cargo:rerun-if-changed={}", proto_path);
     Ok(())
 }

--- a/docker/rpm/Dockerfile.rpm.rust.zen
+++ b/docker/rpm/Dockerfile.rpm.rust.zen
@@ -25,6 +25,10 @@ COPY ${BINARY_PATH}/Cargo.lock .
 COPY ${BINARY_PATH}/src ./src/
 COPY ${BINARY_PATH}/build.rs .
 
+# Include shared protobuf definitions
+RUN mkdir -p ../proto
+COPY proto ../proto/
+
 # Build the Rust binary
 RUN echo "Building Rust binary..." && \
     cargo build --release --target x86_64-unknown-linux-gnu --verbose && \


### PR DESCRIPTION
## Summary
- copy shared protobuf files into the zen build container
- handle repository-level proto path in zen build script

## Testing
- `cargo test --manifest-path cmd/consumers/zen/Cargo.toml --quiet`
- `scripts/setup-package.sh --type=rpm zen` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598bedaa9c83209b1169c39bb59fa9