### PR TITLE
Fix count query handling

### DIFF
--- a/pkg/core/api/query_test.go
+++ b/pkg/core/api/query_test.go
@@ -177,6 +177,23 @@ func TestPrepareQuery(t *testing.T) {
 			},
 		},
 		{
+			name: "Count devices should skip pagination",
+			req: &QueryRequest{
+				Query: "count devices",
+			},
+			dbType:      parser.Proton,
+			expectError: false,
+			setupMock:   func(*APIServer) {},
+			validateQuery: func(t *testing.T, query *models.Query, _ map[string]interface{}) {
+				t.Helper()
+
+				assert.Equal(t, models.Count, query.Type)
+				assert.Equal(t, models.Devices, query.Entity)
+				assert.False(t, query.HasLimit)
+				assert.Len(t, query.OrderBy, 0)
+			},
+		},
+		{
 			name: "Valid query with cursor",
 			req: &QueryRequest{
 				Query:     "show devices",


### PR DESCRIPTION
## Summary
- avoid setting default pagination for `COUNT` queries
- test pagination skipping for count queries

## Testing
- `go test ./...`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b47fff03883208bf5b6f5811b42e4