### PR TITLE
Apply preferred .bazelrc changes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,14 @@ try-import %workspace%/.bazelrc.remote
 # Metadata for buildbuddy
 build --workspace_status_command=$(pwd)/scripts/workspace_status.sh
 
+# Disable remote execution/caching when explicitly requested.
+build:no_remote --remote_executor=
+build:no_remote --remote_cache=
+build:no_remote --remote_upload_local_results=false
+build:no_remote --remote_download_minimal
+build:no_remote --bes_backend=
+build:no_remote --bes_results_url=
+
 # CI profile can layer on top of the remote config without re-declaring values.
 build:ci --keep_going --build_tag_filters=-manual
 build:ci --config=remote
@@ -100,12 +108,10 @@ build:darwin_pkg --action_env=PKG_SIGN_IDENTITY
 build:darwin_pkg --action_env=PKG_NOTARIZE_PROFILE
 build:darwin_pkg --action_env=PKG_VERSION
 build:darwin_pkg --action_env=PKG_IDENTIFIER
-build:darwin_pkg --action_env=PKG_DISABLE_TIMESTAMP=1
+build:darwin_pkg --action_env=PKG_DISABLE_TIMESTAMP=0
 build:darwin_pkg --action_env=XCODE_VERSION_OVERRIDE=26.0
 build:darwin_pkg --remote_default_exec_properties=OSFamily=MacOS
 build:darwin_pkg --repo_env=PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin
 build:darwin_pkg --repo_env=BAZEL=/usr/local/bin/bazel
 build:darwin_pkg --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:darwin_pkg --remote_executor=
-build:darwin_pkg --remote_cache=
-build:darwin_pkg --remote_upload_local_results=false
+build:darwin_pkg --config=no_remote

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ k8s/buildbuddy/values.yaml
 #MODULE.bazel.lock
 
 .gomodcache/
+pkg/cpufreq/hostfreq_darwin_embed.o


### PR DESCRIPTION
### **User description**
….bazel.lock


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `no_remote` configuration profile to disable remote execution and caching

- Update `darwin_pkg` profile to use `no_remote` config and enable timestamps

- Consolidate remote execution settings into reusable configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New no_remote config"] --> B["Disables remote execution"]
  A --> C["Disables remote caching"]
  D["darwin_pkg profile"] --> E["Uses no_remote config"]
  D --> F["Enables PKG timestamps"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.bazelrc</strong><dd><code>Add no_remote config and refactor darwin_pkg profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.bazelrc

<ul><li>Added <code>no_remote</code> configuration profile with flags to disable remote <br>execution, caching, and BES backend<br> <li> Modified <code>darwin_pkg</code> profile to use <code>no_remote</code> config instead of <br>individual flags<br> <li> Changed <code>PKG_DISABLE_TIMESTAMP</code> from <code>1</code> to <code>0</code> in <code>darwin_pkg</code> profile</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1747/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

