### PR TITLE
Handle 207 from Armis bulk updates

### DIFF
--- a/pkg/sync/integrations/armis/armis_test.go
+++ b/pkg/sync/integrations/armis/armis_test.go
@@ -831,7 +831,7 @@ func TestDefaultArmisUpdater_UpdateDeviceStatus(t *testing.T) {
 			// Expect one operation per device
 			require.Len(t, payload, 2, "payload length")
 
-			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"success": true}`))}, nil
+			return &http.Response{StatusCode: http.StatusMultiStatus, Body: io.NopCloser(strings.NewReader(`[{"result":{},"status":202}]`))}, nil
 		},
 	)
 

--- a/pkg/sync/integrations/armis/armis_updater.go
+++ b/pkg/sync/integrations/armis/armis_updater.go
@@ -189,7 +189,8 @@ func (u *DefaultArmisUpdater) UpdateDeviceStatus(ctx context.Context, updates []
 
 	respBody, _ := io.ReadAll(resp.Body)
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusMultiStatus {
 		return fmt.Errorf("%w: %d, response: %s", errUnexpectedStatusCode, resp.StatusCode, string(respBody))
 	}
 
@@ -251,7 +252,8 @@ func (u *DefaultArmisUpdater) UpdateDeviceCustomAttributes(ctx context.Context, 
 
 	respBody, _ := io.ReadAll(resp.Body)
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated &&
+		resp.StatusCode != http.StatusMultiStatus {
 		return fmt.Errorf("%w: %d, response: %s", errUnexpectedStatusCode, resp.StatusCode, string(respBody))
 	}
 


### PR DESCRIPTION
## Summary
- allow 207 Multi-Status responses from Armis bulk APIs
- update tests for the new status handling

## Testing
- `go test ./pkg/sync/integrations/armis -run TestDefaultArmisUpdater_UpdateDeviceStatus -count=1`

------
https://chatgpt.com/codex/tasks/task_e_685c1e3b4fc483209e650495b933a1af