### PR TITLE
adding missing files

### DIFF
--- a/k8s/external-dns/base/README.md
+++ b/k8s/external-dns/base/README.md
@@ -1,0 +1,17 @@
+# external-dns
+
+## Setup
+
+### Secrets
+
+```bash
+kubectl create secret generic cloudflare-api-secret \
+    --from-literal=CF_API_KEY="YOUR_CLOUDFLARE_API_KEY" \
+    --from-literal=CF_API_EMAIL="YOUR_CLOUDFLARE_API_EMAIL"
+```
+
+## Install ExternalDNS
+
+```bash
+kubectl apply -f external-dns.yaml
+```

--- a/k8s/external-dns/base/clusterrolebinding.yaml
+++ b/k8s/external-dns/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: default

--- a/k8s/external-dns/base/external-dns.yaml
+++ b/k8s/external-dns/base/external-dns.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: default
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+        - name: external-dns
+          image: registry.k8s.io/external-dns/external-dns:v0.15.1
+          args:
+            - --source=service
+            - --source=ingress
+            - --domain-filter=
+            - --provider=cloudflare
+            - --cloudflare-dns-records-per-page=5000 # (optional) configure how many DNS records to fetch per request
+            - --log-level=debug
+            - --registry=txt
+            - --txt-owner-id=external-dns-1
+            - --managed-record-types=A
+            - --managed-record-types=AAAA
+            - --policy=sync
+            - --request-timeout=30s
+            - --min-event-sync-interval=5s
+            - --events
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          env:
+            - name: CF_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-secret
+                  key: CF_API_KEY
+            - name: CF_API_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-secret
+                  key: CF_API_EMAIL
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 7979
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 7979
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane

--- a/k8s/external-dns/base/kustomization.yaml
+++ b/k8s/external-dns/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service-account.yaml
+  - clusterrolebinding.yaml
+  - external-dns.yaml
+  - service.yaml
+  - rbac.yaml

--- a/k8s/external-dns/base/patch.yaml
+++ b/k8s/external-dns/base/patch.yaml
@@ -1,0 +1,16 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: external-dns
+        args:
+        - --source=service
+        - --source=ingress
+        - --domain-filter=carverauto.dev
+        - --provider=cloudflare
+        - --cloudflare-dns-records-per-page=5000
+        - --log-level=trace
+        - --policy=sync
+        - --request-timeout=30s
+        - --min-event-sync-interval=5s
+        - --events

--- a/k8s/external-dns/base/rbac.yaml
+++ b/k8s/external-dns/base/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+  # Existing permissions
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get","watch","list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get","watch","list"]
+  - apiGroups: ["networking","networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get","watch","list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get","watch","list"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get","watch","list"]
+  # Add DNS CRD permissions
+  - apiGroups: ["dns.tunnel.carverauto.dev"]
+    resources: ["dnsendpoints"]
+    verbs: ["get","watch","list","create","update","patch","delete"]
+  - apiGroups: ["dns.tunnel.carverauto.dev"]
+    resources: ["dnsendpoints/status"]
+    verbs: ["get","update","patch"]

--- a/k8s/external-dns/base/service-account.yaml
+++ b/k8s/external-dns/base/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: default

--- a/k8s/external-dns/base/service.yaml
+++ b/k8s/external-dns/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-dns
+  namespace: default
+spec:
+  selector:
+    app: external-dns
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 7979  # This should be the port that the application inside the container listens on.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add complete external-dns Kubernetes configuration

- Configure Cloudflare DNS provider integration

- Set up RBAC permissions and service account

- Include deployment with health checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SA["ServiceAccount"] --> CRB["ClusterRoleBinding"]
  CRB --> CR["ClusterRole"]
  CR --> DEP["Deployment"]
  DEP --> SVC["Service"]
  DEP --> CF["Cloudflare API"]
  KUST["Kustomization"] --> SA
  KUST --> CRB
  KUST --> DEP
  KUST --> SVC
  KUST --> CR
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation for external-dns setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/README.md

<ul><li>Add setup instructions for Cloudflare API secrets<br> <li> Include installation commands for external-dns</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-894e6b1d6c15adedc469c46c437989dc603f1885e0de515b90b42986490cafcc">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterrolebinding.yaml</strong><dd><code>RBAC cluster role binding configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/clusterrolebinding.yaml

<ul><li>Create cluster role binding for external-dns service account<br> <li> Bind to external-dns cluster role in default namespace</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-6b6391a6dede6ec2508fff29ee6b581b3ac0524c8a085e6877fbaa1f7a63d7eb">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Kustomization resource definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/kustomization.yaml

<ul><li>Define Kustomize resources for external-dns components<br> <li> Include all YAML files for complete deployment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-1f8670d9e224b0180e23741a598af52e0563cb5fb0ac36cc8968eaaa4f96bb31">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patch.yaml</strong><dd><code>Domain-specific configuration patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/patch.yaml

<ul><li>Override deployment args with carverauto.dev domain filter<br> <li> Set trace logging level for debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-afcb40e9c7c625d732b1c45bc6d21f995da3b4b481add772c476ecf3ee1c2149">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rbac.yaml</strong><dd><code>RBAC permissions for external-dns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/rbac.yaml

<ul><li>Define cluster role with standard Kubernetes resource permissions<br> <li> Add custom DNS CRD permissions for carverauto.dev<br> <li> Grant access to services, ingresses, pods, nodes, endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-b18efa3c62b1a4d2fa979c51c5d429b45a8c282073e5d1c8b6c504e088d0071d">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service-account.yaml</strong><dd><code>Service account for external-dns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/service-account.yaml

- Create service account for external-dns in default namespace


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-4dafae6dddc56704c6cc6c5e489a79c7fed07ec90590d7167c8186ee4338c98d">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.yaml</strong><dd><code>Service configuration for external-dns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/service.yaml

<ul><li>Expose external-dns on port 80 targeting port 7979<br> <li> Configure service selector for external-dns app</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-69a7479c4834d7c07ceef6a240320141642697082690bbea8f4649f32fa71fd2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external-dns.yaml</strong><dd><code>Main external-dns deployment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/external-dns/base/external-dns.yaml

<ul><li>Deploy external-dns with Cloudflare provider configuration<br> <li> Configure resource limits and health checks<br> <li> Set up environment variables for Cloudflare API credentials<br> <li> Add tolerations for master/control-plane nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1681/files#diff-a11795ea19e03d0f45d96ce9fd444ecfd2b292058b75ade332640c942f50913d">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

