### PR TITLE
make sure core generates jwks

### DIFF
--- a/k8s/demo/base/configmap.yaml
+++ b/k8s/demo/base/configmap.yaml
@@ -792,7 +792,7 @@ data:
     # Update the config file with secrets using jq for in-place editing
     if [ -f "$CONFIG_PATH" ]; then
         echo "Updating configuration with secrets..."
-        
+
         # Use jq to update the existing config - match production auth format exactly  
         jq --arg pwd "$PROTON_PASSWORD" \
            --arg jwt "$JWT_SECRET" \
@@ -802,8 +802,19 @@ data:
            "$CONFIG_PATH" > /var/lib/serviceradar/core.json
         CONFIG_PATH="/var/lib/serviceradar/core.json"
         echo "Configuration updated with all secrets and saved to $CONFIG_PATH"
+
+        if command -v serviceradar-cli >/dev/null 2>&1; then
+            if ! jq -e '.auth.jwt_private_key_pem // empty' "$CONFIG_PATH" >/dev/null 2>&1; then
+                echo "Generating RS256 JWT keys for Core JWKS..."
+                if ! serviceradar-cli generate-jwt-keys --file "$CONFIG_PATH" --bits 2048 --force; then
+                    echo "Failed to generate RS256 keys" >&2
+                fi
+            fi
+        else
+            echo "serviceradar-cli not available; skipping RS256 key generation" >&2
+        fi
     fi
-    
+
     # Wait for Proton to be ready
     if [ "${WAIT_FOR_PROTON:-false}" = "true" ]; then
         PROTON_TLS_ADDR="${PROTON_HOST:-serviceradar-proton}:9440"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add RS256 JWT key generation for Core JWKS

- Ensure JWT private key exists in configuration

- Minor whitespace cleanup in ConfigMap


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ConfigMap Script"] --> B["Check JWT Private Key"]
  B --> C["Generate RS256 Keys"]
  C --> D["Core JWKS Ready"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Add RS256 JWT key generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/configmap.yaml

<ul><li>Add JWT private key existence check using jq<br> <li> Generate RS256 keys with <code>serviceradar-cli</code> if missing<br> <li> Include error handling for key generation failures<br> <li> Clean up trailing whitespace</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1706/files#diff-f4548beaa0a3a01a46971c82c5647a0f3f49eb38d66dd939d06d19018173fcd6">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

