### PR TITLE
Enable events pagination in SRQL API

### DIFF
--- a/pkg/core/api/query.go
+++ b/pkg/core/api/query.go
@@ -112,8 +112,8 @@ func (s *APIServer) prepareQuery(req *QueryRequest) (*models.Query, map[string]i
 	}
 
 	// Validate entity
-	if query.Entity != models.Devices && query.Entity != models.Interfaces && query.Entity != models.SweepResults {
-		return nil, nil, errors.New("pagination is only supported for devices, interfaces, and sweep_results")
+	if query.Entity != models.Devices && query.Entity != models.Interfaces && query.Entity != models.SweepResults && query.Entity != models.Events {
+		return nil, nil, errors.New("pagination is only supported for devices, interfaces, sweep_results, and events")
 	}
 
 	var defaultOrderField string
@@ -279,6 +279,8 @@ func (s *APIServer) executeQuery(ctx context.Context, query string, entity model
 		results, err = s.queryExecutor.ExecuteQuery(ctx, query, "icmp_results")
 	case models.SNMPResults:
 		results, err = s.queryExecutor.ExecuteQuery(ctx, query, "snmp_results")
+	case models.Events:
+		results, err = s.queryExecutor.ExecuteQuery(ctx, query, "events")
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedEntity, entity)
 	}
@@ -444,6 +446,11 @@ func addEntityFields(cursorData, result map[string]interface{}, entity models.En
 	case models.ICMPResults:
 		// No additional fields needed for now
 	case models.SNMPResults:
+		// No additional fields needed for now
+	case models.Events:
+		if id, ok := result["id"]; ok {
+			cursorData["id"] = id
+		}
 	}
 }
 

--- a/pkg/core/api/query_test.go
+++ b/pkg/core/api/query_test.go
@@ -158,6 +158,25 @@ func TestPrepareQuery(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid query for events",
+			req: &QueryRequest{
+				Query: "show events",
+				Limit: 5,
+			},
+			dbType:      parser.Proton,
+			expectError: false,
+			setupMock:   func(*APIServer) {},
+			validateQuery: func(t *testing.T, query *models.Query, _ map[string]interface{}) {
+				t.Helper()
+
+				assert.Equal(t, models.Events, query.Entity)
+				assert.Equal(t, 5, query.Limit)
+				assert.True(t, query.HasLimit)
+				assert.Len(t, query.OrderBy, 1)
+				assert.Equal(t, "_tp_time", query.OrderBy[0].Field)
+			},
+		},
+		{
 			name: "Valid query with cursor",
 			req: &QueryRequest{
 				Query:     "show devices",


### PR DESCRIPTION
## Summary
- allow `events` entity in paginated SRQL queries
- route `events` entity to query executor
- include `id` in cursor data for events
- add unit test for events queries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b4389d0808320a030f8abf35f4310