### PR TITLE
fixing jwks issues

### DIFF
--- a/k8s/demo/base/configmap.yaml
+++ b/k8s/demo/base/configmap.yaml
@@ -778,9 +778,15 @@ data:
     echo "🔑 Using API_KEY: ${API_KEY:0:8}... (${#API_KEY} chars)"
     echo "🔐 Using JWT_SECRET: ${JWT_SECRET:0:8}... (${#JWT_SECRET} chars)"
     
-    # Default configuration path
-    CONFIG_PATH="${CONFIG_PATH:-/etc/serviceradar/core.json}"
-    echo "Using configuration from $CONFIG_PATH"
+    TEMPLATE_PATH="/etc/serviceradar/core.json"
+    CONFIG_PATH="${CONFIG_PATH:-/var/lib/serviceradar/core.json}"
+    CONFIG_DIR=$(dirname "$CONFIG_PATH")
+    mkdir -p "$CONFIG_DIR"
+    if [ ! -f "$CONFIG_PATH" ]; then
+        echo "Seeding runtime config from $TEMPLATE_PATH into $CONFIG_PATH"
+        cp "$TEMPLATE_PATH" "$CONFIG_PATH"
+    fi
+    echo "Using runtime configuration at $CONFIG_PATH"
     
     # Get Proton password from Kubernetes secret (loaded as env var)
     if [ -n "$PROTON_PASSWORD" ]; then
@@ -794,24 +800,18 @@ data:
         echo "Updating configuration with secrets..."
 
         # Use jq to update the existing config - match production auth format exactly  
+        TMP_CONFIG=$(mktemp)
         jq --arg pwd "$PROTON_PASSWORD" \
            --arg jwt "$JWT_SECRET" \
            --arg api_key "$API_KEY" \
            --arg bcrypt "$ADMIN_BCRYPT_HASH" \
            '.database.password = $pwd | .auth.jwt_secret = $jwt | .auth.jwt_expiration = "24h" | .auth.local_users.admin = $bcrypt | .api_key = $api_key' \
-           "$CONFIG_PATH" > /var/lib/serviceradar/core.json
-        CONFIG_PATH="/var/lib/serviceradar/core.json"
-        echo "Configuration updated with all secrets and saved to $CONFIG_PATH"
+           "$CONFIG_PATH" > "$TMP_CONFIG"
+        mv "$TMP_CONFIG" "$CONFIG_PATH"
+        echo "Configuration updated with secrets at $CONFIG_PATH"
 
-        if command -v serviceradar-cli >/dev/null 2>&1; then
-            if ! jq -e '.auth.jwt_private_key_pem // empty' "$CONFIG_PATH" >/dev/null 2>&1; then
-                echo "Generating RS256 JWT keys for Core JWKS..."
-                if ! serviceradar-cli generate-jwt-keys --file "$CONFIG_PATH" --bits 2048 --force; then
-                    echo "Failed to generate RS256 keys" >&2
-                fi
-            fi
-        else
-            echo "serviceradar-cli not available; skipping RS256 key generation" >&2
+        if ! jq -e '.auth.jwt_private_key_pem // empty' "$CONFIG_PATH" >/dev/null 2>&1; then
+            echo "Warning: RS256 key material missing from $CONFIG_PATH; Core JWKS will be empty" >&2
         fi
     fi
 

--- a/k8s/demo/base/serviceradar-core.yaml
+++ b/k8s/demo/base/serviceradar-core.yaml
@@ -17,6 +17,24 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-io-cred
+      initContainers:
+      - name: init-core-jwks
+        image: ghcr.io/carverauto/serviceradar-kong-config:latest
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          mkdir -p /var/lib/serviceradar
+          cp /etc/serviceradar/core.json /var/lib/serviceradar/core.json
+          serviceradar-cli generate-jwt-keys --file /var/lib/serviceradar/core.json --bits 2048 --force
+        volumeMounts:
+        - name: serviceradar-config
+          mountPath: /etc/serviceradar
+          readOnly: true
+        - name: core-data
+          mountPath: /var/lib/serviceradar
       containers:
       - name: core
         image: ghcr.io/carverauto/serviceradar-core:latest
@@ -50,7 +68,7 @@ spec:
         - name: CONFIG_SOURCE
           value: "file"
         - name: CONFIG_PATH
-          value: "/etc/serviceradar/core.json"
+          value: "/var/lib/serviceradar/core.json"
         - name: PROTON_HOST
           value: "serviceradar-proton"
         - name: PROTON_USER


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix JWKS key generation using dedicated init container

- Separate template and runtime configuration paths

- Improve configuration file handling and error reporting

- Remove CLI dependency from main init script


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Template Config"] --> B["Init Container"]
  B --> C["Generate JWKS Keys"]
  C --> D["Runtime Config"]
  D --> E["Core Container"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configmap.yaml</strong><dd><code>Refactor configuration handling and remove CLI dependency</code></dd></summary>
<hr>

k8s/demo/base/configmap.yaml

<ul><li>Separate template and runtime configuration paths<br> <li> Remove serviceradar-cli dependency from init script<br> <li> Improve configuration file handling with proper directory creation<br> <li> Add warning for missing RS256 key material</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1707/files#diff-f4548beaa0a3a01a46971c82c5647a0f3f49eb38d66dd939d06d19018173fcd6">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serviceradar-core.yaml</strong><dd><code>Add init container for JWKS key generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-core.yaml

<ul><li>Add dedicated init container for JWKS key generation<br> <li> Use kong-config image with serviceradar-cli for key generation<br> <li> Update CONFIG_PATH to use runtime configuration location<br> <li> Add core-data volume mount for persistent configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1707/files#diff-2f484d8fe3bae65aace437568f6dd660c92f57b452f7bd1608083a8fe3716ba3">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

