### PR TITLE
fixing resource limits

### DIFF
--- a/k8s/demo/base/serviceradar-agent.yaml
+++ b/k8s/demo/base/serviceradar-agent.yaml
@@ -57,11 +57,11 @@ spec:
             privileged: true
           resources:
             limits:
-              cpu: "200m"
-              memory: "512Mi"
+              cpu: "500m"
+              memory: "2Gi"
             requests:
-              cpu: "100m"
-              memory: "128Mi"
+              cpu: "250m"
+              memory: "1Gi"
       volumes:
         - name: serviceradar-config
           configMap:

--- a/k8s/demo/base/serviceradar-nats.yaml
+++ b/k8s/demo/base/serviceradar-nats.yaml
@@ -37,10 +37,10 @@ spec:
         resources:
           limits:
             cpu: "1"
-            memory: "1Gi"
+            memory: "4Gi"
           requests:
-            cpu: "100m"
-            memory: "256Mi"
+            cpu: "250m"
+            memory: "2Gi"
         livenessProbe:
           httpGet:
             path: /

--- a/k8s/demo/base/serviceradar-poller.yaml
+++ b/k8s/demo/base/serviceradar-poller.yaml
@@ -35,11 +35,11 @@ spec:
           value: "info"
         resources:
           limits:
-            cpu: "500m"
-            memory: "512Mi"
+            cpu: "1"
+            memory: "2Gi"
           requests:
-            cpu: "100m"
-            memory: "256Mi"
+            cpu: "250m"
+            memory: "1Gi"
         livenessProbe:
           tcpSocket:
             port: 50053

--- a/k8s/demo/base/serviceradar-poller.yaml
+++ b/k8s/demo/base/serviceradar-poller.yaml
@@ -35,11 +35,11 @@ spec:
           value: "info"
         resources:
           limits:
-            cpu: "1"
-            memory: "2Gi"
+            cpu: "2"
+            memory: "6Gi"
           requests:
-            cpu: "250m"
-            memory: "1Gi"
+            cpu: "500m"
+            memory: "2Gi"
         livenessProbe:
           tcpSocket:
             port: 50053

--- a/k8s/demo/base/serviceradar-sync.yaml
+++ b/k8s/demo/base/serviceradar-sync.yaml
@@ -35,11 +35,11 @@ spec:
           value: "info"
         resources:
           requests:
-            cpu: "250m"
-            memory: "2Gi"
+            cpu: "500m"
+            memory: "3Gi"
           limits:
-            cpu: "1"
-            memory: "4Gi"
+            cpu: "2"
+            memory: "8Gi"
         livenessProbe:
           tcpSocket:
             port: 50058

--- a/k8s/demo/base/serviceradar-sync.yaml
+++ b/k8s/demo/base/serviceradar-sync.yaml
@@ -35,11 +35,11 @@ spec:
           value: "info"
         resources:
           requests:
-            cpu: "100m"
-            memory: "128Mi"
+            cpu: "250m"
+            memory: "2Gi"
           limits:
-            cpu: "500m"
-            memory: "512Mi"
+            cpu: "1"
+            memory: "4Gi"
         livenessProbe:
           tcpSocket:
             port: 50058


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increase CPU and memory limits across all ServiceRadar components

- Scale memory from 512Mi-1Gi to 2Gi-4Gi ranges

- Boost CPU requests from 100m to 250m consistently

- Enhance resource allocation for better performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current Resources"] --> B["Increased CPU Limits"]
  A --> C["Increased Memory Limits"]
  B --> D["Better Performance"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serviceradar-agent.yaml</strong><dd><code>Scale agent resource limits significantly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-agent.yaml

<ul><li>CPU limits increased from 200m to 500m<br> <li> Memory limits increased from 512Mi to 2Gi<br> <li> CPU requests increased from 100m to 250m<br> <li> Memory requests increased from 128Mi to 1Gi</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1704/files#diff-750aaa803a43f0993450026e4174b8a7d20fe016b9ff726f154a77a4f0fb4e19">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-nats.yaml</strong><dd><code>Boost NATS server memory allocation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-nats.yaml

<ul><li>Memory limits increased from 1Gi to 4Gi<br> <li> CPU requests increased from 100m to 250m<br> <li> Memory requests increased from 256Mi to 2Gi</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1704/files#diff-48984f0444e9f5e0d051d71ee217f64c5dfab202889db4564e6c1a7a6a248b05">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-poller.yaml</strong><dd><code>Double poller resource allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-poller.yaml

<ul><li>CPU limits increased from 500m to 1 core<br> <li> Memory limits increased from 512Mi to 2Gi<br> <li> CPU requests increased from 100m to 250m<br> <li> Memory requests increased from 256Mi to 1Gi</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1704/files#diff-20492d7f5153e92f95cbbf2f62fb75b1a43f530304372a5e7731fdf95b583f3b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-sync.yaml</strong><dd><code>Maximize sync service resource limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-sync.yaml

<ul><li>CPU limits increased from 500m to 1 core<br> <li> Memory limits increased from 512Mi to 4Gi<br> <li> CPU requests increased from 100m to 250m<br> <li> Memory requests increased from 128Mi to 2Gi</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1704/files#diff-8b12e23e4eec411255c9ae947b353c680f5ff75a4e0891bc14e2db88d9e6b778">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

