### PR TITLE
chore(k8s): bump proton pvc size to 512Gi for demo

### DIFF
--- a/k8s/demo/base/serviceradar-proton.yaml
+++ b/k8s/demo/base/serviceradar-proton.yaml
@@ -135,4 +135,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 150Gi
+      storage: 512Gi


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Increase Proton PVC storage from 150Gi to 512Gi


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Proton PVC"] -- "storage increase" --> B["150Gi → 512Gi"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serviceradar-proton.yaml</strong><dd><code>Increase PVC storage capacity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-proton.yaml

- Updated PVC storage request from 150Gi to 512Gi


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1713/files#diff-d8814c9cdfa0f83548605468ce867dc550b5d51a4afdc46074f91420d1218686">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

