### PR TITLE
1768 bugotel inconsistent otel log counts on dashboards

### DIFF
--- a/cmd/core/BUILD.bazel
+++ b/cmd/core/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//alias:swagger",
         "//proto",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//stats",
     ],
 )
 

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -50,8 +50,10 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
+	grpcstats "google.golang.org/grpc/stats"
 
 	"github.com/carverauto/serviceradar/pkg/core"
 	"github.com/carverauto/serviceradar/pkg/core/api"
@@ -260,5 +262,8 @@ func run() error {
 		RegisterGRPCServices: []lifecycle.GRPCServiceRegistrar{registerService},
 		EnableHealthCheck:    true,
 		Security:             cfg.Security,
+		TelemetryFilter: func(info *grpcstats.RPCTagInfo) bool {
+			return !strings.HasPrefix(info.FullMethodName, "/proto.KVService/")
+		},
 	})
 }

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -59,6 +59,7 @@ func main() {
 		Service:           server,
 		EnableHealthCheck: true,
 		Security:          cfg.Security,
+		DisableTelemetry:  true,
 		RegisterGRPCServices: []lifecycle.GRPCServiceRegistrar{
 			func(srv *ggrpc.Server) error {
 				proto.RegisterKVServiceServer(srv, server)

--- a/docker/compose/poller.docker.json
+++ b/docker/compose/poller.docker.json
@@ -70,7 +70,7 @@
                     "service_type": "grpc",
                     "service_name": "sync",
                     "details": "sync:50058",
-                    "results_interval": "30s"
+                    "results_interval": "5m"
                 },
                 {
                     "service_type": "grpc",
@@ -98,7 +98,7 @@
     },
     "core_address": "core:50052",
     "listen_addr": ":50053",
-    "poll_interval": "30s",
+    "poll_interval": "5m",
     "poller_id": "docker-poller",
     "partition": "default",
     "source_ip": "poller",

--- a/docker/compose/poller.docker.json
+++ b/docker/compose/poller.docker.json
@@ -98,7 +98,7 @@
     },
     "core_address": "core:50052",
     "listen_addr": ":50053",
-    "poll_interval": "5m",
+    "poll_interval": "30s",
     "poller_id": "docker-poller",
     "partition": "default",
     "source_ip": "poller",

--- a/docs/docs/rperf-monitoring.md
+++ b/docs/docs/rperf-monitoring.md
@@ -216,7 +216,7 @@ Update `/etc/serviceradar/poller.json` to include the rperf checker:
   },
   "core_address": "localhost:50052",
   "listen_addr": ":50053",
-  "poll_interval": "30s",
+  "poll_interval": "5m",
   "poller_id": "my-poller",
   "service_name": "PollerService",
   "service_type": "grpc",

--- a/docs/docs/tls-security.md
+++ b/docs/docs/tls-security.md
@@ -634,7 +634,7 @@ Update `/etc/serviceradar/poller.json`:
   },
   "core_address": "192.168.2.23:50052",
   "listen_addr": ":50053",
-  "poll_interval": "5m",
+  "poll_interval": "30s",
   "poller_id": "my-poller",
   "service_name": "PollerService",
   "service_type": "grpc",

--- a/docs/docs/tls-security.md
+++ b/docs/docs/tls-security.md
@@ -634,7 +634,7 @@ Update `/etc/serviceradar/poller.json`:
   },
   "core_address": "192.168.2.23:50052",
   "listen_addr": ":50053",
-  "poll_interval": "30s",
+  "poll_interval": "5m",
   "poller_id": "my-poller",
   "service_name": "PollerService",
   "service_type": "grpc",

--- a/k8s/demo/base/configmap.yaml
+++ b/k8s/demo/base/configmap.yaml
@@ -263,7 +263,7 @@ data:
             { "service_type": "grpc",    "service_name": "zen",               "details": "serviceradar-zen:50040" },
             { "service_type": "grpc",    "service_name": "trapd",             "details": "serviceradar-trapd:50043" },
             { "service_type": "grpc",    "service_name": "flowgger",          "details": "serviceradar-flowgger:50044" },
-            { "service_type": "grpc",    "service_name": "sync",              "details": "serviceradar-sync:50058", "results_interval": "30s" },
+            { "service_type": "grpc",    "service_name": "sync",              "details": "serviceradar-sync:50058", "results_interval": "5m" },
             { "service_type": "grpc",    "service_name": "kv",                "details": "serviceradar-kv:50057" }
           ]
         }
@@ -281,7 +281,7 @@ data:
         }
       },
       "listen_addr": ":50053",
-      "poll_interval": "30s",
+      "poll_interval": "5m",
       "poller_id": "k8s-poller",
       "partition": "default",
       "source_ip": "poller",

--- a/k8s/demo/base/configmap.yaml
+++ b/k8s/demo/base/configmap.yaml
@@ -281,7 +281,7 @@ data:
         }
       },
       "listen_addr": ":50053",
-      "poll_interval": "5m",
+      "poll_interval": "30s",
       "poller_id": "k8s-poller",
       "partition": "default",
       "source_ip": "poller",

--- a/k8s/demo/base/serviceradar-core.yaml
+++ b/k8s/demo/base/serviceradar-core.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: serviceradar-core
+  labels:
+    app.kubernetes.io/part-of: serviceradar
 spec:
   replicas: 1
   strategy:
@@ -10,10 +12,12 @@ spec:
   selector:
     matchLabels:
       app: serviceradar-core
+      app.kubernetes.io/part-of: serviceradar
   template:
     metadata:
       labels:
         app: serviceradar-core
+        app.kubernetes.io/part-of: serviceradar
     spec:
       imagePullSecrets:
         - name: ghcr-io-cred
@@ -26,9 +30,32 @@ spec:
         - -c
         - |
           set -e
+          TEMPLATE=/etc/serviceradar/core.json
+          TARGET=/var/lib/serviceradar/core.json
           mkdir -p /var/lib/serviceradar
-          cp /etc/serviceradar/core.json /var/lib/serviceradar/core.json
-          serviceradar-cli generate-jwt-keys --file /var/lib/serviceradar/core.json --bits 2048
+
+          PRESERVE_PRIV=""
+          PRESERVE_KID=""
+          if [ -f "$TARGET" ]; then
+            PRESERVE_PRIV=$(jq -r '.auth.jwt_private_key_pem // empty' "$TARGET")
+            PRESERVE_KID=$(jq -r '.auth.jwt_key_id // empty' "$TARGET")
+          fi
+
+          cp "$TEMPLATE" "${TARGET}.tmp"
+
+          if [ -n "$PRESERVE_PRIV" ]; then
+            jq --arg priv "$PRESERVE_PRIV" --arg kid "$PRESERVE_KID" '
+              .auth = (.auth // {}) |
+              .auth.jwt_algorithm = "RS256" |
+              .auth.jwt_private_key_pem = $priv |
+              (if $kid != "" then .auth.jwt_key_id = $kid else . end)
+            ' "${TARGET}.tmp" > "$TARGET"
+            rm -f "${TARGET}.tmp"
+          else
+            mv "${TARGET}.tmp" "$TARGET"
+          fi
+
+          serviceradar-cli generate-jwt-keys --file "$TARGET" --bits 2048
         volumeMounts:
         - name: serviceradar-config
           mountPath: /etc/serviceradar

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -157,9 +157,10 @@ func setupKVStore(ctx context.Context, cfgLoader *config.Config, cfg *ServerConf
 	}
 
 	clientCfg := grpc.ClientConfig{
-		Address:    cfg.KVAddress,
-		MaxRetries: 3,
-		Logger:     log,
+		Address:          cfg.KVAddress,
+		MaxRetries:       3,
+		Logger:           log,
+		DisableTelemetry: true,
 	}
 
 	securityConfig := cfg.Security

--- a/pkg/config/kv_client.go
+++ b/pkg/config/kv_client.go
@@ -179,6 +179,7 @@ func NewKVServiceClientFromEnv(ctx context.Context, role models.ServiceRole) (pr
 	client, err := coregrpc.NewClient(ctx, coregrpc.ClientConfig{
 		Address:          addr,
 		SecurityProvider: provider,
+		DisableTelemetry: true,
 	})
 	if err != nil {
 		_ = provider.Close()

--- a/pkg/core/api/server.go
+++ b/pkg/core/api/server.go
@@ -72,7 +72,7 @@ func NewAPIServer(config models.CORSConfig, options ...func(server *APIServer)) 
 		if s.kvAddress == "" {
 			return ErrKVAddressNotConfigured
 		}
-		clientCfg := coregrpc.ClientConfig{Address: s.kvAddress, MaxRetries: 3, Logger: s.logger}
+		clientCfg := coregrpc.ClientConfig{Address: s.kvAddress, MaxRetries: 3, Logger: s.logger, DisableTelemetry: true}
 		if s.kvSecurity != nil {
 			sec := *s.kvSecurity
 			sec.Role = models.RolePoller
@@ -98,7 +98,7 @@ func NewAPIServer(config models.CORSConfig, options ...func(server *APIServer)) 
 		if s.kvAddress == "" {
 			return nil, false, ErrKVAddressNotConfigured
 		}
-		clientCfg := coregrpc.ClientConfig{Address: s.kvAddress, MaxRetries: 3, Logger: s.logger}
+		clientCfg := coregrpc.ClientConfig{Address: s.kvAddress, MaxRetries: 3, Logger: s.logger, DisableTelemetry: true}
 		if s.kvSecurity != nil {
 			sec := *s.kvSecurity
 			sec.Role = models.RolePoller
@@ -217,7 +217,7 @@ func (s *APIServer) getKVClient(ctx context.Context, id string) (proto.KVService
 	if ep == nil || ep.Address == "" {
 		return nil, func() {}, ErrKVAddressNotConfigured
 	}
-	clientCfg := coregrpc.ClientConfig{Address: ep.Address, MaxRetries: 3, Logger: s.logger}
+	clientCfg := coregrpc.ClientConfig{Address: ep.Address, MaxRetries: 3, Logger: s.logger, DisableTelemetry: true}
 	var closer func()
 	if ep.Security != nil {
 		sec := *ep.Security

--- a/pkg/core/backfill.go
+++ b/pkg/core/backfill.go
@@ -191,7 +191,7 @@ func buildIdentityRecord(update *models.DeviceUpdate) *identitymap.Record {
 	return &identitymap.Record{
 		CanonicalDeviceID: update.DeviceID,
 		Partition:         update.Partition,
-		MetadataHash:      identitymap.HashMetadata(update.Metadata),
+		MetadataHash:      identitymap.HashIdentityMetadata(update),
 		UpdatedAt:         time.Now().UTC(),
 		Attributes:        buildIdentityAttributes(update),
 	}

--- a/pkg/core/backfill_test.go
+++ b/pkg/core/backfill_test.go
@@ -175,7 +175,17 @@ func TestBackfillIPAliasTombstonesSkipsWhenKVCanonical(t *testing.T) {
 	)
 	mockDB.EXPECT().PublishBatchDeviceUpdates(gomock.Any(), gomock.Any()).Times(0)
 
-	record := &identitymap.Record{CanonicalDeviceID: "default:canonical", Partition: "default", MetadataHash: identitymap.HashMetadata(map[string]string{"armis_device_id": "ARM-1", "all_ips": "10.0.0.2"})}
+	record := &identitymap.Record{
+		CanonicalDeviceID: "default:canonical",
+		Partition:         "default",
+		MetadataHash: identitymap.HashIdentityMetadata(&models.DeviceUpdate{
+			DeviceID:  "default:canonical",
+			Partition: "default",
+			IP:        "10.0.0.1",
+			Source:    models.DiscoverySourceIntegration,
+			Metadata:  map[string]string{"armis_device_id": "ARM-1", "all_ips": "10.0.0.2"},
+		}),
+	}
 	payload, err := identitymap.MarshalRecord(record)
 	require.NoError(t, err)
 

--- a/pkg/core/identity_lookup.go
+++ b/pkg/core/identity_lookup.go
@@ -295,10 +295,29 @@ func buildRecordFromUnifiedDevice(device *models.UnifiedDevice) *identitymap.Rec
 		metadata = device.Metadata.Value
 	}
 
+	update := &models.DeviceUpdate{
+		DeviceID:  device.DeviceID,
+		Partition: partition,
+		IP:        device.IP,
+		Metadata:  metadata,
+	}
+
+	if len(device.DiscoverySources) > 0 {
+		update.Source = device.DiscoverySources[0].Source
+	}
+	if device.Hostname != nil {
+		host := device.Hostname.Value
+		update.Hostname = &host
+	}
+	if device.MAC != nil {
+		mac := device.MAC.Value
+		update.MAC = &mac
+	}
+
 	return &identitymap.Record{
 		CanonicalDeviceID: device.DeviceID,
 		Partition:         partition,
-		MetadataHash:      identitymap.HashMetadata(metadata),
+		MetadataHash:      identitymap.HashIdentityMetadata(update),
 		Attributes:        attrs,
 	}
 }

--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "@org_golang_google_grpc//health/grpc_health_v1",
         "@org_golang_google_grpc//keepalive",
         "@org_golang_google_grpc//reflection",
+        "@org_golang_google_grpc//stats",
         "@org_uber_go_mock//gomock",
     ],
 )

--- a/pkg/identitymap/identitymap.go
+++ b/pkg/identitymap/identitymap.go
@@ -101,6 +101,56 @@ func BuildKeys(update *models.DeviceUpdate) []Key {
 	return keys
 }
 
+// HashIdentityMetadata produces a stable fingerprint of identity-relevant fields for a device update.
+func HashIdentityMetadata(update *models.DeviceUpdate) string {
+	if update == nil {
+		return ""
+	}
+
+	meta := make(map[string]string)
+
+	if id := strings.TrimSpace(update.DeviceID); id != "" {
+		meta["device_id"] = id
+	}
+	if partition := strings.TrimSpace(update.Partition); partition != "" {
+		meta["partition"] = partition
+	}
+	if ip := strings.TrimSpace(update.IP); ip != "" {
+		meta["ip"] = ip
+	}
+	if update.Hostname != nil {
+		if hostname := strings.TrimSpace(*update.Hostname); hostname != "" {
+			meta["hostname"] = hostname
+		}
+	}
+	if update.MAC != nil {
+		if mac := strings.TrimSpace(*update.MAC); mac != "" {
+			meta["mac"] = strings.ToUpper(mac)
+		}
+	}
+	if src := strings.TrimSpace(string(update.Source)); src != "" {
+		meta["source"] = src
+	}
+
+	if update.Metadata != nil {
+		appendMetadata := func(key string) {
+			if val := strings.TrimSpace(update.Metadata[key]); val != "" {
+				meta[key] = val
+			}
+		}
+		appendMetadata("armis_device_id")
+		appendMetadata("integration_id")
+		appendMetadata("integration_type")
+		appendMetadata("netbox_device_id")
+	}
+
+	if len(meta) == 0 {
+		return ""
+	}
+
+	return HashMetadata(meta)
+}
+
 func partitionIPValue(partition, ip string) string {
 	partition = strings.TrimSpace(partition)
 	ip = strings.TrimSpace(ip)

--- a/pkg/identitymap/identitymap_test.go
+++ b/pkg/identitymap/identitymap_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/carverauto/serviceradar/pkg/models"
 )
 
+const testMACAddress = "aa:bb:cc:dd:ee:ff"
+
 func TestBuildKeys(t *testing.T) {
-	mac := "aa:bb:cc:dd:ee:ff"
+	mac := testMACAddress
 	update := &models.DeviceUpdate{
 		DeviceID:  "tenant-a:1.2.3.4",
 		IP:        "1.2.3.4",
@@ -45,7 +47,7 @@ func TestBuildKeysNil(t *testing.T) {
 }
 
 func TestBuildKeysIncludesIPWhenDistinct(t *testing.T) {
-	mac := "aa:bb:cc:dd:ee:ff"
+	mac := testMACAddress
 	update := &models.DeviceUpdate{
 		DeviceID:  "device-123",
 		IP:        "10.0.0.5",
@@ -146,7 +148,7 @@ func TestSanitizeKeyPath(t *testing.T) {
 
 func TestHashIdentityMetadataIgnoresNoise(t *testing.T) {
 	host := "sensor01"
-	mac := "aa:bb:cc:dd:ee:ff"
+	mac := testMACAddress
 	update := &models.DeviceUpdate{
 		DeviceID:  "tenant-a:1.2.3.4",
 		IP:        "1.2.3.4",

--- a/pkg/lifecycle/server.go
+++ b/pkg/lifecycle/server.go
@@ -66,6 +66,8 @@ type ServerOptions struct {
 	Security             *models.SecurityConfig
 	LoggerConfig         *logger.Config
 	Logger               logger.Logger // Optional: if provided, uses this logger instead of creating a new one
+	DisableTelemetry     bool
+	TelemetryFilter      grpc.TelemetryFilter
 }
 
 // RunServer starts a service with the provided options and handles lifecycle.
@@ -136,6 +138,14 @@ func setupGRPCServer(ctx context.Context, opts *ServerOptions, log logger.Logger
 	serverOpts, err := configureServerOptions(ctx, securityProvider, log)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.DisableTelemetry {
+		serverOpts = append(serverOpts, grpc.WithTelemetryDisabled())
+	}
+
+	if opts.TelemetryFilter != nil {
+		serverOpts = append(serverOpts, grpc.WithTelemetryFilter(opts.TelemetryFilter))
 	}
 
 	grpcServer := grpc.NewServer(opts.ListenAddr, log, serverOpts...)

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -32,14 +32,14 @@ var (
 )
 
 const (
-	pollDefaultInterval = 30 * time.Second
+	defaultPollInterval = 5 * time.Minute
 )
 
 // AgentConfig represents configuration for a single agent.
 type AgentConfig struct {
-    Address  string                 `json:"address" hot:"rebuild"`
-    Checks   []Check                `json:"checks" hot:"rebuild"`
-    Security *models.SecurityConfig `json:"security" hot:"rebuild"` // Per-agent security config
+	Address  string                 `json:"address" hot:"rebuild"`
+	Checks   []Check                `json:"checks" hot:"rebuild"`
+	Security *models.SecurityConfig `json:"security" hot:"rebuild"` // Per-agent security config
 }
 
 // Check represents a service check configuration.
@@ -53,18 +53,18 @@ type Check struct {
 
 // Config represents poller configuration.
 type Config struct {
-    Agents       map[string]AgentConfig `json:"agents" hot:"rebuild"`
-    ListenAddr   string                 `json:"listen_addr"`
-    ServiceName  string                 `json:"service_name"`
-    CoreAddress  string                 `json:"core_address" hot:"rebuild"`
-    PollInterval models.Duration        `json:"poll_interval" hot:"reload"`
-    PollerID     string                 `json:"poller_id"`
-    Partition    string                 `json:"partition"`
-    SourceIP     string                 `json:"source_ip"`
-    Security     *models.SecurityConfig `json:"security" hot:"rebuild"`
-    Logging      *logger.Config         `json:"logging,omitempty"` // Logger configuration
-    KVAddress    string                 `json:"kv_address,omitempty"` // Optional KV store address (deprecated for ID/domain)
-    KVDomain     string                 `json:"kv_domain,omitempty"`  // JetStream domain for KV (e.g., "hub", "leaf-001")
+	Agents       map[string]AgentConfig `json:"agents" hot:"rebuild"`
+	ListenAddr   string                 `json:"listen_addr"`
+	ServiceName  string                 `json:"service_name"`
+	CoreAddress  string                 `json:"core_address" hot:"rebuild"`
+	PollInterval models.Duration        `json:"poll_interval" hot:"reload"`
+	PollerID     string                 `json:"poller_id"`
+	Partition    string                 `json:"partition"`
+	SourceIP     string                 `json:"source_ip"`
+	Security     *models.SecurityConfig `json:"security" hot:"rebuild"`
+	Logging      *logger.Config         `json:"logging,omitempty"`    // Logger configuration
+	KVAddress    string                 `json:"kv_address,omitempty"` // Optional KV store address (deprecated for ID/domain)
+	KVDomain     string                 `json:"kv_domain,omitempty"`  // JetStream domain for KV (e.g., "hub", "leaf-001")
 }
 
 // Validate implements config.Validator interface.
@@ -92,7 +92,7 @@ func (c *Config) Validate() error {
 	// Compare PollInterval to zero by casting to time.Duration
 	if time.Duration(c.PollInterval) == 0 {
 		// Construct a config.Duration from a time.Duration
-		c.PollInterval = models.Duration(pollDefaultInterval)
+		c.PollInterval = models.Duration(defaultPollInterval)
 	}
 
 	return nil

--- a/pkg/poller/config_test.go
+++ b/pkg/poller/config_test.go
@@ -187,7 +187,7 @@ func TestConfig_ValidateWithAllFields(t *testing.T) {
 		CoreAddress:  "localhost:50052",
 		ListenAddr:   ":50053",
 		ServiceName:  "PollerService",
-		PollInterval: models.Duration(5 * time.Minute),
+		PollInterval: models.Duration(30 * time.Second),
 		PollerID:     "test-poller",
 		Partition:    "default",
 		SourceIP:     "192.168.1.1",

--- a/pkg/poller/config_test.go
+++ b/pkg/poller/config_test.go
@@ -187,7 +187,7 @@ func TestConfig_ValidateWithAllFields(t *testing.T) {
 		CoreAddress:  "localhost:50052",
 		ListenAddr:   ":50053",
 		ServiceName:  "PollerService",
-		PollInterval: models.Duration(30 * time.Second),
+		PollInterval: models.Duration(5 * time.Minute),
 		PollerID:     "test-poller",
 		Partition:    "default",
 		SourceIP:     "192.168.1.1",

--- a/pkg/registry/identity_publisher.go
+++ b/pkg/registry/identity_publisher.go
@@ -108,7 +108,7 @@ func (c *identityCache) get(key string) *identityCacheEntry {
 
 	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
 		c.mu.Lock()
-		if current, ok := c.entries[key]; ok && current.expiresAt == entry.expiresAt {
+		if current, ok := c.entries[key]; ok && current.expiresAt.Equal(entry.expiresAt) {
 			delete(c.entries, key)
 		}
 		c.mu.Unlock()

--- a/pkg/registry/identity_publisher.go
+++ b/pkg/registry/identity_publisher.go
@@ -318,8 +318,8 @@ func (p *identityPublisher) upsertIdentity(ctx context.Context, key string, payl
 		p.metrics.recordPublish(1)
 		identitymap.RecordKVPublish(ctx, 1, "updated")
 		p.logger.Debug().Str("key", key).Msg("Updated canonical identity entry in KV")
-		newRevision := resp.GetRevision()
-		if updateResp != nil && updateResp.GetRevision() != 0 {
+		var newRevision uint64
+		if updateResp != nil {
 			newRevision = updateResp.GetRevision()
 		}
 		p.cache.set(key, metadataHash, attrsHash, newRevision)

--- a/pkg/registry/identity_publisher_revision_bug_test.go
+++ b/pkg/registry/identity_publisher_revision_bug_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/carverauto/serviceradar/pkg/identitymap"
+	"github.com/carverauto/serviceradar/pkg/logger"
+	"github.com/carverauto/serviceradar/pkg/models"
+)
+
+// This regression test ensures we do not cache a stale revision when the KV Update
+// RPC omits a revision in its response.
+func TestIdentityPublisherCachesStaleRevisionWithoutUpdateResponse(t *testing.T) {
+	t.Parallel()
+
+	kvClient := newFakeIdentityKVClient()
+	pub := newIdentityPublisher(kvClient, identitymap.DefaultNamespace, 0, logger.NewTestLogger())
+
+	key := identitymap.Key{Kind: identitymap.KindDeviceID, Value: "device-revision"}.KeyPath(identitymap.DefaultNamespace)
+
+	existingRecord := &identitymap.Record{
+		CanonicalDeviceID: "device-revision",
+		MetadataHash: identitymap.HashIdentityMetadata(&models.DeviceUpdate{
+			DeviceID: "device-revision",
+			Metadata: map[string]string{"armis_device_id": "armis-old"},
+		}),
+		Attributes: map[string]string{"armis_device_id": "armis-old"},
+	}
+
+	payload, err := identitymap.MarshalRecord(existingRecord)
+	require.NoError(t, err)
+
+	kvClient.entries[key] = &fakeKVEntry{value: payload, revision: 1}
+	kvClient.omitUpdateResp[key] = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	first := &models.DeviceUpdate{
+		DeviceID: "device-revision",
+		Metadata: map[string]string{"armis_device_id": "armis-new"},
+	}
+	require.NoError(t, pub.Publish(ctx, []*models.DeviceUpdate{first}))
+
+	second := &models.DeviceUpdate{
+		DeviceID: "device-revision",
+		Metadata: map[string]string{"armis_device_id": "armis-newer"},
+	}
+	require.NoError(t, pub.Publish(ctx, []*models.DeviceUpdate{second}))
+
+	require.Zero(t, kvClient.revisionMiss[key], "unexpected revision mismatch: stale revision cached after Update without response")
+}

--- a/pkg/registry/identity_publisher_test.go
+++ b/pkg/registry/identity_publisher_test.go
@@ -114,7 +114,7 @@ func TestIdentityPublisherPublishesNewEntries(t *testing.T) {
 		record, err := identitymap.UnmarshalRecord(entry.value)
 		require.NoError(t, err)
 		require.Equal(t, update.DeviceID, record.CanonicalDeviceID)
-		require.Equal(t, identitymap.HashMetadata(update.Metadata), record.MetadataHash)
+		require.Equal(t, identitymap.HashIdentityMetadata(update), record.MetadataHash)
 		require.Equal(t, "armis-1", record.Attributes["armis_device_id"])
 	}
 }
@@ -173,7 +173,7 @@ func TestIdentityPublisherRetriesOnCASConflict(t *testing.T) {
 	require.Equal(t, uint64(2), entry.revision)
 	record, err := identitymap.UnmarshalRecord(entry.value)
 	require.NoError(t, err)
-	require.Equal(t, identitymap.HashMetadata(updated.Metadata), record.MetadataHash)
+	require.Equal(t, identitymap.HashIdentityMetadata(updated), record.MetadataHash)
 }
 
 func TestIdentityPublisherUpdatesWhenAttributesChange(t *testing.T) {
@@ -185,8 +185,11 @@ func TestIdentityPublisherUpdatesWhenAttributesChange(t *testing.T) {
 	metadata := map[string]string{"armis_device_id": "armis-attr"}
 	initialRecord := &identitymap.Record{
 		CanonicalDeviceID: "device-attr",
-		MetadataHash:      identitymap.HashMetadata(metadata),
-		Attributes:        map[string]string{},
+		MetadataHash: identitymap.HashIdentityMetadata(&models.DeviceUpdate{
+			DeviceID: "device-attr",
+			Metadata: metadata,
+		}),
+		Attributes: map[string]string{},
 	}
 	payload, err := identitymap.MarshalRecord(initialRecord)
 	require.NoError(t, err)

--- a/pkg/sync/config.go
+++ b/pkg/sync/config.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultTimeout = 30 * time.Second
+	defaultPollInterval = 5 * time.Minute
 )
 
 var (
@@ -38,16 +38,16 @@ var (
 
 // Config defines the configuration for the sync service including sources, logging, and OTEL settings.
 type Config struct {
-    Sources           map[string]*models.SourceConfig `json:"sources" hot:"rebuild"`            // integration configs
-    KVAddress         string                          `json:"kv_address"`                                 // KV gRPC server address (optional)
-    ListenAddr        string                          `json:"listen_addr"`                                // gRPC listen address
-    PollInterval      models.Duration                 `json:"poll_interval" hot:"reload"`      // Polling interval
-    DiscoveryInterval models.Duration                 `json:"discovery_interval" hot:"reload"` // Fetch cadence
-    UpdateInterval    models.Duration                 `json:"update_interval" hot:"reload"`    // External update cadence
-    AgentID           string                          `json:"agent_id"`
-    PollerID          string                          `json:"poller_id"`
-    Security          *models.SecurityConfig          `json:"security" hot:"rebuild"`
-    Logging           *logger.Config                  `json:"logging"`
+	Sources           map[string]*models.SourceConfig `json:"sources" hot:"rebuild"`           // integration configs
+	KVAddress         string                          `json:"kv_address"`                      // KV gRPC server address (optional)
+	ListenAddr        string                          `json:"listen_addr"`                     // gRPC listen address
+	PollInterval      models.Duration                 `json:"poll_interval" hot:"reload"`      // Polling interval
+	DiscoveryInterval models.Duration                 `json:"discovery_interval" hot:"reload"` // Fetch cadence
+	UpdateInterval    models.Duration                 `json:"update_interval" hot:"reload"`    // External update cadence
+	AgentID           string                          `json:"agent_id"`
+	PollerID          string                          `json:"poller_id"`
+	Security          *models.SecurityConfig          `json:"security" hot:"rebuild"`
+	Logging           *logger.Config                  `json:"logging"`
 }
 
 func (c *Config) Validate() error {
@@ -60,7 +60,7 @@ func (c *Config) Validate() error {
 	}
 
 	if time.Duration(c.PollInterval) == 0 {
-		c.PollInterval = models.Duration(defaultTimeout)
+		c.PollInterval = models.Duration(defaultPollInterval)
 	}
 
 	if time.Duration(c.DiscoveryInterval) == 0 {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -139,9 +139,10 @@ func setupGRPCClient(ctx context.Context, config *Config, log logger.Logger) (pr
 	}
 
 	clientCfg := ggrpc.ClientConfig{
-		Address:    config.KVAddress,
-		MaxRetries: 3,
-		Logger:     log,
+		Address:          config.KVAddress,
+		MaxRetries:       3,
+		Logger:           log,
+		DisableTelemetry: true,
 	}
 
 	if config.Security != nil {

--- a/scripts/reset-proton.sh
+++ b/scripts/reset-proton.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Reset the Proton Timeplus datastore by rotating its PVC and restarting core.
+# Usage:
+#   scripts/reset-proton.sh [namespace]
+# Environment overrides:
+#   KUBECTL        Path to kubectl (default: kubectl)
+#   PVC_NAME       Proton PVC name (default: serviceradar-proton-data)
+#   DEPLOY_NAME    Proton deployment (default: serviceradar-proton)
+#   CORE_DEPLOY    Core deployment (default: serviceradar-core)
+#   STORAGE_CLASS  StorageClass for the replacement PVC (default: local-path)
+#   PVC_SIZE       Requested storage size (default: 512Gi)
+
+set -euo pipefail
+
+ns="${1:-demo}"
+kubectl_bin="${KUBECTL:-kubectl}"
+pvc_name="${PVC_NAME:-serviceradar-proton-data}"
+deploy_name="${DEPLOY_NAME:-serviceradar-proton}"
+core_deploy="${CORE_DEPLOY:-serviceradar-core}"
+storage_class="${STORAGE_CLASS:-local-path}"
+pvc_size="${PVC_SIZE:-512Gi}"
+
+log() {
+  printf '[reset-proton] %s\n' "$*"
+}
+
+run_kubectl() {
+  "${kubectl_bin}" -n "${ns}" "$@"
+}
+
+log "Scaling ${deploy_name} to 0"
+run_kubectl scale deployment/"${deploy_name}" --replicas=0
+run_kubectl rollout status deployment/"${deploy_name}" --timeout=5m
+
+log "Deleting PVC ${pvc_name}"
+run_kubectl delete pvc "${pvc_name}" --ignore-not-found --wait=true
+
+log "Recreating PVC ${pvc_name} (${pvc_size}, storageClass=${storage_class})"
+cat <<EOF | "${kubectl_bin}" apply -n "${ns}" -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc_name}
+  labels:
+    app.kubernetes.io/part-of: serviceradar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${pvc_size}
+  storageClassName: ${storage_class}
+EOF
+
+log "Scaling ${deploy_name} back to 1"
+run_kubectl scale deployment/"${deploy_name}" --replicas=1
+run_kubectl rollout status deployment/"${deploy_name}" --timeout=5m
+
+log "Restarting ${core_deploy} to rebuild Proton schema"
+run_kubectl rollout restart deployment/"${core_deploy}"
+run_kubectl rollout status deployment/"${core_deploy}" --timeout=5m
+
+log "Reset complete. Consider checking OTEL counts via proton-client or /api/query."

--- a/web/src/components/Analytics/ObservabilityWidget.tsx
+++ b/web/src/components/Analytics/ObservabilityWidget.tsx
@@ -43,9 +43,9 @@ const ObservabilityWidget = () => {
         }
 
         const totalMetrics = analyticsData.totalMetrics;
-        const totalErrors = analyticsData.errorMetrics;
+        const errorTraces = analyticsData.errorTraces;
         const totalTraces = analyticsData.totalTraces;
-        const slowSpans = analyticsData.slowMetrics;
+        const slowSpans = analyticsData.slowTraces;
         
         // Calculate average duration - for now use 0, can be enhanced later
         const avgDuration = 0;
@@ -54,7 +54,7 @@ const ObservabilityWidget = () => {
             totalMetrics,
             totalTraces,
             avgDuration,
-            errorRate: totalMetrics > 0 ? totalErrors / totalMetrics : 0,
+            errorRate: totalTraces > 0 ? errorTraces / totalTraces : 0,
             slowSpans
         };
 

--- a/web/src/components/Analytics/ObservabilityWidget.tsx
+++ b/web/src/components/Analytics/ObservabilityWidget.tsx
@@ -21,6 +21,7 @@ import { useAnalytics } from '@/contexts/AnalyticsContext';
 import { BarChart3, TrendingUp, Clock, Activity, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { formatNumber, formatDuration, formatPercentage } from '@/utils/formatters';
+import { useTraceCounts } from '@/hooks/useTraceCounts';
 
 
 interface SlowSpan {
@@ -32,38 +33,49 @@ interface SlowSpan {
 }
 
 const ObservabilityWidget = () => {
-    const { data: analyticsData, loading, error } = useAnalytics();
-    
-    const { stats, recentSlowSpans } = useMemo(() => {
-        if (!analyticsData) {
-            return {
-                stats: { totalMetrics: 0, totalTraces: 0, avgDuration: 0, errorRate: 0, slowSpans: 0 },
-                recentSlowSpans: []
-            };
-        }
+    const {
+        data: analyticsData,
+        loading: analyticsLoading,
+        error: analyticsError,
+    } = useAnalytics();
+    const {
+        counts: traceCounts,
+        loading: traceCountsLoading,
+        error: traceCountsError,
+    } = useTraceCounts();
 
-        const totalMetrics = analyticsData.totalMetrics;
-        const errorTraces = analyticsData.errorTraces;
-        const totalTraces = analyticsData.totalTraces;
-        const slowSpans = analyticsData.slowTraces;
-        
-        // Calculate average duration - for now use 0, can be enhanced later
-        const avgDuration = 0;
-        
-        const stats = {
+    const stats = useMemo(() => {
+        const totalMetrics = analyticsData?.totalMetrics ?? 0;
+        const totalTraces =
+            traceCounts.total !== undefined
+                ? traceCounts.total
+                : analyticsData?.totalTraces ?? 0;
+        const errorTraces =
+            traceCounts.errors !== undefined
+                ? traceCounts.errors
+                : analyticsData?.errorTraces ?? 0;
+        const slowSpans =
+            traceCounts.slow !== undefined
+                ? traceCounts.slow
+                : analyticsData?.slowTraces ?? 0;
+
+        const avgDuration = 0; // Placeholder until we add latency aggregates
+
+        return {
             totalMetrics,
             totalTraces,
             avgDuration,
             errorRate: totalTraces > 0 ? errorTraces / totalTraces : 0,
-            slowSpans
+            slowSpans,
         };
+    }, [analyticsData, traceCounts.errors, traceCounts.slow, traceCounts.total]);
 
-        const recentSlowSpans = (analyticsData.recentSlowSpans as SlowSpan[] || []).slice(0, 3);
-        
-        return { stats, recentSlowSpans };
+    const recentSlowSpans = useMemo(() => {
+        const spans = (analyticsData?.recentSlowSpans as SlowSpan[] | undefined) ?? [];
+        return spans.slice(0, 3);
     }, [analyticsData]);
 
-    if (loading) {
+    if (analyticsLoading || traceCountsLoading) {
         return (
             <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4 flex flex-col h-[320px]">
                 <div className="flex justify-between items-start mb-4">
@@ -76,7 +88,7 @@ const ObservabilityWidget = () => {
         );
     }
 
-    if (error) {
+    if (analyticsError || traceCountsError) {
         return (
             <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg p-4 flex flex-col h-[320px]">
                 <div className="flex justify-between items-start mb-4">
@@ -86,6 +98,11 @@ const ObservabilityWidget = () => {
                     <div className="text-center text-red-500 dark:text-red-400">
                         <Activity className="h-8 w-8 mx-auto mb-2" />
                         <p className="text-sm">Failed to load observability data</p>
+                        {(traceCountsError || analyticsError) && (
+                            <p className="text-xs mt-1 text-red-400 dark:text-red-300">
+                                {(traceCountsError || analyticsError) as string}
+                            </p>
+                        )}
                     </div>
                 </div>
             </div>

--- a/web/src/contexts/AnalyticsContext.tsx
+++ b/web/src/contexts/AnalyticsContext.tsx
@@ -39,8 +39,8 @@ interface AnalyticsData {
   recentErrorLogs: unknown[];
   totalMetrics: number;
   totalTraces: number;
-  slowMetrics: number;
-  errorMetrics: number;
+  slowTraces: number;
+  errorTraces: number;
   recentSlowSpans: unknown[];
   devicesLatest: unknown[];
   servicesLatest: unknown[];

--- a/web/src/hooks/useTraceCounts.ts
+++ b/web/src/hooks/useTraceCounts.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared hook for fetching trace count aggregates so analytics dashboard
+ * widgets and the observability experience stay consistent.
+ */
+
+'use client';
+
+import { useAuth } from '@/components/AuthProvider';
+import { cachedQuery } from '@/lib/cached-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const TRACE_TOTAL_QUERY =
+    'in:otel_trace_summaries stats:"count() as total" sort:total:desc time:last_24h';
+const TRACE_SUCCESS_QUERY =
+    'in:otel_trace_summaries status_code:1 stats:"count() as total" sort:total:desc time:last_24h';
+const TRACE_ERROR_QUERY =
+    'in:otel_trace_summaries status_code!=1 stats:"count() as total" sort:total:desc time:last_24h';
+const TRACE_SLOW_QUERY =
+    'in:otel_trace_summaries duration_ms>100 stats:"count() as total" sort:total:desc time:last_24h';
+
+export interface TraceCounts {
+    total: number;
+    successful: number;
+    errors: number;
+    slow: number;
+}
+
+interface UseTraceCountsOptions {
+    refreshInterval?: number;
+    ttl?: number;
+}
+
+const DEFAULT_REFRESH_INTERVAL = 30000; // 30 seconds
+
+export const useTraceCounts = (
+    { refreshInterval = DEFAULT_REFRESH_INTERVAL, ttl }: UseTraceCountsOptions = {}
+) => {
+    const { token } = useAuth();
+    const [counts, setCounts] = useState<TraceCounts>({
+        total: 0,
+        successful: 0,
+        errors: 0,
+        slow: 0,
+    });
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [hasFetched, setHasFetched] = useState(false);
+
+    const authToken = token || undefined;
+    const queryTtl = ttl ?? DEFAULT_REFRESH_INTERVAL;
+
+    const executeQueries = useCallback(async () => {
+        if (!hasFetched) {
+            setLoading(true);
+        }
+
+        try {
+            const [totalRes, successRes, errorRes, slowRes] = await Promise.all([
+                cachedQuery<{ results: Array<{ total?: number }> }>(
+                    TRACE_TOTAL_QUERY,
+                    authToken,
+                    queryTtl
+                ),
+                cachedQuery<{ results: Array<{ total?: number }> }>(
+                    TRACE_SUCCESS_QUERY,
+                    authToken,
+                    queryTtl
+                ),
+                cachedQuery<{ results: Array<{ total?: number }> }>(
+                    TRACE_ERROR_QUERY,
+                    authToken,
+                    queryTtl
+                ),
+                cachedQuery<{ results: Array<{ total?: number }> }>(
+                    TRACE_SLOW_QUERY,
+                    authToken,
+                    queryTtl
+                ),
+            ]);
+
+            setCounts({
+                total: totalRes.results?.[0]?.total ?? 0,
+                successful: successRes.results?.[0]?.total ?? 0,
+                errors: errorRes.results?.[0]?.total ?? 0,
+                slow: slowRes.results?.[0]?.total ?? 0,
+            });
+            setError(null);
+        } catch (err) {
+            const message =
+                err instanceof Error ? err.message : 'Failed to fetch trace counts';
+            setError(message);
+            console.error('[useTraceCounts] Unable to fetch trace aggregates:', err);
+        } finally {
+            setHasFetched(true);
+            setLoading(false);
+        }
+    }, [authToken, hasFetched, queryTtl]);
+
+    useEffect(() => {
+        executeQueries();
+    }, [executeQueries]);
+
+    useEffect(() => {
+        if (!refreshInterval) {
+            return;
+        }
+
+        const intervalId = setInterval(executeQueries, refreshInterval);
+        return () => clearInterval(intervalId);
+    }, [executeQueries, refreshInterval]);
+
+    return useMemo(
+        () => ({
+            counts,
+            loading,
+            error,
+            refresh: executeQueries,
+        }),
+        [counts, error, executeQueries, loading]
+    );
+};
+

--- a/web/src/services/analyticsService.ts
+++ b/web/src/services/analyticsService.ts
@@ -40,8 +40,8 @@ export interface AnalyticsData {
   // Observability stats
   totalMetrics: number;
   totalTraces: number;
-  slowMetrics: number;
-  errorMetrics: number;
+  slowTraces: number;
+  errorTraces: number;
   recentSlowSpans: unknown[];
   
   // Device data for widgets
@@ -142,10 +142,10 @@ class AnalyticsService {
       'in:logs severity_text:debug stats:"count() as total" sort:total:desc time:last_24h',
       'in:logs severity_text:(fatal,error) time:last_24h sort:timestamp:desc limit:100',
       'in:otel_metrics stats:"count() as total" sort:total:desc time:last_24h',
-      'in:otel_traces stats:"count() as total" sort:total:desc time:last_24h',
-      'in:otel_metrics is_slow:true stats:"count() as total" sort:total:desc time:last_24h',
-      'in:otel_metrics http_status_code:[400,] stats:"count() as total" sort:total:desc time:last_24h',
-      'in:otel_metrics is_slow:true time:last_24h sort:timestamp:desc limit:100',
+      'in:otel_trace_summaries stats:"count() as total" sort:total:desc time:last_24h',
+      'in:otel_trace_summaries status_code!=1 stats:"count() as total" sort:total:desc time:last_24h',
+      'in:otel_trace_summaries duration_ms>100 stats:"count() as total" sort:total:desc time:last_24h',
+      'in:otel_trace_summaries time:last_24h sort:duration_ms:desc limit:100',
       `in:devices time:[${last7DaysIso},] sort:last_seen:desc limit:100`,
       'in:services sort:timestamp:desc limit:200'
     ];
@@ -188,7 +188,7 @@ class AnalyticsService {
       highEventsRes, mediumEventsRes, lowEventsRes, recentCriticalEventsRes,
       totalLogsRes, fatalLogsRes, errorLogsRes, warningLogsRes, infoLogsRes,
       debugLogsRes, recentErrorLogsRes, totalMetricsRes, totalTracesRes,
-      slowMetricsRes, errorMetricsRes, recentSlowSpansRes, devicesLatestRes, servicesLatestRes
+      errorTracesRes, slowTracesRes, slowTraceListRes, devicesLatestRes, servicesLatestRes
     ] = queryResults;
 
     const totalDevices = totalDevicesRes.results[0]?.total || 0;
@@ -220,9 +220,15 @@ class AnalyticsService {
       // Observability stats
       totalMetrics: totalMetricsRes.results[0]?.total || 0,
       totalTraces: totalTracesRes.results[0]?.total || 0,
-      slowMetrics: slowMetricsRes.results[0]?.total || 0,
-      errorMetrics: errorMetricsRes.results[0]?.total || 0,
-      recentSlowSpans: (recentSlowSpansRes.results || []).slice(0, 5),
+      slowTraces: slowTracesRes.results[0]?.total || 0,
+      errorTraces: errorTracesRes.results[0]?.total || 0,
+      recentSlowSpans: (slowTraceListRes.results || []).slice(0, 5).map((trace: any) => ({
+        trace_id: trace.trace_id,
+        service_name: trace.root_service_name || trace.service_name || 'Unknown Service',
+        span_name: trace.root_span_name || 'Root Span',
+        duration_ms: trace.duration_ms || 0,
+        timestamp: trace.timestamp || trace.start_time_unix_nano || null,
+      })),
       
       // Raw data for widgets
       devicesLatest: devicesLatestRes.results || [],
@@ -236,7 +242,7 @@ class AnalyticsService {
       totalDevices: 0, offlineDevices: 0, onlineDevices: 0,
       totalEvents: 0, criticalEvents: 0, highEvents: 0, mediumEvents: 0, lowEvents: 0, recentCriticalEvents: [],
       totalLogs: 0, fatalLogs: 0, errorLogs: 0, warningLogs: 0, infoLogs: 0, debugLogs: 0, recentErrorLogs: [],
-      totalMetrics: 0, totalTraces: 0, slowMetrics: 0, errorMetrics: 0, recentSlowSpans: [],
+      totalMetrics: 0, totalTraces: 0, slowTraces: 0, errorTraces: 0, recentSlowSpans: [],
       devicesLatest: [], servicesLatest: [], pollers: []
     };
   }

--- a/web/src/services/analyticsService.ts
+++ b/web/src/services/analyticsService.ts
@@ -42,7 +42,7 @@ export interface AnalyticsData {
   totalTraces: number;
   slowTraces: number;
   errorTraces: number;
-  recentSlowSpans: unknown[];
+  recentSlowSpans: RecentSlowSpan[];
   
   // Device data for widgets
   devicesLatest: unknown[];
@@ -56,6 +56,24 @@ interface CachedAnalyticsData {
   data: AnalyticsData;
   timestamp: number;
   promise?: Promise<AnalyticsData>;
+}
+
+interface SlowTraceResult {
+  trace_id?: string;
+  root_service_name?: string;
+  service_name?: string;
+  root_span_name?: string;
+  duration_ms?: number;
+  timestamp?: string;
+  start_time_unix_nano?: string | number;
+}
+
+interface RecentSlowSpan {
+  trace_id: string;
+  service_name: string;
+  span_name: string;
+  duration_ms: number;
+  timestamp: string | number | null;
 }
 
 class AnalyticsService {
@@ -222,8 +240,8 @@ class AnalyticsService {
       totalTraces: totalTracesRes.results[0]?.total || 0,
       slowTraces: slowTracesRes.results[0]?.total || 0,
       errorTraces: errorTracesRes.results[0]?.total || 0,
-      recentSlowSpans: (slowTraceListRes.results || []).slice(0, 5).map((trace: any) => ({
-        trace_id: trace.trace_id,
+      recentSlowSpans: (slowTraceListRes.results || []).slice(0, 5).map((trace: SlowTraceResult): RecentSlowSpan => ({
+        trace_id: trace.trace_id ?? 'unknown_trace',
         service_name: trace.root_service_name || trace.service_name || 'Unknown Service',
         span_name: trace.root_span_name || 'Root Span',
         duration_ms: trace.duration_ms || 0,


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Disabled OpenTelemetry tracing for KV service calls to reduce telemetry noise

- Fixed trace count queries to use `otel_trace_summaries` instead of `otel_traces`

- Added identity metadata caching to reduce redundant KV writes

- Changed default poll intervals from 30s to 5m across services


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Disable KV telemetry"] --> B["Update trace queries"]
  B --> C["Add identity cache"]
  C --> D["Increase poll intervals"]
  D --> E["Reduce OTEL noise"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Add telemetry filter to exclude KV service RPCs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-4ab3fd1d4debc53dd2499d94a0f60c648fdae4235dd1e3678095a975f5bb434a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong><dd><code>Disable telemetry for KV server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-a1a2df15ecc88de7f8a4832cc2d06fa0ec6c6d32112c8c718d420f91c71d2e8c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Disable telemetry for KV client connections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-3c51e5356a25859a3300ab62ed2494462feb2567ef69e6db3aa2bbc1032c1c5d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kv_client.go</strong><dd><code>Disable telemetry in KV client factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-0c911990aa32d43404f0f23dadc0363ec97ed4ca315592e6c9bd24510e82e06d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Disable telemetry for API server KV clients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-1bb99367fdd853c728b7cfbf5893a293f6d217144dfb5282cb8dd32e5261021e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client.go</strong><dd><code>Add DisableTelemetry option to client config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-fd9886430687bce681e21ea8ea209148b7a46bfc29023f2af6cd9509a28bb208">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Add telemetry filter and disable options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-af62cb3a3a7c777bd1b8feed18657c3ecae951d2dbdea55527f08c8c67967c71">+50/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>identitymap.go</strong><dd><code>Add HashIdentityMetadata for stable identity fingerprints</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-a65f0769de3a5f025da1654d9545c7d3c43da843b3c608d96958893766f8ab8e">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.go</strong><dd><code>Wire telemetry options through server lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-77964f1432d665b19a8f5c81976f787a3c745da1ee2cfffdd0aedc7ee3956df1">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity_publisher.go</strong><dd><code>Add identity cache to reduce redundant KV writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-e851df98fc8e7a63419a9e8ea29bebf3c143028ceadb549b35e9c1eb130fd1a1">+132/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sync.go</strong><dd><code>Disable telemetry for sync KV client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6bef">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useTraceCounts.ts</strong><dd><code>Add shared hook for trace count aggregates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-61c65c2d6cd0d743a6575ad656f2a5bc352c4415e5447f804be0ebb1e9195a34">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Skip metrics export for fast spans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-8295e6c8105718065b7c8b401cee9efc20e2eb5010b2e1f8d91afe670498e2f7">+23/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reset-proton.sh</strong><dd><code>Add script to reset Proton PVC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-79e29e485b3489c3a44e185dfc5525abc2ddac5205cb02d5dcb056279cd3fb7f">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ObservabilityWidget.tsx</strong><dd><code>Use useTraceCounts hook for trace statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-469ba40fa407e64ef80f447276989d9bb7891322da5dcb57549ea99a2d5a01d6">+44/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TracesDashboard.tsx</strong><dd><code>Integrate useTraceCounts hook in traces dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-2ef490885a0b6e53d3fa243395f8209914ac8d955dca43333cb1f59c6eeb3d48">+47/-38</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>backfill.go</strong><dd><code>Use HashIdentityMetadata for identity record hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-d7d2f4aea42bb0d5c5c3439c6d4c27f27ce935961e8a5479203c67e958a10345">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity_lookup.go</strong><dd><code>Build full DeviceUpdate for identity hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-419c60961080aa9e36a729e3a0f5b489b4dc6af0871d23c57d2817e1c0795741">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analyticsService.ts</strong><dd><code>Fix trace queries to use otel_trace_summaries table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-1140b7ee45921b9100c38a5330d66377a73258a776733b422d4689dc4ce282c5">+17/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-core.yaml</strong><dd><code>Preserve JWT keys across core restarts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-2f484d8fe3bae65aace437568f6dd660c92f57b452f7bd1608083a8fe3716ba3">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AnalyticsContext.tsx</strong><dd><code>Rename metrics fields to trace fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-8bd8a5899b5763f65b9f01fe71cfb7e19526a6f463cbd724f279328a04853517">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>backfill_test.go</strong><dd><code>Update test to use HashIdentityMetadata function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-62cfe426bf9c2ee7e6722969c78e74cf928f86a564d66b9856aea4c0232ddd06">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identitymap_test.go</strong><dd><code>Add tests for HashIdentityMetadata behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-7838a8a0f701320d27842704cc844b4e28592220a5622f7a2880e1d535a3b916">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config_test.go</strong><dd><code>Update test expectations for new poll interval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-05ef22b193b3acfecc895fe1f364e852dcb2f3b08c606bc06c968cc88f0271e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity_publisher_test.go</strong><dd><code>Update tests for HashIdentityMetadata usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-a3b353a63f2cc222e61c29b0da162ad11c17f71be6c64b6222b2c1769a3c8f28">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>config.go</strong><dd><code>Change default poll interval to 5 minutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-626ab53e2c4405a09e43c5ce9fb841a3cc83fec9dfa506366a4a8c2ecd490135">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config.go</strong><dd><code>Change default poll interval to 5 minutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-e4cfa17894bdfb56238b434eb208069edd7b48686712873129518c6a5d25dc70">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.docker.json</strong><dd><code>Update poll intervals to 5 minutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-d64ebb69ec31e831efd187c47a5bfff2573960306b177f6464e91cb44a3c709d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configmap.yaml</strong><dd><code>Update poll intervals in Kubernetes config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-f4548beaa0a3a01a46971c82c5647a0f3f49eb38d66dd939d06d19018173fcd6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Add grpc stats dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-cf437f055db002c5a1dba0ac4a4949d0ecc4b095e8e760bf5aec0f5d4c08f572">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong><dd><code>Add grpc stats dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-8646f2266fed1c91edf396d18f3bcf8f2194a9d2ccc7597d8391c60ac834cbc1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>agents.md</strong><dd><code>Document Proton reset procedure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-af8d04277f2353629065b0cc5fad3e44bd3e7c20339bd125e0812104bdbeff28">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rperf-monitoring.md</strong><dd><code>Update poll interval in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-70d068dec062c5ed771e7294401c52d55e85e279e9eee4f1084ca06c23b2fde8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls-security.md</strong><dd><code>Update poll interval in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1770/files#diff-fe75bcced80b2fb5cf39bd06e6edda7de714827915abedfaf41a54802f561d22">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

