### PR TITLE
Build/core rpm build failing

### DIFF
--- a/docker/rpm/Dockerfile.rpm.simple
+++ b/docker/rpm/Dockerfile.rpm.simple
@@ -40,7 +40,10 @@ RUN echo "===== DEBUG INFO =====" && \
 
 # Build the binary
 RUN mkdir -p /build-out && \
-    if [ -d "${BINARY_PATH}" ] && [ -f "${BINARY_PATH}/main.go" ]; then \
+    if [ -z "${BINARY_PATH}" ]; then \
+        echo "No build path provided; skipping binary compilation for ${COMPONENT}"; \
+        touch /build-out/.keep; \
+    elif [ -d "${BINARY_PATH}" ] && [ -f "${BINARY_PATH}/main.go" ]; then \
         echo "Building from ${BINARY_PATH}" && \
         cd ${BINARY_PATH} && ls -la && \
         cd /src && \
@@ -63,6 +66,7 @@ RUN dnf clean all && \
     rpm-build \
     rpmdevtools \
     systemd-devel \
+    systemd-rpm-macros \
     libcap-devel \
     policycoreutils-python-utils \
     gcc \

--- a/packaging/components.json
+++ b/packaging/components.json
@@ -34,7 +34,7 @@
     "name": "kong",
     "package_name": "serviceradar-kong",
     "version": "3.11.0.3",
-    "description": "Wrapper package bundling Kong Gateway Enterprise for air-gapped installs",
+    "description": "Wrapper package bundling Kong Gateway (enterprise by default) for air-gapped installs",
     "maintainer": "Michael Freeman <mfreeman@carverauto.dev>",
     "architecture": "amd64",
     "section": "net",
@@ -56,16 +56,24 @@
       "dockerfile": "docker/rpm/Dockerfile.rpm.simple",
       "release": "1"
     },
-    
     "config_files": [
-      { "source": "packaging/kong/config/kong.conf", "dest": "/etc/kong/kong.conf", "optional": true },
-      { "source": "packaging/kong/vendor/kong-enterprise-edition-3.11.0.3.el9.x86_64.rpm", "dest": "/usr/share/serviceradar-kong/vendor/kong-enterprise-edition-3.11.0.3.el9.x86_64.rpm", "optional": true },
-      { "source": "packaging/kong/vendor/kong-enterprise-edition-3.11.0.3.el9.aarch64.rpm", "dest": "/usr/share/serviceradar-kong/vendor/kong-enterprise-edition-3.11.0.3.el9.aarch64.rpm", "optional": true },
-      { "source": "packaging/kong/vendor/kong-enterprise-edition_3.11.0.3_amd64.deb", "dest": "/usr/share/serviceradar-kong/vendor/kong-enterprise-edition_3.11.0.3_amd64.deb", "optional": true },
-      { "source": "packaging/kong/vendor/kong-enterprise-edition_3.11.0.3_arm64.deb", "dest": "/usr/share/serviceradar-kong/vendor/kong-enterprise-edition_3.11.0.3_arm64.deb", "optional": true }
+      {
+        "source": "packaging/kong/config/kong.conf",
+        "dest": "/etc/kong/kong.conf",
+        "optional": true
+      },
+      {
+        "source": "packaging/kong/vendor",
+        "dest": "/usr/share/serviceradar-kong/vendor",
+        "optional": true
+      }
     ],
-    "postinst": { "source": "packaging/kong/scripts/postinstall.sh" },
-    "prerm": { "source": "packaging/kong/scripts/preremove.sh" },
+    "postinst": {
+      "source": "packaging/kong/scripts/postinstall.sh"
+    },
+    "prerm": {
+      "source": "packaging/kong/scripts/preremove.sh"
+    },
     "conffiles": []
   },
   {

--- a/packaging/kong/README.md
+++ b/packaging/kong/README.md
@@ -1,20 +1,24 @@
 ServiceRadar Kong Packaging
 
 Overview
-- Provides a wrapper package `serviceradar-kong` for Debian and RHEL that vendors the official Kong Gateway (Community or Enterprise) packages for air‑gapped installs.
+- Provides a wrapper package `serviceradar-kong` for Debian and RHEL that vendors Kong Gateway Enterprise by default for air‑gapped installs.
+- You can optionally fetch the community artifacts by setting `KONG_FETCH_COMMUNITY=1` when downloading binaries.
 - Post‑install script installs the bundled upstream package locally (dpkg/rpm), so no external repos are required at install time.
 
-Included Artifacts (to be downloaded before building)
-- Choose one set:
-  - Community: `kong-<ver>.<arch>.rpm` (EL9) and `kong_<ver>_<arch>.deb` (Debian)
-  - Enterprise (optional): `kong-enterprise-edition-3.11.0.3.el9.<arch>.rpm` and `kong-enterprise-edition_3.11.0.3_<arch>.deb`
+Included Artifacts (download before building)
+- Enterprise (default): `kong-enterprise-edition-<ver>.el9.<arch>.rpm` and `kong-enterprise-edition_<ver>_<arch>.deb`
+- Community (optional): `kong-<ver>.<arch>.rpm` (EL9) and `kong_<ver>_<arch>.deb` (Debian)
 
 Fetch Artifacts
-- Run `scripts/fetch-kong-artifacts.sh` to download the vendor packages into `packaging/kong/vendor/` (edit script if using Community URLs) prior to building the wrapper packages.
+- Run `scripts/fetch-kong-artifacts.sh` to download the enterprise binaries into `packaging/kong/vendor/`.
+- Adjust the following env vars as needed:
+  - `KONG_ENTERPRISE_VERSION` (default `3.11.0.3`)
+  - `KONG_FETCH_COMMUNITY=1` to also pull the community artifacts (version controlled by `KONG_COMMUNITY_VERSION`, default `3.7.1`).
+  - `KONG_VENDOR_DIR` if you want a different destination directory.
 
 Install Behavior
-- Debian: `serviceradar-kong` installs the appropriate `kong-enterprise-edition_3.11.0.3_<arch>.deb` with `dpkg -i`.
-- RHEL: `serviceradar-kong` installs the appropriate `kong-enterprise-edition-3.11.0.3.el9.<arch>.rpm` with `rpm -Uvh --nodeps`.
+- Debian: `serviceradar-kong` installs the appropriate `kong-enterprise-edition_<version>_<arch>.deb` (or the community `.deb` if present) with `dpkg -i`.
+- RHEL: `serviceradar-kong` installs the appropriate `kong-enterprise-edition-<version>.el9.<arch>.rpm` (or the community `.rpm` if present) with `rpm -Uvh --nodeps`.
 - No repository configuration is required on the target host.
 
 Kong Setup Notes

--- a/packaging/specs/serviceradar-agent.spec
+++ b/packaging/specs/serviceradar-agent.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar monitoring agent
 License:        Proprietary
 
-BuildRequires:  systemd-devel
+BuildRequires:  systemd-rpm-macros
 BuildRequires:  libcap-devel
 BuildRequires:  gcc
 Requires:       systemd

--- a/packaging/specs/serviceradar-core.spec
+++ b/packaging/specs/serviceradar-core.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar core service with web interface
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       epel-release
 %{?systemd_requires}

--- a/packaging/specs/serviceradar-event-writer.spec
+++ b/packaging/specs/serviceradar-event-writer.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar Event Writer
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       epel-release
 %{?systemd_requires}

--- a/packaging/specs/serviceradar-flowgger.spec
+++ b/packaging/specs/serviceradar-flowgger.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar Flowgger logging ingestion service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       serviceradar-flowgger
 %{?systemd_requires}

--- a/packaging/specs/serviceradar-goflow2.spec
+++ b/packaging/specs/serviceradar-goflow2.spec
@@ -7,7 +7,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar NetFlow/sFlow/IPFIX collector with NATS support.
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd, serviceradar-cli
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-kong.spec
+++ b/packaging/specs/serviceradar-kong.spec
@@ -1,0 +1,76 @@
+Name:           serviceradar-kong
+Version:        %{version}
+Release:        %{release}%{?dist}
+Summary:        ServiceRadar Kong Gateway bundle
+License:        Proprietary
+
+BuildRequires:  systemd-rpm-macros
+Requires:       systemd
+Requires:       ca-certificates
+Requires:       serviceradar-cli
+%{?systemd_requires}
+
+%description
+Distributes Kong Gateway Enterprise artifacts and helpers for ServiceRadar air-gapped deployments.
+Installs bundled Kong packages into a vendor directory and runs a post-install script to install the
+appropriate Kong RPM on target systems, alongside default DB-less configuration.
+
+%prep
+# No sources to untar
+
+%install
+mkdir -p %{buildroot}/usr/share/serviceradar-kong/vendor
+mkdir -p %{buildroot}/usr/share/serviceradar-kong/scripts
+mkdir -p %{buildroot}/etc/kong
+
+# Copy optional configuration if provided
+if [ -f %{_sourcedir}/packaging/kong/config/kong.conf ]; then
+  install -m 644 %{_sourcedir}/packaging/kong/config/kong.conf %{buildroot}/etc/kong/kong.conf
+fi
+
+# Install helper scripts
+install -m 755 %{_sourcedir}/packaging/kong/scripts/postinstall.sh \
+  %{buildroot}/usr/share/serviceradar-kong/scripts/postinstall.sh
+install -m 755 %{_sourcedir}/packaging/kong/scripts/preremove.sh \
+  %{buildroot}/usr/share/serviceradar-kong/scripts/preremove.sh
+
+# Copy any bundled vendor artifacts that are present
+for artifact in \
+  %{_sourcedir}/packaging/kong/vendor/kong-enterprise-edition-*.rpm \
+  %{_sourcedir}/packaging/kong/vendor/kong-enterprise-edition_*.deb \
+  %{_sourcedir}/packaging/kong/vendor/kong-*.rpm \
+  %{_sourcedir}/packaging/kong/vendor/kong-*.deb; do
+  if [ -f "$artifact" ]; then
+    install -m 644 "$artifact" %{buildroot}/usr/share/serviceradar-kong/vendor/
+  fi
+done
+
+touch %{buildroot}/usr/share/serviceradar-kong/vendor/.keep
+
+# Track vendor artifacts dynamically for %files
+find %{buildroot}/usr/share/serviceradar-kong/vendor -type f \
+  | sed "s|%{buildroot}||" > %{_builddir}/vendor-files.lst
+if [ ! -s %{_builddir}/vendor-files.lst ]; then
+  : > %{_builddir}/vendor-files.lst
+fi
+
+%files -f %{_builddir}/vendor-files.lst
+%attr(0755, root, root) /usr/share/serviceradar-kong/scripts/postinstall.sh
+%attr(0755, root, root) /usr/share/serviceradar-kong/scripts/preremove.sh
+%dir %attr(0755, root, root) /usr/share/serviceradar-kong
+%dir %attr(0755, root, root) /usr/share/serviceradar-kong/scripts
+%dir %attr(0755, root, root) /usr/share/serviceradar-kong/vendor
+%dir %attr(0755, root, root) /etc/kong
+%config(noreplace) %attr(0644, root, root) /etc/kong/kong.conf
+
+%post
+/usr/share/serviceradar-kong/scripts/postinstall.sh || true
+
+%preun
+if [ $1 -eq 0 ]; then
+  /usr/share/serviceradar-kong/scripts/preremove.sh || true
+fi
+
+%postun
+# Nothing additional
+:

--- a/packaging/specs/serviceradar-kv.spec
+++ b/packaging/specs/serviceradar-kv.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar KV service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-mapper.spec
+++ b/packaging/specs/serviceradar-mapper.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar Mapper Service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-nats.spec
+++ b/packaging/specs/serviceradar-nats.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar NATS JetStream service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-otel.spec
+++ b/packaging/specs/serviceradar-otel.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar OTEL Collector
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-poller.spec
+++ b/packaging/specs/serviceradar-poller.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar poller service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-profiler.spec
+++ b/packaging/specs/serviceradar-profiler.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar eBPF Profiler for Linux Systems
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-proton.spec
+++ b/packaging/specs/serviceradar-proton.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar Proton Server (Time-series database)
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-rperf-checker.spec
+++ b/packaging/specs/serviceradar-rperf-checker.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar RPerf Network Performance Checker
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       serviceradar-rperf
 %{?systemd_requires}

--- a/packaging/specs/serviceradar-rperf.spec
+++ b/packaging/specs/serviceradar-rperf.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar RPerf Server
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-snmp-checker.spec
+++ b/packaging/specs/serviceradar-snmp-checker.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar SNMP poller
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-srql.spec
+++ b/packaging/specs/serviceradar-srql.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar SRQL OCaml query service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       ca-certificates
 Requires:       libev

--- a/packaging/specs/serviceradar-sync.spec
+++ b/packaging/specs/serviceradar-sync.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar KV sync service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-sysmon.spec
+++ b/packaging/specs/serviceradar-sysmon.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar SysMon metrics checker plugin
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 %{?systemd_requires}
 

--- a/packaging/specs/serviceradar-trapd.spec
+++ b/packaging/specs/serviceradar-trapd.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar SNMP trap receiver service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       serviceradar-trapd
 %{?systemd_requires}

--- a/packaging/specs/serviceradar-web.spec
+++ b/packaging/specs/serviceradar-web.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar web interface
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       nginx
 Requires:       nodejs >= 20.0.0

--- a/packaging/specs/serviceradar-zen.spec
+++ b/packaging/specs/serviceradar-zen.spec
@@ -4,7 +4,7 @@ Release:        %{release}%{?dist}
 Summary:        ServiceRadar Zen Consumer Service
 License:        Proprietary
 
-BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
 Requires:       systemd
 Requires:       serviceradar-zen
 %{?systemd_requires}

--- a/scripts/fetch-kong-artifacts.sh
+++ b/scripts/fetch-kong-artifacts.sh
@@ -1,32 +1,62 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OUT_DIR="packaging/kong/vendor"
+OUT_DIR=${KONG_VENDOR_DIR:-packaging/kong/vendor}
+FETCH_ENTERPRISE=${KONG_FETCH_ENTERPRISE:-1}
+ENTERPRISE_VERSION=${KONG_ENTERPRISE_VERSION:-3.11.0.3}
+ENTERPRISE_CHANNEL=${ENTERPRISE_VERSION//./}
+FETCH_COMMUNITY=${KONG_FETCH_COMMUNITY:-0}
+COMMUNITY_VERSION=${KONG_COMMUNITY_VERSION:-3.7.1}
+COMMUNITY_CHANNEL=${COMMUNITY_VERSION//./}
+
 mkdir -p "$OUT_DIR"
 
-echo "[INFO] Downloading Kong Enterprise 3.11.0.3 artifacts to $OUT_DIR"
-
 download() {
-  local url="$1"; local out="$2";
-  if [[ -f "$out" ]]; then
-    echo "[SKIP] $out exists"
-    return 0
+  local label="$1"
+  local url="$2"
+  local dest="$3"
+
+  if [[ -f "$dest" ]]; then
+    echo "[SKIP] $label already present at $dest"
+    return
   fi
-  echo "[GET ] $url"
-  curl -fL --retry 3 --retry-delay 2 -o "$out" "$url"
+
+  echo "[GET ] $label -> $dest"
+  curl -fL --retry 3 --retry-delay 2 -o "$dest" "$url"
 }
 
-# RPMs (EL9)
-download "https://packages.konghq.com/public/gateway-311/rpm/el/9/x86_64/kong-enterprise-edition-3.11.0.3.el9.x86_64.rpm" \
-         "$OUT_DIR/kong-enterprise-edition-3.11.0.3.el9.x86_64.rpm"
-download "https://packages.konghq.com/public/gateway-311/rpm/el/9/aarch64/kong-enterprise-edition-3.11.0.3.el9.aarch64.rpm" \
-         "$OUT_DIR/kong-enterprise-edition-3.11.0.3.el9.aarch64.rpm"
+if [[ "$FETCH_ENTERPRISE" != "0" ]]; then
+  echo "[INFO] Fetching Kong enterprise artifacts (version ${ENTERPRISE_VERSION}) into $OUT_DIR"
+  download "Kong enterprise RPM (el9 x86_64)" \
+    "https://packages.konghq.com/public/gateway-${ENTERPRISE_CHANNEL}/rpm/el/9/x86_64/kong-enterprise-edition-${ENTERPRISE_VERSION}.el9.x86_64.rpm" \
+    "$OUT_DIR/kong-enterprise-edition-${ENTERPRISE_VERSION}.el9.x86_64.rpm"
+  download "Kong enterprise RPM (el9 aarch64)" \
+    "https://packages.konghq.com/public/gateway-${ENTERPRISE_CHANNEL}/rpm/el/9/aarch64/kong-enterprise-edition-${ENTERPRISE_VERSION}.el9.aarch64.rpm" \
+    "$OUT_DIR/kong-enterprise-edition-${ENTERPRISE_VERSION}.el9.aarch64.rpm"
+  download "Kong enterprise DEB (amd64)" \
+    "https://packages.konghq.com/public/gateway-${ENTERPRISE_CHANNEL}/deb/debian/pool/bookworm/main/k/ko/kong-enterprise-edition_${ENTERPRISE_VERSION}/kong-enterprise-edition_${ENTERPRISE_VERSION}_amd64.deb" \
+    "$OUT_DIR/kong-enterprise-edition_${ENTERPRISE_VERSION}_amd64.deb"
+  download "Kong enterprise DEB (arm64)" \
+    "https://packages.konghq.com/public/gateway-${ENTERPRISE_CHANNEL}/deb/debian/pool/bookworm/main/k/ko/kong-enterprise-edition_${ENTERPRISE_VERSION}/kong-enterprise-edition_${ENTERPRISE_VERSION}_arm64.deb" \
+    "$OUT_DIR/kong-enterprise-edition_${ENTERPRISE_VERSION}_arm64.deb"
+else
+  echo "[INFO] Skipping enterprise artifact downloads (set KONG_FETCH_ENTERPRISE=1 to enable)"
+fi
 
-# DEBs (Debian bookworm)
-download "https://packages.konghq.com/public/gateway-311/deb/debian/pool/bookworm/main/k/ko/kong-enterprise-edition_3.11.0.3/kong-enterprise-edition_3.11.0.3_amd64.deb" \
-         "$OUT_DIR/kong-enterprise-edition_3.11.0.3_amd64.deb"
-download "https://packages.konghq.com/public/gateway-311/deb/debian/pool/bookworm/main/k/ko/kong-enterprise-edition_3.11.0.3/kong-enterprise-edition_3.11.0.3_arm64.deb" \
-         "$OUT_DIR/kong-enterprise-edition_3.11.0.3_arm64.deb"
+if [[ "$FETCH_COMMUNITY" != "0" ]]; then
+  echo "[INFO] Fetching Kong community artifacts (version ${COMMUNITY_VERSION}) into $OUT_DIR"
+  download "Kong community RPM (el9 x86_64)" \
+    "https://packages.konghq.com/public/gateway-${COMMUNITY_CHANNEL}/rpm/el/9/x86_64/kong-${COMMUNITY_VERSION}.el9.x86_64.rpm" \
+    "$OUT_DIR/kong-${COMMUNITY_VERSION}.el9.x86_64.rpm"
+  download "Kong community RPM (el9 aarch64)" \
+    "https://packages.konghq.com/public/gateway-${COMMUNITY_CHANNEL}/rpm/el/9/aarch64/kong-${COMMUNITY_VERSION}.el9.aarch64.rpm" \
+    "$OUT_DIR/kong-${COMMUNITY_VERSION}.el9.aarch64.rpm"
+  download "Kong community DEB (amd64)" \
+    "https://packages.konghq.com/public/gateway-${COMMUNITY_CHANNEL}/deb/debian/pool/bookworm/main/k/kong/kong_${COMMUNITY_VERSION}_amd64.deb" \
+    "$OUT_DIR/kong_${COMMUNITY_VERSION}_amd64.deb"
+  download "Kong community DEB (arm64)" \
+    "https://packages.konghq.com/public/gateway-${COMMUNITY_CHANNEL}/deb/debian/pool/bookworm/main/k/kong/kong_${COMMUNITY_VERSION}_arm64.deb" \
+    "$OUT_DIR/kong_${COMMUNITY_VERSION}_arm64.deb"
+fi
 
-echo "[DONE] Kong artifacts ready in $OUT_DIR"
-
+echo "[DONE] Kong artifacts available in $OUT_DIR"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced Kong artifact fetching with configurable versions

- Added support for both enterprise and community Kong packages

- Fixed RPM build dependencies across all spec files

- Created new Kong wrapper package specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fetch-kong-artifacts.sh"] --> B["Configurable Downloads"]
  B --> C["Enterprise Artifacts"]
  B --> D["Community Artifacts"]
  C --> E["serviceradar-kong Package"]
  D --> E
  F["RPM Spec Files"] --> G["systemd-rpm-macros"]
  G --> H["Fixed Build Dependencies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>fetch-kong-artifacts.sh</strong><dd><code>Enhanced artifact fetching with configurable versions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-448068ce58b8f5324251c7496e00a7955fe479b20c43a3111b4f9187b90150cd">+51/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.rpm.simple</strong><dd><code>Added systemd-rpm-macros and empty build handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-4064ba5cca15792a3395bec09f98ff4ee5d3612d60b9073ff50c8b731131626b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-kong.spec</strong><dd><code>Created new Kong wrapper package specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-e1be0e25d1d167a40c46c2b32773948a0e0df715f27f9cf4c011fec892b27583">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>components.json</strong><dd><code>Updated Kong package configuration structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-3ae5949d89b0252d10fce9bf950231c8151a73b2154dccfe4e7261acc116582c">+17/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Updated documentation for new artifact fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-0371346dc2a772957ae98006d92841ad86b86df489bcb6951b15f698f5c65192">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td><strong>serviceradar-agent.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-9fd8b118e9eb1b76ed4cc7664b788115634d3f1978bcc4fee0ea5873de1f6b90">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-core.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-b03570dbdd332568f77902ae5a6dc38255e2639e1fa4bb921c06c1557dbf35e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-event-writer.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-2a02c3cc8b4a3ab0ba76ce10f8c2e9168179e0f9f3eaa19807bb77d9a79b30e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-flowgger.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-894a88a48d87c8564c8958dff8a5d186cff83a1b48163182436f7f324f765e8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-goflow2.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-bab457844021064fedca41f57b7eca08a506f4985a9364da6e1691b7167aebd9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-kv.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-413b49672fc2bf028e0db1cf08f88fdc57608a82e4dfe3aed2cec699d3237d75">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-mapper.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-169bda1e25390e292d863fec1a7e455de7800143e08312ff3f67349b5edd0270">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-nats.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-3341a04774c8bd3113142b3abaab5c5f4db8e12cc6a6a789b30555f602444172">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-otel.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-593ca55958a2e0326e3eadce02fdd31e240e68bdf31fda39b9607d0c23cdf6c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-poller.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-afe5af03df8123f1126cf5b790cca19c707968dae11d300dd75a52097323857f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-profiler.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-268b89d5448fb107cdfe16cc0d9964781c02dc39dc828725315f482fd48e16b6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-proton.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-6aa5dc112bfc6b27d076f2a6a5f87cf7a285ec70dbf032f720b9b4c9dc646eab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-rperf-checker.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-fd3217cc52aeca1a10d4826f4b78fd2319a39a11039d798840baab1d0d174875">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-rperf.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-e29a7a6d3f0619a2460280c62bbd7bb8f608fde56c8078041c42cbe41e9ad95e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-snmp-checker.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-b29e95ee68a3151965ee19d69ed21f519ddf530dde9dfd1ad8d90e88b48717c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-srql.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-0f0d2551b721585ca16456a6217f4633c70f56c4a667e721d6783744ca3e5ff8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-sync.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-ad03df822d4f446590c2e7f35f39921575ea7f7600209eabd02ea4888fd3f8d9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-sysmon.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-1140c1c7039cda75a719ccf637cec7bb67e49313ebcbe632f34381901c5c5005">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-trapd.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-230b82e75a46737b86cede13d2b7c9a8b63e11f5ecffd8593d37ca8d637ff65e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-web.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-c84b985ecad45b6ee62657446e763878a6dd4e9a01e5903053cc923d88c34edb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-zen.spec</strong><dd><code>Fixed systemd build requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1658/files#diff-b09626493d21438651625c21e3a01752c29aff928093ae915b0f738ae1e4404c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

