### PR TITLE
adding immutable image tags for docker images

### DIFF
--- a/docker/images/container_tags.bzl
+++ b/docker/images/container_tags.bzl
@@ -1,0 +1,94 @@
+"""Helper rules for deriving immutable OCI image tags."""
+
+def _immutable_tag_file_impl(ctx):
+    if ctx.attr.short_length <= 0:
+        fail("short_length must be positive")
+
+    digest_file = ctx.file.digest
+    commit_file = ctx.file.commit_tags
+    out = ctx.outputs.tags
+
+    args = [
+        digest_file.path,
+        ctx.attr.digest_prefix,
+        str(ctx.attr.short_length),
+        out.path,
+        commit_file.path if commit_file else "",
+    ] + ctx.attr.static_tags
+
+    command = """
+set -euo pipefail
+
+digest=$(cat "$1")
+if [[ "$digest" != sha256:* ]]; then
+  echo "unexpected digest format: $digest" >&2
+  exit 1
+fi
+
+prefix="$2"
+length="$3"
+out="$4"
+commit_file="$5"
+shift 5
+
+short=$(printf '%s' "${digest#sha256:}" | cut -c1-"${length}")
+
+{
+  if [[ -n "$commit_file" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ -n "$line" ]]; then
+        printf '%s\\n' "$line"
+      fi
+    done < "$commit_file"
+  fi
+
+  for tag in "$@"; do
+    if [[ -n "$tag" ]]; then
+      printf '%s\\n' "$tag"
+    fi
+  done
+
+  printf '%s%s\\n' "$prefix" "$short"
+} > "$out"
+"""
+
+    inputs = [digest_file]
+    if commit_file:
+        inputs.append(commit_file)
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [out],
+        command = command,
+        arguments = args,
+        progress_message = "Deriving immutable tags for {}".format(ctx.label.name),
+        mnemonic = "GenerateImmutableTags",
+    )
+
+immutable_push_tags = rule(
+    implementation = _immutable_tag_file_impl,
+    doc = "Writes an immutable tag list combining static tags with a short digest hash.",
+    attrs = {
+        "digest": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "commit_tags": attr.label(
+            allow_single_file = True,
+            doc = "Optional file providing commit-derived tags (one per line).",
+        ),
+        "static_tags": attr.string_list(
+            default = [],
+            doc = "Additional fixed tags to include (e.g. latest).",
+        ),
+        "digest_prefix": attr.string(
+            default = "sha-",
+            doc = "Prefix applied to the digest-based tag.",
+        ),
+        "short_length": attr.int(
+            default = 12,
+            doc = "Number of digest characters to include in the generated tag.",
+        ),
+    },
+    outputs = {"tags": "%{name}.txt"},
+)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add immutable image tagging system for Docker containers

- Create helper rule to generate digest-based tags

- Refactor GHCR push targets to use new tagging system

- Replace hardcoded tags with dynamic tag generation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Image Digest"] --> B["immutable_push_tags rule"]
  C["Commit Tags"] --> B
  D["Static Tags"] --> B
  B --> E["Generated Tag File"]
  E --> F["oci_push Target"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>container_tags.bzl</strong><dd><code>Add immutable container tagging rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/images/container_tags.bzl

<ul><li>Create new Bazel rule <code>immutable_push_tags</code> for generating container <br>tags<br> <li> Implement shell script logic to combine digest, commit, and static <br>tags<br> <li> Add validation for digest format and configurable tag prefixes<br> <li> Support optional commit-derived tags and customizable digest length</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1686/files#diff-9976c1b5a185e265900bc362d8e8bee2b4e94c354922c1c29c92687b7669c0c3">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push_targets.bzl</strong><dd><code>Integrate immutable tagging into push targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/images/push_targets.bzl

<ul><li>Import new <code>immutable_push_tags</code> rule from container_tags.bzl<br> <li> Replace hardcoded tag template with separate commit tag generation<br> <li> Integrate immutable tagging system into GHCR push targets<br> <li> Maintain existing functionality while adding digest-based tags</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1686/files#diff-4af33fe62caba04b6d479589c16cfb85babc39bae5c92595d4d4e31660738513">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

