### PR TITLE
Fix Armis updater custom field usage

### DIFF
--- a/pkg/sync/integrations/armis/armis_test.go
+++ b/pkg/sync/integrations/armis/armis_test.go
@@ -811,8 +811,8 @@ func TestDefaultArmisUpdater_UpdateDeviceStatus(t *testing.T) {
 			err = json.Unmarshal(body, &payload)
 			require.NoError(t, err)
 
-			// Expect 6 operations: 3 for device1, 2 for device2 (no RTT)
-			require.Len(t, payload, 5, "payload length")
+			// Expect one operation per device
+			require.Len(t, payload, 2, "payload length")
 
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"success": true}`))}, nil
 		},

--- a/pkg/sync/integrations/armis/armis_updater.go
+++ b/pkg/sync/integrations/armis/armis_updater.go
@@ -255,37 +255,15 @@ func (u *DefaultArmisUpdater) UpdateDeviceStatus(ctx context.Context, updates []
 		} `json:"upsert"`
 	}
 
-	operations := make([]upsertBody, 0, len(updates)*3)
+	operations := make([]upsertBody, 0, len(updates))
 
 	for _, upd := range updates {
-		// Always send availability and last checked
-		opAvail := upsertBody{}
-		opAvail.Upsert.DeviceID = upd.DeviceID
-		opAvail.Upsert.Key = "serviceradar_available"
-		opAvail.Upsert.Value = upd.Available
-		operations = append(operations, opAvail)
-
-		opChecked := upsertBody{}
-		opChecked.Upsert.DeviceID = upd.DeviceID
-		opChecked.Upsert.Key = "serviceradar_last_checked"
-		opChecked.Upsert.Value = upd.LastChecked.Format(time.RFC3339)
-		operations = append(operations, opChecked)
-
-		if upd.RTT > 0 {
-			opRTT := upsertBody{}
-			opRTT.Upsert.DeviceID = upd.DeviceID
-			opRTT.Upsert.Key = "serviceradar_rtt_ms"
-			opRTT.Upsert.Value = upd.RTT
-			operations = append(operations, opRTT)
-		}
-
-		if upd.ServiceRadarURL != "" {
-			opURL := upsertBody{}
-			opURL.Upsert.DeviceID = upd.DeviceID
-			opURL.Upsert.Key = "serviceradar_url"
-			opURL.Upsert.Value = upd.ServiceRadarURL
-			operations = append(operations, opURL)
-		}
+		// Only update the SERVICERADAR_COMPLIANT custom field
+		op := upsertBody{}
+		op.Upsert.DeviceID = upd.DeviceID
+		op.Upsert.Key = "SERVICERADAR_COMPLIANT"
+		op.Upsert.Value = upd.Available
+		operations = append(operations, op)
 	}
 
 	bodyBytes, err := json.Marshal(operations)


### PR DESCRIPTION
## Summary
- update Armis updater to only set `SERVICERADAR_COMPLIANT`
- adjust unit test expectations

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859dde4ffe88320ba7374f6143e4009