### PR TITLE
Add JetStream config to trapd

### DIFF
--- a/cmd/trapd/README.md
+++ b/cmd/trapd/README.md
@@ -10,18 +10,21 @@ Create a JSON file with the following fields:
 {
   "listen_addr": "0.0.0.0:162",
   "nats_url": "nats://127.0.0.1:4222",
+  "nats_domain": "edge",
+  "stream_name": "events",
   "subject": "snmp.traps"
 }
 ```
 
-Optionally enable TLS by adding a `security` section:
+Optionally enable TLS for NATS by adding a `nats_security` section:
 
 ```json
 {
   "listen_addr": "0.0.0.0:162",
   "nats_url": "nats://127.0.0.1:4222",
+  "stream_name": "events",
   "subject": "snmp.traps",
-  "security": {
+  "nats_security": {
     "cert_file": "/etc/serviceradar/certs/trapd.pem",
     "key_file": "/etc/serviceradar/certs/trapd-key.pem",
     "ca_file": "/etc/serviceradar/certs/root.pem"
@@ -36,8 +39,9 @@ To enable the gRPC health check server, add `grpc_listen_addr` and optional
 {
   "listen_addr": "0.0.0.0:162",
   "nats_url": "nats://127.0.0.1:4222",
+  "stream_name": "events",
   "subject": "snmp.traps",
-  "security": {
+  "nats_security": {
     "cert_file": "/etc/serviceradar/certs/trapd.pem",
     "key_file": "/etc/serviceradar/certs/trapd-key.pem",
     "ca_file": "/etc/serviceradar/certs/root.pem"

--- a/cmd/trapd/src/config.rs
+++ b/cmd/trapd/src/config.rs
@@ -25,12 +25,21 @@ pub struct SecurityConfig {
     pub ca_file: Option<String>,
 }
 
+fn default_stream_name() -> String {
+    "events".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub listen_addr: String,
     pub nats_url: String,
+    #[serde(default)]
+    pub nats_domain: Option<String>,
+    #[serde(default = "default_stream_name")]
+    pub stream_name: String,
     pub subject: String,
-    pub security: Option<SecurityConfig>,
+    #[serde(default, alias = "security")]
+    pub nats_security: Option<SecurityConfig>,
     pub grpc_listen_addr: Option<String>,
     pub grpc_security: Option<SecurityConfig>,
 }
@@ -50,8 +59,18 @@ impl Config {
         if self.nats_url.is_empty() {
             anyhow::bail!("nats_url is required");
         }
+        if self.stream_name.is_empty() {
+            anyhow::bail!("stream_name is required");
+        }
         if self.subject.is_empty() {
             anyhow::bail!("subject is required");
+        }
+        if let Some(sec) = &self.nats_security {
+            if sec.cert_file.is_some() || sec.key_file.is_some() || sec.ca_file.is_some() {
+                if sec.cert_file.is_none() || sec.key_file.is_none() || sec.ca_file.is_none() {
+                    anyhow::bail!("nats_security requires cert_file, key_file, and ca_file when any are provided");
+                }
+            }
         }
         if let Some(addr) = &self.grpc_listen_addr {
             if addr.is_empty() {

--- a/packaging/trapd/config/trapd.json
+++ b/packaging/trapd/config/trapd.json
@@ -1,8 +1,10 @@
 {
   "listen_addr": "0.0.0.0:162",
   "nats_url": "nats://127.0.0.1:4222",
+  "nats_domain": "edge",
+  "stream_name": "events",
   "subject": "snmp.traps",
-  "security": {
+  "nats_security": {
     "cert_file": "/etc/serviceradar/certs/nats-client.pem",
     "key_file": "/etc/serviceradar/certs/nats-client-key.pem",
     "ca_file": "/etc/serviceradar/certs/root.pem"


### PR DESCRIPTION
## Summary
- extend trapd config with `stream_name`, `nats_domain` and `nats_security`
- ensure JetStream stream is created at startup
- document new fields and update example config
- rename TLS settings for NATS to `nats_security`

## Testing
- `cargo test --locked` in `cmd/trapd`

------
https://chatgpt.com/codex/tasks/task_e_6859af4b128883208077ab95ab0284d1