### PR TITLE
Improve auth header logging

### DIFF
--- a/web/src/app/api/query/route.ts
+++ b/web/src/app/api/query/route.ts
@@ -1,71 +1,77 @@
 // src/app/api/query/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { env } from 'next-runtime-env';
+import { env } from "next-runtime-env";
 
 export async function POST(req: NextRequest) {
-    const apiKey = env("API_KEY") || "";
-    const apiUrl = env("NEXT_PUBLIC_API_URL") || "http://localhost:8090";
+  const apiKey = env("API_KEY") || "";
+  const apiUrl = env("NEXT_PUBLIC_API_URL") || "http://localhost:8090";
+  const authEnabled = env("AUTH_ENABLED") === "true";
 
-    try {
-        const body = await req.json();
-        const { query } = body;
+  try {
+    const body = await req.json();
+    const { query } = body;
 
-        if (!query) {
-            return NextResponse.json(
-                { error: "Query is required" },
-                { status: 400 },
-            );
-        }
-
-        const authHeader = req.headers.get("Authorization");
-        const headersToBackend: HeadersInit = {
-            "Content-Type": "application/json",
-            "X-API-Key": apiKey,
-        };
-
-        if (authHeader) {
-            headersToBackend["Authorization"] = authHeader;
-        } else {
-            // If AUTH_ENABLED is true (implicitly, as backend requires token),
-            // and authHeader is missing, this indicates a problem.
-            // Middleware should ideally catch this if AUTH_ENABLED=true and cookie is missing.
-            // If APIQueryClient also failed to send a token, this is where it would be missing.
-            console.warn("[API Query Route] Authorization header is missing from the incoming request.");
-            // Depending on how strict AUTH_ENABLED is, you might return 401 here,
-            // but the Go backend will likely do it if it's missing.
-        }
-
-        const backendResponse = await fetch(`${apiUrl}/api/query`, {
-            method: "POST",
-            headers: headersToBackend,
-            body: JSON.stringify(body),
-            cache: "no-store",
-        });
-
-        if (!backendResponse.ok) {
-            let errorData;
-            const contentType = backendResponse.headers.get("content-type");
-            if (contentType && contentType.includes("application/json")) {
-                errorData = await backendResponse.json();
-            } else {
-                const textError = await backendResponse.text();
-                errorData = { error: "Backend returned non-JSON error response", details: textError.substring(0, 500) };
-            }
-
-            return NextResponse.json(
-                errorData || { error: "Failed to execute query on backend" },
-                { status: backendResponse.status },
-            );
-        }
-
-        const responseData = await backendResponse.json();
-        return NextResponse.json(responseData);
-
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Internal server error";
-        return NextResponse.json(
-            { error: "Internal server error processing query", details: errorMessage },
-            { status: 500 },
-        );
+    if (!query) {
+      return NextResponse.json({ error: "Query is required" }, { status: 400 });
     }
+
+    const authHeader = req.headers.get("Authorization");
+    const headersToBackend: HeadersInit = {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKey,
+    };
+
+    if (authHeader) {
+      headersToBackend["Authorization"] = authHeader;
+    } else if (authEnabled) {
+      // Authorization is required when authentication is enabled, but the
+      // incoming request didn't include a token. Middleware should catch
+      // most cases where the access token cookie is missing, so log here
+      // in case the request bypassed it.
+      console.warn(
+        "[API Query Route] Authorization header is missing from the incoming request.",
+      );
+      // Depending on how strict AUTH_ENABLED is, you might return 401 here,
+      // but the Go backend will likely do it if it's missing.
+    }
+
+    const backendResponse = await fetch(`${apiUrl}/api/query`, {
+      method: "POST",
+      headers: headersToBackend,
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+
+    if (!backendResponse.ok) {
+      let errorData;
+      const contentType = backendResponse.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        errorData = await backendResponse.json();
+      } else {
+        const textError = await backendResponse.text();
+        errorData = {
+          error: "Backend returned non-JSON error response",
+          details: textError.substring(0, 500),
+        };
+      }
+
+      return NextResponse.json(
+        errorData || { error: "Failed to execute query on backend" },
+        { status: backendResponse.status },
+      );
+    }
+
+    const responseData = await backendResponse.json();
+    return NextResponse.json(responseData);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json(
+      {
+        error: "Internal server error processing query",
+        details: errorMessage,
+      },
+      { status: 500 },
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- only log missing Authorization header when `AUTH_ENABLED` is enabled

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b32d3f44083209436a63965ba0224