### PR TITLE
fixing ephemeral storage limits with bb pods

### DIFF
--- a/k8s/buildbuddy/README.md
+++ b/k8s/buildbuddy/README.md
@@ -18,6 +18,7 @@ The BuildBuddy executors connect to the remote BuildBuddy instance at `remote.bu
 - **Resources per executor**:
   - CPU: 8-16 cores (request-limit)
   - Memory: 16-32Gi (request-limit)
+  - Ephemeral Storage: 10-30Gi (request-limit)
 - **Cache**: 20GB local cache per executor
 - **Persistent Disk**: 160Gi per executor
 
@@ -98,9 +99,14 @@ kubectl get hpa -n buildbuddy
 
 If pods are being evicted due to resource pressure:
 1. Check node resources: `kubectl describe node <node-name>`
-2. Reduce resource requests/limits in `values.yaml`
-3. Add node affinity to avoid problematic nodes
-4. Reduce cache size (`local_cache_size_bytes`)
+2. Common causes:
+   - **Ephemeral storage exhaustion**: Ensure `ephemeral-storage` limits are set in `resources`
+   - **Memory pressure**: Adjust memory limits
+   - **Disk pressure**: Check node disk usage
+3. Reduce resource requests/limits in `values.yaml`
+4. Add node affinity to avoid problematic nodes
+5. Reduce cache size (`local_cache_size_bytes`)
+6. Clean up evicted pods: `kubectl delete pods --field-selector status.phase=Failed -n buildbuddy`
 
 ### Connection Issues
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add ephemeral storage resource requirements to BuildBuddy documentation

- Expand troubleshooting guide for pod eviction issues

- Include cleanup command for failed pods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Resource Requirements"] --> B["Add Ephemeral Storage"]
  C["Troubleshooting Guide"] --> D["Expand Pod Eviction Causes"]
  D --> E["Add Cleanup Commands"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update resource requirements and troubleshooting documentation</code></dd></summary>
<hr>

k8s/buildbuddy/README.md

<ul><li>Add ephemeral storage resource specification (10-30Gi)<br> <li> Expand pod eviction troubleshooting with specific causes<br> <li> Add command to clean up failed/evicted pods<br> <li> Restructure troubleshooting steps with numbered list</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1698/files#diff-b9a22507afd694c735354f80d644288a1bad09fcc380eab7e7ca1b5b61e1cd1b">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

