### PR TITLE
k8s updates, nats updates for otel to create stream if missing, poller

### DIFF
--- a/cmd/otel/src/config.rs
+++ b/cmd/otel/src/config.rs
@@ -55,6 +55,10 @@ pub struct NATSConfigTOML {
     pub stream: String,
     #[serde(default = "default_timeout_secs")]
     pub timeout_secs: u64,
+    #[serde(default = "default_max_bytes")]
+    pub max_bytes: i64,
+    #[serde(default = "default_max_age_secs")]
+    pub max_age_secs: u64,
     pub tls: Option<NATSTLSConfig>,
 }
 
@@ -148,6 +152,8 @@ impl Config {
                 subject: nats.subject.clone(),
                 stream: nats.stream.clone(),
                 timeout: Duration::from_secs(nats.timeout_secs),
+                max_bytes: nats.max_bytes,
+                max_age: Duration::from_secs(nats.max_age_secs),
                 tls_cert,
                 tls_key,
                 tls_ca,
@@ -171,6 +177,8 @@ impl Config {
                 subject: "events.otel".to_string(),
                 stream: "events".to_string(),
                 timeout_secs: 30,
+                max_bytes: default_max_bytes(),
+                max_age_secs: default_max_age_secs(),
                 tls: Some(NATSTLSConfig {
                     cert_file: "/path/to/nats-client.crt".to_string(),
                     key_file: "/path/to/nats-client.key".to_string(),
@@ -208,6 +216,14 @@ fn default_nats_stream() -> String {
 
 fn default_timeout_secs() -> u64 {
     30
+}
+
+fn default_max_bytes() -> i64 {
+    2 * 1024 * 1024 * 1024 // 2 GiB
+}
+
+fn default_max_age_secs() -> u64 {
+    30 * 60 // 30 minutes
 }
 
 fn default_metrics_bind_address() -> String {
@@ -410,6 +426,8 @@ key_file = "/grpc.key"
                 subject: "test.subject".to_string(),
                 stream: "test_stream".to_string(),
                 timeout_secs: 45,
+                max_bytes: default_max_bytes(),
+                max_age_secs: default_max_age_secs(),
                 tls: Some(NATSTLSConfig {
                     cert_file: "/cert.pem".to_string(),
                     key_file: "/key.pem".to_string(),
@@ -424,6 +442,11 @@ key_file = "/grpc.key"
         assert_eq!(nats_config.subject, "test.subject");
         assert_eq!(nats_config.stream, "test_stream");
         assert_eq!(nats_config.timeout, Duration::from_secs(45));
+        assert_eq!(nats_config.max_bytes, default_max_bytes());
+        assert_eq!(
+            nats_config.max_age,
+            Duration::from_secs(default_max_age_secs())
+        );
         assert_eq!(nats_config.tls_cert.unwrap(), PathBuf::from("/cert.pem"));
         assert_eq!(nats_config.tls_key.unwrap(), PathBuf::from("/key.pem"));
         assert_eq!(nats_config.tls_ca.unwrap(), PathBuf::from("/ca.pem"));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,8 @@ services:
   core:
     image: ghcr.io/carverauto/serviceradar-core:latest
     container_name: serviceradar-core
+    mem_limit: 8g
+    mem_reservation: 4g
     # Expose core ports for debugging authentication
     ports:
       - "8090:8090"  # HTTP API
@@ -434,6 +436,7 @@ services:
   kv:
     image: ghcr.io/carverauto/serviceradar-kv:latest
     container_name: serviceradar-kv
+    cpus: "2.0"
     ports:
       - "50057:50057"  # gRPC port
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,7 +247,7 @@ services:
     image: nginx:alpine
     container_name: serviceradar-nginx
     ports:
-      - "80:80"      # HTTP
+      - "${SERVICERADAR_HTTP_PORT:-80}:80"      # HTTP
       # - "443:443"  # HTTPS (add SSL termination later)
     environment:
       API_UPSTREAM: ${API_UPSTREAM:-http://kong:8000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - cert-data:/etc/serviceradar/certs:ro
       - cert-data:/etc/proton-server/certs:ro
       - credentials:/etc/serviceradar/credentials
+      - ./docker/compose/proton-init.sh:/usr/local/bin/proton-init.sh:ro
     environment:
       - PROTON_PASSWORD=${PROTON_PASSWORD:-}  # Will generate if not set
       - PROTON_LOG_LEVEL=${PROTON_LOG_LEVEL:-error}
@@ -188,7 +189,7 @@ services:
     environment:
       - NODE_ENV=production
       - NEXT_PUBLIC_API_URL=http://localhost/api
-      - NEXT_INTERNAL_API_URL=http://core:8090
+      - NEXT_INTERNAL_API_URL=http://kong:8000
       - AUTH_ENABLED=true
       # API_KEY and JWT_SECRET will be loaded from generated config volume at runtime
     volumes:

--- a/docker/compose/entrypoint-db-event-writer.sh
+++ b/docker/compose/entrypoint-db-event-writer.sh
@@ -15,6 +15,9 @@
 
 set -e
 
+# Default attempt count for dependency waits (2 minutes at 2s interval)
+DEFAULT_WAIT_ATTEMPTS="${WAIT_FOR_ATTEMPTS_DEFAULT:-60}"
+
 # Helper to resolve service hosts depending on the environment (Docker vs. Kubernetes)
 resolve_service_host() {
     service_name="$1"
@@ -49,7 +52,7 @@ if [ -n "${WAIT_FOR_NATS:-}" ]; then
     NATS_PORT_VALUE=$(resolve_service_port NATS_PORT "4222")
     echo "Waiting for NATS service at ${NATS_HOST_VALUE}:${NATS_PORT_VALUE}..."
 
-    NATS_ATTEMPTS="${WAIT_FOR_NATS_ATTEMPTS:-0}"
+    NATS_ATTEMPTS="${WAIT_FOR_NATS_ATTEMPTS:-$DEFAULT_WAIT_ATTEMPTS}"
     if wait-for-port \
         --host "${NATS_HOST_VALUE}" \
         --port "${NATS_PORT_VALUE}" \
@@ -68,7 +71,7 @@ if [ -n "${WAIT_FOR_PROTON:-}" ]; then
     PROTON_PORT_VALUE=$(resolve_service_port PROTON_PORT "9440")
     echo "Waiting for Proton database at ${PROTON_HOST_VALUE}:${PROTON_PORT_VALUE}..."
 
-    PROTON_ATTEMPTS="${WAIT_FOR_PROTON_ATTEMPTS:-0}"
+    PROTON_ATTEMPTS="${WAIT_FOR_PROTON_ATTEMPTS:-$DEFAULT_WAIT_ATTEMPTS}"
     if wait-for-port \
         --host "${PROTON_HOST_VALUE}" \
         --port "${PROTON_PORT_VALUE}" \

--- a/docker/compose/entrypoint-db-event-writer.sh
+++ b/docker/compose/entrypoint-db-event-writer.sh
@@ -49,10 +49,11 @@ if [ -n "${WAIT_FOR_NATS:-}" ]; then
     NATS_PORT_VALUE=$(resolve_service_port NATS_PORT "4222")
     echo "Waiting for NATS service at ${NATS_HOST_VALUE}:${NATS_PORT_VALUE}..."
 
+    NATS_ATTEMPTS="${WAIT_FOR_NATS_ATTEMPTS:-0}"
     if wait-for-port \
         --host "${NATS_HOST_VALUE}" \
         --port "${NATS_PORT_VALUE}" \
-        --attempts 30 \
+        --attempts "${NATS_ATTEMPTS}" \
         --interval 2s \
         --quiet; then
         echo "NATS service is ready!"
@@ -67,10 +68,11 @@ if [ -n "${WAIT_FOR_PROTON:-}" ]; then
     PROTON_PORT_VALUE=$(resolve_service_port PROTON_PORT "9440")
     echo "Waiting for Proton database at ${PROTON_HOST_VALUE}:${PROTON_PORT_VALUE}..."
 
+    PROTON_ATTEMPTS="${WAIT_FOR_PROTON_ATTEMPTS:-0}"
     if wait-for-port \
         --host "${PROTON_HOST_VALUE}" \
         --port "${PROTON_PORT_VALUE}" \
-        --attempts 30 \
+        --attempts "${PROTON_ATTEMPTS}" \
         --interval 2s \
         --quiet; then
         echo "Proton database is ready!"

--- a/docker/compose/otel.docker.toml
+++ b/docker/compose/otel.docker.toml
@@ -19,6 +19,12 @@ stream = "events"
 # Timeout for NATS operations in seconds (default: 30)
 timeout_secs = 30
 
+# Maximum retained size of the events stream (default: 2 GiB)
+max_bytes = 2147483648
+
+# Maximum retention window for the events stream in seconds (default: 30 minutes)
+max_age_secs = 1800
+
 # mTLS configuration for NATS
 [nats.tls]
 cert_file = "/etc/serviceradar/certs/otel.pem"

--- a/docker/compose/proton-init.sh
+++ b/docker/compose/proton-init.sh
@@ -105,13 +105,23 @@ done
 
 # Generate DH parameters if not present (for SSL security)
 log_info "Checking DH parameters..."
-if [ ! -f "/etc/proton-server/dhparam.pem" ]; then
-    log_info "Generating DH parameters (this may take a few minutes for security)..."
-    openssl dhparam -out /etc/proton-server/dhparam.pem 2048
-    chmod 644 /etc/proton-server/dhparam.pem
-    log_info "DH parameters generated successfully"
+DH_PARAMS_PERSIST="/var/lib/proton/dhparam.pem"
+DH_PARAMS_TARGET="/etc/proton-server/dhparam.pem"
+mkdir -p "$(dirname "$DH_PARAMS_PERSIST")"
+
+if [ -f "$DH_PARAMS_TARGET" ]; then
+    log_info "DH parameters already present at ${DH_PARAMS_TARGET}"
+elif [ -f "$DH_PARAMS_PERSIST" ]; then
+    log_info "Restoring DH parameters from persistent storage"
+    cp "$DH_PARAMS_PERSIST" "$DH_PARAMS_TARGET"
+    chmod 644 "$DH_PARAMS_TARGET"
 else
-    log_info "DH parameters already exist"
+    log_info "Generating DH parameters (this may take a few minutes for security)..."
+    openssl dhparam -out "$DH_PARAMS_TARGET" 2048
+    chmod 644 "$DH_PARAMS_TARGET"
+    cp "$DH_PARAMS_TARGET" "$DH_PARAMS_PERSIST"
+    chmod 644 "$DH_PARAMS_PERSIST"
+    log_info "DH parameters generated and saved to persistent storage"
 fi
 
 # Verify certificate access

--- a/k8s/demo/base/configmap.yaml
+++ b/k8s/demo/base/configmap.yaml
@@ -264,8 +264,7 @@ data:
             { "service_type": "grpc",    "service_name": "trapd",             "details": "serviceradar-trapd:50043" },
             { "service_type": "grpc",    "service_name": "flowgger",          "details": "serviceradar-flowgger:50044" },
             { "service_type": "grpc",    "service_name": "sync",              "details": "serviceradar-sync:50058", "results_interval": "30s" },
-            { "service_type": "grpc",    "service_name": "kv",                "details": "serviceradar-kv:50057" },
-            { "service_type": "grpc",    "service_name": "nats",              "details": "serviceradar-nats:4222" }
+            { "service_type": "grpc",    "service_name": "kv",                "details": "serviceradar-kv:50057" }
           ]
         }
       },
@@ -1122,6 +1121,12 @@ data:
     
     # Timeout for NATS operations in seconds (default: 30)
     timeout_secs = 30
+    
+    # Maximum retained size of the events stream (default: 2 GiB)
+    max_bytes = 2147483648
+    
+    # Maximum retention window for the events stream in seconds (default: 30 minutes)
+    max_age_secs = 1800
     
     # mTLS configuration for NATS
     [nats.tls]

--- a/k8s/demo/base/serviceradar-core.yaml
+++ b/k8s/demo/base/serviceradar-core.yaml
@@ -113,11 +113,11 @@ spec:
           value: "kv.serviceradar"
         resources:
           limits:
-            cpu: "2"
-            memory: "4Gi"
+            cpu: "3"
+            memory: "8Gi"
           requests:
-            cpu: "500m"
-            memory: "512Mi"
+            cpu: "1"
+            memory: "4Gi"
         livenessProbe:
           exec:
             command:

--- a/k8s/demo/base/serviceradar-kong.yaml
+++ b/k8s/demo/base/serviceradar-kong.yaml
@@ -32,6 +32,7 @@ spec:
             --srql-service http://serviceradar-srql:8080 \
             --srql-path /api/query \
             --out /opt/kong/kong.yml
+          chmod 0644 /opt/kong/kong.yml
         volumeMounts:
         - name: kong-config
           mountPath: /opt/kong
@@ -114,6 +115,7 @@ spec:
             if render "$tmp_file"; then
               if [ ! -f /opt/kong/kong.yml ] || ! cmp -s "$tmp_file" /opt/kong/kong.yml; then
                 mv "$tmp_file" /opt/kong/kong.yml
+                chmod 0644 /opt/kong/kong.yml
                 http_code=$(curl -s -o /tmp/kong-config-apply.log -w "%{http_code}" -X POST http://127.0.0.1:8001/config -F "config=@/opt/kong/kong.yml") || true
                 echo "Applied Kong config update (HTTP ${http_code:-000})" >&2
               else

--- a/k8s/demo/base/serviceradar-kv.yaml
+++ b/k8s/demo/base/serviceradar-kv.yaml
@@ -41,10 +41,10 @@ spec:
           value: "info"
         resources:
           limits:
-            cpu: "500m"
+            cpu: "2"
             memory: "512Mi"
           requests:
-            cpu: "100m"
+            cpu: "500m"
             memory: "128Mi"
         livenessProbe:
           exec:

--- a/k8s/demo/base/serviceradar-nats.yaml
+++ b/k8s/demo/base/serviceradar-nats.yaml
@@ -36,10 +36,10 @@ spec:
           readOnly: true
         resources:
           limits:
-            cpu: "1"
+            cpu: "2"
             memory: "16Gi"
           requests:
-            cpu: "250m"
+            cpu: "1"
             memory: "8Gi"
         livenessProbe:
           httpGet:


### PR DESCRIPTION
### **User description**
stability fixes


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced NATS stream configuration with retention policies (`max_bytes`, `max_age`)

- Added thread-safe core client access with nil checks in poller

- Increased Kubernetes resource limits for core, KV, and NATS services

- Improved error handling for unavailable core client connections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  poller["Poller Service"] -- "thread-safe access" --> coreClient["Core Client"]
  otel["OTEL Service"] -- "stream config" --> nats["NATS JetStream"]
  nats -- "retention policies" --> stream["Events Stream"]
  k8s["K8s Resources"] -- "increased limits" --> services["Core/KV/NATS"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>poller.go</strong><dd><code>Add thread-safe core client access and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-28a10dea1596540e55ce9a8b68bd1af3d96bd4634f6def668643892cef25a086">+25/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-kong.yaml</strong><dd><code>Add file permissions for Kong configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-e1426b570f5caae8eee31f02984392f1bc68d0c329ae2f1118de3272d654856e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>config.rs</strong><dd><code>Add NATS stream retention configuration fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-abbaec651da3d6af96b482e0f77bb909b65dbe0cabd78b5803769cc9dab0a1b0">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats_output.rs</strong><dd><code>Implement stream retention policy updates and validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-6b585ea3564a481174e04da1270e2e13edd4e2b980d02a2652d6d21e6d82a498">+40/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>entrypoint-db-event-writer.sh</strong><dd><code>Make wait-for service attempts configurable via environment</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-a76a07ca0b18c5d7d9cf0ba3f1a3f9330307be7acd0ca3d7a6be7b67c84f81af">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Add memory limits and CPU constraints to services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.docker.toml</strong><dd><code>Configure NATS stream retention parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-d4af38790e3657b7589cd37a7539d5308b032f11caba7aa740ddc86bf99f4415">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configmap.yaml</strong><dd><code>Remove NATS health check and add retention settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-f4548beaa0a3a01a46971c82c5647a0f3f49eb38d66dd939d06d19018173fcd6">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-core.yaml</strong><dd><code>Increase CPU and memory resource limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-2f484d8fe3bae65aace437568f6dd660c92f57b452f7bd1608083a8fe3716ba3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-kv.yaml</strong><dd><code>Increase CPU resource limits for KV service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-0bedf1050e417709a3d4f2c98946604aa17a974a55dce16fd3447e55bcb80b0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-nats.yaml</strong><dd><code>Increase CPU resource limits for NATS service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1759/files#diff-48984f0444e9f5e0d051d71ee217f64c5dfab202889db4564e6c1a7a6a248b05">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

