### PR TITLE
Updates/srql param queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@
 
 # Go configuration
 GO ?= go
+GOCACHE ?= $(CURDIR)/.gocache
+GOMODCACHE ?= $(CURDIR)/.gomodcache
+export GOCACHE
+export GOMODCACHE
 GOBIN ?= $$($(GO) env GOPATH)/bin
 GOLANGCI_LINT ?= golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.4.0

--- a/ocaml/srql/lib/proton_client.ml
+++ b/ocaml/srql/lib/proton_client.ml
@@ -106,7 +106,10 @@ module Client = struct
     Lwt.return client
 
   let execute client query = Proton.Client.execute client query
-  let execute_with_params client query ~params = Proton.Client.execute_with_params client query ~params
+
+  let execute_with_params client query ~params =
+    Proton.Client.execute_with_params client query ~params
+
   let query client query = Proton.Client.execute client query
   let close client = Proton.Client.disconnect client
 
@@ -187,10 +190,7 @@ module SRQL = struct
         before ^ "table(" ^ tbl ^ ")" ^ after
       with _ -> sql
 
-  type translation = {
-    sql : string;
-    params : (string * Proton.Column.value) list;
-  }
+  type translation = { sql : string; params : (string * Proton.Column.value) list }
 
   let translate srql_query : translation =
     let ast = parse_to_ast srql_query in

--- a/ocaml/srql/lib/proton_client.mli
+++ b/ocaml/srql/lib/proton_client.mli
@@ -65,10 +65,7 @@ module Client : sig
 end
 
 module SRQL : sig
-  type translation = {
-    sql : string;
-    params : (string * Proton.Column.value) list;
-  }
+  type translation = { sql : string; params : (string * Proton.Column.value) list }
   (** Result of translating SRQL into Proton SQL along with parameter bindings. *)
 
   val translate : string -> translation

--- a/ocaml/srql/lib/proton_client.mli
+++ b/ocaml/srql/lib/proton_client.mli
@@ -47,6 +47,10 @@ module Client : sig
   val execute : t -> string -> Proton.Client.query_result Lwt.t
   (** Execute a query without returning results *)
 
+  val execute_with_params :
+    t -> string -> params:(string * Proton.Column.value) list -> Proton.Client.query_result Lwt.t
+  (** Execute a parameterized query using named placeholders *)
+
   val query : t -> string -> Proton.Client.query_result Lwt.t
   (** Execute a query and return results *)
 
@@ -61,6 +65,15 @@ module Client : sig
 end
 
 module SRQL : sig
+  type translation = {
+    sql : string;
+    params : (string * Proton.Column.value) list;
+  }
+  (** Result of translating SRQL into Proton SQL along with parameter bindings. *)
+
+  val translate : string -> translation
+  (** Translate SRQL to SQL with parameters without executing it. *)
+
   val translate_and_execute : Client.t -> string -> Proton.Client.query_result Lwt.t
   (** Translate SRQL query to SQL and execute it *)
 

--- a/ocaml/srql/lib/translator.ml
+++ b/ocaml/srql/lib/translator.ml
@@ -2,17 +2,11 @@
 open Sql_ir
 open Field_mapping
 open Sql_sanitize
-
 module Column = Proton.Column
 
 type param_binding = string * Column.value
-
 type query_with_params = { sql : string; params : param_binding list }
-
-type param_builder = {
-  mutable counter : int;
-  mutable params : param_binding list;
-}
+type param_builder = { mutable counter : int; mutable params : param_binding list }
 
 let create_builder () = { counter = 0; params = [] }
 
@@ -195,7 +189,8 @@ let translate_query (q : query) : query_with_params =
               let filters = ref [] in
               if e = "devices" then
                 filters := !filters @ [ "coalesce(metadata['_deleted'], '') != 'true'" ];
-              if e = "sweep_results" then filters := !filters @ [ "has(discovery_sources, 'sweep')" ];
+              if e = "sweep_results" then
+                filters := !filters @ [ "has(discovery_sources, 'sweep')" ];
               if e = "snmp_results" || e = "snmp_metrics" then
                 filters := !filters @ [ "metric_type = 'snmp'" ];
               !filters
@@ -250,7 +245,8 @@ let translate_query (q : query) : query_with_params =
               let filters = ref [] in
               if e = "devices" then
                 filters := !filters @ [ "coalesce(metadata['_deleted'], '') != 'true'" ];
-              if e = "sweep_results" then filters := !filters @ [ "has(discovery_sources, 'sweep')" ];
+              if e = "sweep_results" then
+                filters := !filters @ [ "has(discovery_sources, 'sweep')" ];
               if e = "snmp_results" || e = "snmp_metrics" then
                 filters := !filters @ [ "metric_type = 'snmp'" ];
               !filters

--- a/ocaml/srql/test/test_bounded_unbounded.ml
+++ b/ocaml/srql/test/test_bounded_unbounded.ml
@@ -29,7 +29,8 @@ let test_bounded_wraps_table () =
       latest = false;
     }
   in
-  let sql = Translator.translate_query q in
+  let translation = Translator.translate_query q in
+  let sql = translation.sql in
   check bool "has table() wrapper" true (contains ~needle:" FROM table(unified_devices)" sql);
   check bool "has LIMIT 10" true (contains ~needle:" LIMIT 10" sql)
 
@@ -50,7 +51,7 @@ let test_unbounded_no_table_wrapper () =
       latest = false;
     }
   in
-  let sql = Translator.translate_query q in
+  let sql = (Translator.translate_query q).sql in
   check bool "no table() wrapper" false (contains ~needle:" FROM table(" sql);
   check bool "from unified_devices" true (contains ~needle:" FROM unified_devices" sql)
 

--- a/ocaml/srql/test/test_query_engine.ml
+++ b/ocaml/srql/test/test_query_engine.ml
@@ -1,5 +1,4 @@
 open Alcotest
-
 module Column = Proton.Column
 
 let translation_of qstr =
@@ -31,9 +30,7 @@ let test_devices_today () =
   contains "time today func" sql ") = today()";
   contains "hostname mapping" sql "hostname = {{";
   check bool "hostname parameter present" true
-    (List.exists
-       (function _, Column.String "server01" -> true | _ -> false)
-       translation.params)
+    (List.exists (function _, Column.String "server01" -> true | _ -> false) translation.params)
 
 let test_flows_topk_by () =
   let translation = translation_of "in:flows src:10.0.0.1 stats:\"topk(dst, 5)\"" in
@@ -44,9 +41,7 @@ let test_flows_topk_by () =
   contains "limit present" sql "limit 5";
   contains "src filter" sql "src_ip = {{";
   check bool "src placeholder value" true
-    (List.exists
-       (function _, Column.String "10.0.0.1" -> true | _ -> false)
-       translation.params)
+    (List.exists (function _, Column.String "10.0.0.1" -> true | _ -> false) translation.params)
 
 let test_validation_having_error () =
   let qspec =
@@ -83,7 +78,9 @@ let test_services_ports_timeframe () =
     (List.exists (function _, Column.Int64 n -> n = 2222L | _ -> false) translation.params)
 
 let test_devices_nested_services_and_type () =
-  let translation = translation_of "in:devices services:(name:(facebook)) type:MRIs timeFrame:\"7 Days\"" in
+  let translation =
+    translation_of "in:devices services:(name:(facebook)) type:MRIs timeFrame:\"7 Days\""
+  in
   let sql = translation.sql in
   contains "devices table" sql "from table(unified_devices)";
   contains "service name flattened" sql "services_name = {{";
@@ -106,7 +103,9 @@ let test_activity_connection_nested () =
   contains "nested flatten 2" sql "connection_direction = {{";
   contains "boundary->partition alias" sql "connection_to_partition = {{";
   let expect_string value =
-    List.exists (function _, Column.String s -> String.equal s value | _ -> false) translation.params
+    List.exists
+      (function _, Column.String s -> String.equal s value | _ -> false)
+      translation.params
   in
   check bool "mobile phone param" true (expect_string "Mobile Phone");
   check bool "direction param" true (expect_string "From > To");
@@ -190,7 +189,9 @@ let () = Alcotest.run "asq_more" [ ("more", suite_more) ]
 (* discovery_sources contains both 'sweep' and 'armis' *)
 
 let test_devices_discovery_sources_both () =
-  let translation = translation_of "in:devices discovery_sources:(sweep) discovery_sources:(armis)" in
+  let translation =
+    translation_of "in:devices discovery_sources:(sweep) discovery_sources:(armis)"
+  in
   let sql = translation.sql in
   contains "has sweep" sql "has(discovery_sources, {{";
   contains "has armis" sql "has(discovery_sources, {{";

--- a/ocaml/srql/test/test_sql_sanitize.ml
+++ b/ocaml/srql/test/test_sql_sanitize.ml
@@ -1,5 +1,4 @@
 open Alcotest
-
 module Column = Proton.Column
 
 let translation_of qstr =

--- a/ocaml/srql/test/test_sql_sanitize.ml
+++ b/ocaml/srql/test/test_sql_sanitize.ml
@@ -1,6 +1,8 @@
 open Alcotest
 
-let sql_of qstr =
+module Column = Proton.Column
+
+let translation_of qstr =
   let qspec = Srql_translator.Query_parser.parse qstr in
   match Srql_translator.Query_planner.plan_to_srql qspec with
   | None -> fail "planner returned None"
@@ -28,13 +30,21 @@ let expect_invalid_arg name f =
   | _ -> fail (name ^ ": expected Invalid_argument to be raised")
 
 let test_escape_single_quote () =
-  let sql = sql_of "in:events host:\"O'Reilly\"" in
-  check_contains "escaped single quote" sql "host = 'O''Reilly'"
+  let translation = translation_of "in:events host:\"O'Reilly\"" in
+  check_contains "placeholder present" translation.sql "host = {{";
+  check bool "parameter captured" true
+    (List.exists
+       (function _, Column.String s -> String.equal s "O'Reilly" | _ -> false)
+       translation.params)
 
 let test_escape_injection_payload () =
   let payload = "a'); DROP STREAM devices; --" in
-  let sql = sql_of (Printf.sprintf "in:events host:\"%s\"" payload) in
-  check_contains "escaped payload" sql "host = 'a''); DROP STREAM devices; --'"
+  let translation = translation_of (Printf.sprintf "in:events host:\"%s\"" payload) in
+  check_contains "placeholder present" translation.sql "host = {{";
+  check bool "payload captured as param" true
+    (List.exists
+       (function _, Column.String s -> String.equal s payload | _ -> false)
+       translation.params)
 
 let test_absolute_time_escape () =
   expect_invalid_arg "time injection" (fun () ->
@@ -147,38 +157,6 @@ let alphabet =
     '^';
   |]
 
-let is_double_quoted s idx = idx + 1 < String.length s && s.[idx + 1] = '\''
-
-let rec literal_is_safely_escaped lit idx len =
-  if idx >= len then true
-  else
-    match lit.[idx] with
-    | '\'' -> is_double_quoted lit idx && literal_is_safely_escaped lit (idx + 2) len
-    | '\\' -> false
-    | _ -> literal_is_safely_escaped lit (idx + 1) len
-
-let assert_literal_safe sql =
-  let len = String.length sql in
-  let rec loop i =
-    if i >= len then ()
-    else if sql.[i] = '\'' then (
-      let rec find_end j =
-        if j >= len then None
-        else if sql.[j] = '\'' then
-          if j + 1 < len && sql.[j + 1] = '\'' then find_end (j + 2) else Some j
-        else find_end (j + 1)
-      in
-      match find_end (i + 1) with
-      | None -> fail "unterminated literal"
-      | Some end_idx ->
-          let literal = String.sub sql (i + 1) (end_idx - i - 1) in
-          if not (literal_is_safely_escaped literal 0 (String.length literal)) then
-            fail (Printf.sprintf "unsafe literal produced: %s" sql);
-          loop (end_idx + 1))
-    else loop (i + 1)
-  in
-  loop 0
-
 let random_payload () =
   let len = 1 + Random.int 24 in
   String.init len (fun _ -> alphabet.(Random.int (Array.length alphabet)))
@@ -188,10 +166,9 @@ let test_fuzz_string_escaping () =
   for _ = 1 to 200 do
     let payload = random_payload () in
     try
-      let sql = sql_of (Printf.sprintf "in:events host:\"%s\"" payload) in
-      try assert_literal_safe sql
-      with Not_found ->
-        fail (Printf.sprintf "missing literal in sql for payload: %s -> %s" payload sql)
+      let translation = translation_of (Printf.sprintf "in:events host:\"%s\"" payload) in
+      check_contains "placeholder present" translation.sql "{{";
+      check bool "parameters captured" true (translation.params <> [])
     with Invalid_argument _ -> ()
   done
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add parameterized query support to SRQL translator

- Replace string literal concatenation with parameter placeholders

- Update client interface for parameter binding

- Enhance test coverage for parameter validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SRQL Query"] --> B["Parse & Plan"]
  B --> C["Translate with Parameters"]
  C --> D["SQL + Params"]
  D --> E["Execute with Params"]
  E --> F["Proton Database"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proton_client.ml</strong><dd><code>Add parameterized query execution support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/lib/proton_client.ml

<ul><li>Add <code>execute_with_params</code> function for parameterized queries<br> <li> Refactor <code>translate_to_sql</code> to use new parameter-aware translation<br> <li> Extract table wrapping logic into separate function<br> <li> Update <code>translate_and_execute</code> to use parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-474590ab3468b98ee363f3cd78535c90bc83cf3b2e77ae9871db741e2d8dea06">+27/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proton_client.mli</strong><dd><code>Expose parameterized query interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/lib/proton_client.mli

<ul><li>Add <code>execute_with_params</code> function signature<br> <li> Define <code>translation</code> type with SQL and parameters<br> <li> Add <code>translate</code> function for getting SQL with parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-2b549609ea8b875de4a039282ea09be7655ebda3f27f078ea603b8e77b9e31c6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>translator.ml</strong><dd><code>Core parameterized translation implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/lib/translator.ml

<ul><li>Implement parameter builder system for query values<br> <li> Replace string concatenation with parameter placeholders<br> <li> Add <code>column_value_of</code> and <code>render_value</code> functions<br> <li> Return <code>query_with_params</code> type from <code>translate_query</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-c33a65c30e4433358fbe3a1806b6c35291fd999f3abfdaad0ca38419e94764b9">+199/-168</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_live_srql.ml</strong><dd><code>Update live test for parameterized queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/test/run_live_srql.ml

<ul><li>Update to use new <code>translate</code> function with parameters<br> <li> Add parameter printing functionality<br> <li> Support parameterized queries in streaming mode<br> <li> Handle prepared statements for parameter binding</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-ea25a2c5be7493fef8b79f6c49ab84140d70b2458f61c001139f3eec92bfb5e9">+43/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_bounded_unbounded.ml</strong><dd><code>Fix bounded/unbounded tests for new API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/test/test_bounded_unbounded.ml

<ul><li>Update test calls to use new translation structure<br> <li> Extract SQL from translation object</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-3840c3919e65488587d26254fb2c1781bb64fc4da29d0afd8ae3b821acc7a9fe">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_query_engine.ml</strong><dd><code>Comprehensive parameter validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/test/test_query_engine.ml

<ul><li>Replace <code>sql_of</code> with <code>translation_of</code> function<br> <li> Add parameter validation in all test cases<br> <li> Verify parameter values match expected strings/numbers<br> <li> Update assertions for placeholder-based SQL</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-0c1dcb695d94269d0e3f899c01455e21cb50242b4665e3a0ef5f2b198c5cbe2f">+103/-39</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_sql_sanitize.ml</strong><dd><code>Update sanitization tests for parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ocaml/srql/test/test_sql_sanitize.ml

<ul><li>Update sanitization tests for parameter-based approach<br> <li> Remove literal escaping validation logic<br> <li> Verify parameters capture injection payloads safely<br> <li> Update fuzz testing for parameter validation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1645/files#diff-8e9284704ffb8e9d0b5ad1d4641f03b26b291dc87a714647a5d8a0f129ca3453">+18/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

