### PR TITLE
Add sidebar and new homepage with SRQL query

### DIFF
--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cookies } from "next/headers";
+import { fetchFromAPI } from "@/lib/api";
+import { SystemStatus, Poller } from "@/types/types";
+import { unstable_noStore as noStore } from "next/cache";
+import DashboardWrapper from "@/components/DashboardWrapper";
+import { Suspense } from "react";
+
+async function fetchStatus(token?: string): Promise<SystemStatus | null> {
+  noStore();
+  try {
+    const statusData = await fetchFromAPI<SystemStatus>("/status", token);
+    if (!statusData) throw new Error("Failed to fetch status");
+
+    const pollersData = await fetchFromAPI<Poller[]>("/pollers", token);
+    if (!pollersData) throw new Error("Failed to fetch pollers");
+
+    // Calculate service statistics (unchanged)
+    let totalServices = 0;
+    let offlineServices = 0;
+    let totalResponseTime = 0;
+    let servicesWithResponseTime = 0;
+
+    pollersData.forEach((poller: Poller) => {
+      if (poller.services && Array.isArray(poller.services)) {
+        totalServices += poller.services.length;
+        poller.services.forEach((service) => {
+          if (!service.available) offlineServices++;
+          if (service.type === "icmp" && service.details) {
+            try {
+              const details =
+                typeof service.details === "string"
+                  ? JSON.parse(service.details)
+                  : service.details;
+              if (details && details.response_time) {
+                totalResponseTime += details.response_time;
+                servicesWithResponseTime++;
+              }
+            } catch (e) {
+              console.error("Error parsing service details:", e);
+            }
+          }
+        });
+      }
+    });
+
+    const avgResponseTime =
+      servicesWithResponseTime > 0
+        ? totalResponseTime / servicesWithResponseTime
+        : 0;
+
+    return {
+      ...statusData,
+      service_stats: {
+        total_services: totalServices,
+        offline_services: offlineServices,
+        avg_response_time: avgResponseTime,
+      },
+    };
+  } catch (error) {
+    console.error("Error fetching status:", error);
+    return null;
+  }
+}
+
+export default async function HomePage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("accessToken")?.value;
+  const initialData = await fetchStatus(token);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-6">Dashboard</h1>
+      <Suspense fallback={<div>Loading dashboard...</div>}>
+        <DashboardWrapper initialData={initialData} />
+      </Suspense>
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,94 +1,23 @@
-/*
- * Copyright 2025 Carver Automation Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+import { Suspense } from 'react';
+import SystemMetricsWrapper from '@/components/Metrics/SystemMetricsWrapper';
+import ApiQueryClient from '@/components/APIQueryClient';
 
-import { cookies } from "next/headers";
-import { fetchFromAPI } from "@/lib/api";
-import { SystemStatus, Poller } from "@/types/types";
-import { unstable_noStore as noStore } from "next/cache";
-import DashboardWrapper from "@/components/DashboardWrapper";
-import { Suspense } from "react";
-
-async function fetchStatus(token?: string): Promise<SystemStatus | null> {
-  noStore();
-  try {
-    const statusData = await fetchFromAPI<SystemStatus>("/status", token);
-    if (!statusData) throw new Error("Failed to fetch status");
-
-    const pollersData = await fetchFromAPI<Poller[]>("/pollers", token);
-    if (!pollersData) throw new Error("Failed to fetch pollers");
-
-    // Calculate service statistics (unchanged)
-    let totalServices = 0;
-    let offlineServices = 0;
-    let totalResponseTime = 0;
-    let servicesWithResponseTime = 0;
-
-    pollersData.forEach((poller: Poller) => {
-      if (poller.services && Array.isArray(poller.services)) {
-        totalServices += poller.services.length;
-        poller.services.forEach((service) => {
-          if (!service.available) offlineServices++;
-          if (service.type === "icmp" && service.details) {
-            try {
-              const details =
-                typeof service.details === "string"
-                  ? JSON.parse(service.details)
-                  : service.details;
-              if (details && details.response_time) {
-                totalResponseTime += details.response_time;
-                servicesWithResponseTime++;
-              }
-            } catch (e) {
-              console.error("Error parsing service details:", e);
-            }
-          }
-        });
-      }
-    });
-
-    const avgResponseTime =
-      servicesWithResponseTime > 0
-        ? totalResponseTime / servicesWithResponseTime
-        : 0;
-
-    return {
-      ...statusData,
-      service_stats: {
-        total_services: totalServices,
-        offline_services: offlineServices,
-        avg_response_time: avgResponseTime,
-      },
-    };
-  } catch (error) {
-    console.error("Error fetching status:", error);
-    return null;
-  }
-}
-
-export default async function HomePage() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get("accessToken")?.value;
-  const initialData = await fetchStatus(token);
-
+export default function HomePage() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-6">Dashboard</h1>
-      <Suspense fallback={<div>Loading dashboard...</div>}>
-        <DashboardWrapper initialData={initialData} />
-      </Suspense>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Welcome to ServiceRadar</h1>
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+        <h2 className="text-xl font-semibold mb-4">System Metrics</h2>
+        <Suspense fallback={<div className="p-4 text-center">Loading charts...</div>}>
+          <SystemMetricsWrapper />
+        </Suspense>
+      </div>
+      <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+        <h2 className="text-xl font-semibold mb-4">Run SRQL Query</h2>
+        <Suspense fallback={<div className="p-4 text-center">Loading query tool...</div>}>
+          <ApiQueryClient />
+        </Suspense>
+      </div>
     </div>
   );
 }

--- a/web/src/app/providers.js
+++ b/web/src/app/providers.js
@@ -18,6 +18,7 @@
 
 import { createContext, useState, useEffect, useContext } from 'react';
 import Navbar from '../components/Navbar';
+import Sidebar from '../components/Sidebar.jsx';
 
 // Create context for theme management
 export const ThemeContext = createContext({
@@ -52,11 +53,14 @@ export function Providers({ children }) {
     return (
         <ThemeContext.Provider value={{ darkMode, setDarkMode }}>
             <div className={darkMode ? 'dark' : ''}>
-                <div className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors">
-                    <Navbar />
-                    <main className="container mx-auto px-4 py-8">
-                        {children}
-                    </main>
+                <div className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors flex">
+                    <Sidebar />
+                    <div className="flex-1 flex flex-col">
+                        <Navbar />
+                        <main className="container mx-auto px-4 py-8 flex-1">
+                            {children}
+                        </main>
+                    </div>
                 </div>
             </div>
         </ThemeContext.Provider>

--- a/web/src/components/Navbar.jsx
+++ b/web/src/components/Navbar.jsx
@@ -49,6 +49,9 @@ function Navbar() {
 
             <div className="hidden md:flex items-center space-x-6">
               <Link href="/" className="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100">
+                Home
+              </Link>
+              <Link href="/dashboard" className="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100">
                 Dashboard
               </Link>
               <Link href="/pollers" className="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100">
@@ -118,6 +121,9 @@ function Navbar() {
               <div className="md:hidden mt-3 py-2 border-t border-gray-200 dark:border-gray-700 w-full overflow-x-auto">
                 <div className="flex flex-col space-y-3">
                   <Link href="/" onClick={() => {}} className="block px-2 py-1 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                    Home
+                  </Link>
+                  <Link href="/dashboard" onClick={() => {}} className="block px-2 py-1 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
                     Dashboard
                   </Link>
                   <Link href="/pollers" onClick={() => {}} className="block px-2 py-1 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">

--- a/web/src/components/Sidebar.jsx
+++ b/web/src/components/Sidebar.jsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { Menu, Sun, Moon } from 'lucide-react';
+import { useTheme } from '@/app/providers';
+
+export default function Sidebar() {
+  const { darkMode, setDarkMode } = useTheme();
+  const [open, setOpen] = useState(false);
+
+  const toggleOpen = () => setOpen(!open);
+  const toggleDarkMode = () => setDarkMode(!darkMode);
+
+  return (
+    <div className={`flex flex-col border-r dark:border-gray-700 bg-white dark:bg-gray-800 transition-all duration-300 ${open ? 'w-64' : 'w-16'}`}> 
+      <button onClick={toggleOpen} className="p-4 focus:outline-none">
+        <Menu className="h-5 w-5" />
+      </button>
+      <nav className="flex-1 px-2 space-y-2">
+        <Link href="/" className="block px-2 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+          Home
+        </Link>
+        <Link href="/dashboard" className="block px-2 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+          Dashboard
+        </Link>
+        <Link href="/pollers" className="block px-2 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+          Pollers
+        </Link>
+        <Link href="/query" className="block px-2 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+          Query Tool
+        </Link>
+        <Link href="/swagger/index.html" className="block px-2 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+          API Docs
+        </Link>
+      </nav>
+      <button onClick={toggleDarkMode} className="p-4 border-t dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700">
+        {darkMode ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a sidebar component for navigation
- move old dashboard page into its own route
- create a new homepage that shows graphs and the SRQL query engine
- integrate sidebar in providers layout
- update navbar links for Home/Dashboard

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685b136e87b48320b656fbec4364a97a