### PR TITLE
fixed proton packaging for rpm

### DIFF
--- a/packaging/proton/scripts/postinstall.sh
+++ b/packaging/proton/scripts/postinstall.sh
@@ -111,7 +111,7 @@ done
 
 # Create required directories
 log_info "Creating required directories..."
-for dir in /var/lib/proton/tmp /var/lib/proton/checkpoint /var/lib/proton/nativelog/meta /var/lib/proton/nativelog/log /var/lib/proton/user_files /var/log/proton-server /var/run/proton-server /etc/proton-server/config.d /etc/proton-server/users.d /var/lib/proton/access; do
+for dir in /var/lib/proton/tmp /var/lib/proton/checkpoint /var/lib/proton/nativelog/meta /var/lib/proton/nativelog/log /var/lib/proton/user_files /var/log/proton-server /run/proton-server /etc/proton-server/config.d /etc/proton-server/users.d /var/lib/proton/access; do
     mkdir -p "$dir" || log_error "Failed to create directory $dir"
 done
 
@@ -223,7 +223,8 @@ setcap cap_net_admin,cap_ipc_lock,cap_sys_nice=ep /usr/bin/proton || {
 
 # Set ownership and permissions
 log_info "Setting ownership and permissions..."
-chown -R proton:proton /usr/bin/proton /etc/proton-server /var/log/proton-server /var/run/proton-server /var/lib/proton || log_error "Failed to set ownership"
+chown root:root /usr/bin/proton || log_error "Failed to set ownership on /usr/bin/proton"
+chown -R proton:proton /etc/proton-server /var/log/proton-server /run/proton-server /var/lib/proton || log_error "Failed to set ownership"
 chmod 755 /usr/bin/proton || log_error "Failed to set permissions on /usr/bin/proton"
 chmod 700 /etc/proton-server/users.d /etc/proton-server/config.d || log_error "Failed to set permissions on config directories"
 

--- a/packaging/proton/systemd/serviceradar-proton.service
+++ b/packaging/proton/systemd/serviceradar-proton.service
@@ -5,8 +5,8 @@ After=network-online.target
 [Service]
 Type=forking
 Environment=
-ExecStart=/usr/bin/proton-server --config-file /etc/proton-server/config.yaml --pid-file /var/run/proton-server/proton-server.pid --daemon
-ExecStop=/bin/sh -c '/usr/bin/proton stop || kill -TERM $(cat /var/run/proton-server/proton-server.pid) || true'
+ExecStart=/usr/bin/proton-server --config-file /etc/proton-server/config.yaml --pid-file /run/proton-server/proton-server.pid --daemon
+ExecStop=/bin/sh -c '/usr/bin/proton stop || kill -TERM $(cat /run/proton-server/proton-server.pid) || true'
 ExecReload=/bin/kill -HUP $MAINPID
 User=proton
 Group=proton
@@ -17,7 +17,9 @@ TimeoutStartSec=30
 StandardOutput=journal+append:/var/log/proton-server/proton-server.log
 StandardError=journal+append:/var/log/proton-server/proton-server.err.log
 LimitNOFILE=800000
-PIDFile=/var/run/proton-server/proton-server.pid
+RuntimeDirectory=proton-server
+RuntimeDirectoryMode=0755
+PIDFile=/run/proton-server/proton-server.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/specs/serviceradar-proton.spec
+++ b/packaging/specs/serviceradar-proton.spec
@@ -26,6 +26,11 @@ mkdir -p %{buildroot}/var/log/proton-server
 # Install binary
 install -m 755 %{_sourcedir}/proton %{buildroot}/usr/bin/
 
+# Provide compatibility symlinks expected by service scripts
+ln -sf proton %{buildroot}/usr/bin/proton-server
+ln -sf proton %{buildroot}/usr/bin/proton-client
+ln -sf proton %{buildroot}/usr/bin/proton-local
+
 # Install systemd service
 install -m 644 %{_sourcedir}/systemd/serviceradar-proton.service %{buildroot}/lib/systemd/system/
 
@@ -35,6 +40,9 @@ install -m 644 %{_sourcedir}/config/users.yaml %{buildroot}/etc/proton-server/
 
 %files
 %attr(0755, root, root) /usr/bin/proton
+/usr/bin/proton-server
+/usr/bin/proton-client
+/usr/bin/proton-local
 %config(noreplace) %attr(0644, proton, proton) /etc/proton-server/config.yaml
 %config(noreplace) %attr(0644, proton, proton) /etc/proton-server/users.yaml
 %attr(0644, root, root) /lib/systemd/system/serviceradar-proton.service
@@ -46,6 +54,7 @@ install -m 644 %{_sourcedir}/config/users.yaml %{buildroot}/etc/proton-server/
 %dir %attr(0755, proton, proton) /var/lib/proton/nativelog/log
 %dir %attr(0755, proton, proton) /var/lib/proton/user_files
 %dir %attr(0755, proton, proton) /var/log/proton-server
+%ghost %dir %attr(0755, proton, proton) /run/proton-server
 
 %pre
 # Create proton group if it doesn't exist
@@ -64,11 +73,13 @@ fi
 # Set up required directories
 mkdir -p /var/lib/proton/{tmp,checkpoint,nativelog/meta,nativelog/log,user_files}
 mkdir -p /var/log/proton-server
+install -d -m 0755 -o proton -g proton /run/proton-server
 
 # Set proper ownership and permissions
 chown -R proton:proton /etc/proton-server
 chown -R proton:proton /var/lib/proton
 chown -R proton:proton /var/log/proton-server
+chown root:root /usr/bin/proton
 chmod 755 /usr/bin/proton
 
 # Run proton install to set up the server properly


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix runtime directory paths from `/var/run` to `/run`

- Add compatibility symlinks for proton service scripts

- Correct binary ownership and permissions setup

- Add proper systemd runtime directory management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Runtime Path Fix"] --> B["/var/run → /run"]
  C["Binary Symlinks"] --> D["proton-server, proton-client, proton-local"]
  E["Ownership Fix"] --> F["root:root for /usr/bin/proton"]
  G["Systemd Config"] --> H["RuntimeDirectory directive"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postinstall.sh</strong><dd><code>Update runtime paths and binary ownership</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packaging/proton/scripts/postinstall.sh

<ul><li>Change <code>/var/run/proton-server</code> to <code>/run/proton-server</code> in directory <br>creation<br> <li> Fix binary ownership to <code>root:root</code> for <code>/usr/bin/proton</code><br> <li> Update chown commands to use <code>/run</code> instead of <code>/var/run</code><br> <li> Add missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1670/files#diff-5521f1f61dd62b42bc9ebc8834945805ed6c63ec6672b10bc4b9b42e9ae295e0">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-proton.service</strong><dd><code>Fix systemd service runtime directory configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packaging/proton/systemd/serviceradar-proton.service

<ul><li>Change PID file path from <code>/var/run</code> to <code>/run</code><br> <li> Add <code>RuntimeDirectory</code> and <code>RuntimeDirectoryMode</code> directives<br> <li> Update ExecStart and ExecStop commands to use <code>/run</code> path<br> <li> Add missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1670/files#diff-cb37668d548d2fe8d166a37cdadaec0a0fa86d769958440c93c0c21669547cf4">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-proton.spec</strong><dd><code>Add symlinks and fix RPM spec configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packaging/specs/serviceradar-proton.spec

<ul><li>Add compatibility symlinks for <code>proton-server</code>, <code>proton-client</code>, <br><code>proton-local</code><br> <li> Include symlinks in <code>%files</code> section<br> <li> Add ghost directory for <code>/run/proton-server</code><br> <li> Fix binary ownership in post-install script<br> <li> Add runtime directory creation in <code>%post</code> section</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1670/files#diff-6aa5dc112bfc6b27d076f2a6a5f87cf7a285ec70dbf032f720b9b4c9dc646eab">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

