### PR TITLE
1769 bugui device search is broken

### DIFF
--- a/ocaml/srql/lib/field_mapping.ml
+++ b/ocaml/srql/lib/field_mapping.ml
@@ -41,8 +41,8 @@ let map_field_name ~entity (field : string) : string =
       | "devices" -> (
           match f with
           | "name" | "host" | "device_name" -> "hostname"
-          | "ip_address" | "device.ip" -> "ip"
-          | "mac_address" | "device.mac" -> "mac"
+          | "ip_address" | "ipaddress" | "device.ip" -> "ip"
+          | "mac_address" | "macaddress" | "device.mac" -> "mac"
           | "uid" | "device.uid" -> "device_id"
           | "domain" | "device_domain" -> "device_domain"
           | "site" | "location" | "device_location" -> "device_location"

--- a/ocaml/srql/lib/query_planner.ml
+++ b/ocaml/srql/lib/query_planner.ml
@@ -185,12 +185,12 @@ let parse_having (s : string) : Sql_ir.condition option =
         String.sub s (i + String.length sym) (String.length s - i - String.length sym)
         |> String.trim
       in
-  let v =
-    match float_of_string_opt rhs with
-    | Some f -> Float f
-    | None -> ( match int_of_string_opt rhs with Some n -> Int n | None -> String rhs)
-  in
-  Some (Condition (lhs, op, v))
+      let v =
+        match float_of_string_opt rhs with
+        | Some f -> Float f
+        | None -> ( match int_of_string_opt rhs with Some n -> Int n | None -> String rhs)
+      in
+      Some (Condition (lhs, op, v))
 
 let is_ipv4_literal (s : string) : bool =
   let segments = String.split_on_char '.' s in
@@ -198,8 +198,7 @@ let is_ipv4_literal (s : string) : bool =
   | [ a; b; c; d ] -> (
       let valid_octet part =
         let len = String.length part in
-        len > 0
-        && len <= 3
+        len > 0 && len <= 3
         && String.for_all (function '0' .. '9' -> true | _ -> false) part
         &&
         let value = int_of_string part in
@@ -208,8 +207,7 @@ let is_ipv4_literal (s : string) : bool =
       try List.for_all valid_octet [ a; b; c; d ] with Failure _ -> false)
   | _ -> false
 
-let contains_wildcards (s : string) =
-  String.contains s '%' || String.contains s '_'
+let contains_wildcards (s : string) = String.contains s '%' || String.contains s '_'
 
 let or_chain (conds : Sql_ir.condition list) : Sql_ir.condition option =
   let rec build = function
@@ -224,8 +222,7 @@ let condition_of_filter ~entity ~timestamp_field = function
   | AttributeFilter (k, op, v) -> (
       match (v, op) with
       | ((String _ | Int _ | Float _ | Bool _) as raw), Eq
-        when String.lowercase_ascii entity = "devices"
-             && String.lowercase_ascii k = "search" ->
+        when String.lowercase_ascii entity = "devices" && String.lowercase_ascii k = "search" ->
           let term =
             let raw_string =
               match raw with
@@ -239,9 +236,7 @@ let condition_of_filter ~entity ~timestamp_field = function
           in
           if term = "" then None
           else
-            let wildcard =
-              if contains_wildcards term then term else "%" ^ term ^ "%"
-            in
+            let wildcard = if contains_wildcards term then term else "%" ^ term ^ "%" in
             let base_like = String wildcard in
             let conditions = ref [] in
             let push cond = conditions := cond :: !conditions in

--- a/ocaml/srql/test/test_query_engine.ml
+++ b/ocaml/srql/test/test_query_engine.ml
@@ -27,7 +27,8 @@ let not_contains msg hay needle =
   let len_h = String.length lhay and len_n = String.length lneedle in
   let rec loop i =
     if i + len_n > len_h then false
-    else if String.sub lhay i len_n = lneedle then true else loop (i + 1)
+    else if String.sub lhay i len_n = lneedle then true
+    else loop (i + 1)
   in
   if loop 0 then fail (Printf.sprintf "%s: did not expect '%s' in '%s'" msg needle hay)
 
@@ -94,7 +95,9 @@ let test_devices_search_router () =
   contains "search includes ip wildcard" sql "ip ILIKE {{";
   not_contains "search excludes sys_descr" sql "sys_descr ILIKE {{";
   check bool "router wildcard param present" true
-    (List.exists (function _, Column.String "%router-01%" -> true | _ -> false) translation.params)
+    (List.exists
+       (function _, Column.String "%router-01%" -> true | _ -> false)
+       translation.params)
 
 let test_devices_search_ipv4 () =
   let translation = translation_of "in:devices search:\"10.139.236.7\"" in
@@ -108,8 +111,7 @@ let test_devices_search_ipv4 () =
        translation.params);
   check bool "ip wildcard param present" true
     (List.exists
-       (function _, Column.String value ->
-          String.equal value "%10.139.236.7%" | _ -> false)
+       (function _, Column.String value -> String.equal value "%10.139.236.7%" | _ -> false)
        translation.params)
 
 let test_devices_search_numeric_literal () =
@@ -273,7 +275,8 @@ let test_devices_discovery_sources_both () =
     (List.exists (function _, Column.String "armis" -> true | _ -> false) translation.params);
   contains "both AND" sql "AND"
 
-let suite_arrays = [ ("devices discovery_sources both", `Quick, test_devices_discovery_sources_both) ]
+let suite_arrays =
+  [ ("devices discovery_sources both", `Quick, test_devices_discovery_sources_both) ]
 
 let () = Alcotest.run "asq_arrays" [ ("arrays", suite_arrays) ]
 

--- a/ocaml/srql/test/test_query_engine.ml
+++ b/ocaml/srql/test/test_query_engine.ml
@@ -22,6 +22,15 @@ let contains msg hay needle =
   if not (sub lhay lneedle) then
     fail (Printf.sprintf "%s: expected to find '%s' in '%s'" msg needle hay)
 
+let not_contains msg hay needle =
+  let lhay = String.lowercase_ascii hay and lneedle = String.lowercase_ascii needle in
+  let len_h = String.length lhay and len_n = String.length lneedle in
+  let rec loop i =
+    if i + len_n > len_h then false
+    else if String.sub lhay i len_n = lneedle then true else loop (i + 1)
+  in
+  if loop 0 then fail (Printf.sprintf "%s: did not expect '%s' in '%s'" msg needle hay)
+
 let test_devices_today () =
   let translation = translation_of "in:devices name:server01 time:today" in
   let sql = translation.sql in
@@ -57,11 +66,72 @@ let test_validation_having_error () =
       | Ok () -> fail "expected validation error"
       | Error _ -> ())
 
+let test_devices_ip_equality () =
+  let translation = translation_of "in:devices ip:\"10.139.236.7\"" in
+  let sql = translation.sql in
+  contains "ip equality condition" sql "ip = {{";
+  check bool "ip parameter present" true
+    (List.exists
+       (function _, Column.String value -> String.equal value "10.139.236.7" | _ -> false)
+       translation.params)
+
+let test_devices_ipaddress_alias () =
+  let translation = translation_of "in:devices ipAddress:\"10.238.179.157\"" in
+  let sql = translation.sql in
+  contains "ipAddress alias maps to ip" sql "ip = {{";
+  check bool "ipAddress parameter present" true
+    (List.exists
+       (function _, Column.String value -> String.equal value "10.238.179.157" | _ -> false)
+       translation.params)
+
+let test_devices_search_router () =
+  let translation = translation_of "in:devices search:\"router-01\"" in
+  let sql = translation.sql in
+  contains "search includes hostname match" sql "hostname ILIKE {{";
+  contains "search includes device_id match" sql "device_id ILIKE {{";
+  contains "search includes poller match" sql "poller_id ILIKE {{";
+  contains "search includes mac match" sql "mac ILIKE {{";
+  contains "search includes ip wildcard" sql "ip ILIKE {{";
+  not_contains "search excludes sys_descr" sql "sys_descr ILIKE {{";
+  check bool "router wildcard param present" true
+    (List.exists (function _, Column.String "%router-01%" -> true | _ -> false) translation.params)
+
+let test_devices_search_ipv4 () =
+  let translation = translation_of "in:devices search:\"10.139.236.7\"" in
+  let sql = translation.sql in
+  contains "search includes ip equality" sql "ip = {{";
+  contains "search includes ip wildcard" sql "ip ILIKE {{";
+  not_contains "search excludes observables_ip" sql "has(observables_ip, {{";
+  check bool "ip equality param present" true
+    (List.exists
+       (function _, Column.String value -> String.equal value "10.139.236.7" | _ -> false)
+       translation.params);
+  check bool "ip wildcard param present" true
+    (List.exists
+       (function _, Column.String value ->
+          String.equal value "%10.139.236.7%" | _ -> false)
+       translation.params)
+
+let test_devices_search_numeric_literal () =
+  let translation = translation_of "in:devices search:\"10\"" in
+  let sql = translation.sql in
+  contains "numeric search uses wildcard" sql "ip ILIKE {{";
+  not_contains "numeric search avoids raw column compare" sql "search =";
+  check bool "numeric wildcard param present" true
+    (List.exists
+       (function _, Column.String value -> String.equal value "%10%" | _ -> false)
+       translation.params)
+
 let suite =
   [
     ("devices today mapping", `Quick, test_devices_today);
     ("flows topk_by ranking", `Quick, test_flows_topk_by);
     ("having invalid reference", `Quick, test_validation_having_error);
+    ("devices ip equality filter", `Quick, test_devices_ip_equality);
+    ("devices ipAddress alias", `Quick, test_devices_ipaddress_alias);
+    ("devices search wildcard fanout", `Quick, test_devices_search_router);
+    ("devices search ipv4 equality", `Quick, test_devices_search_ipv4);
+    ("devices search numeric literal", `Quick, test_devices_search_numeric_literal);
   ]
 
 let () = Alcotest.run "query_engine" [ ("planner+translator", suite) ]
@@ -138,7 +208,7 @@ let test_negation_list_devices () =
 let test_negation_like_services () =
   let translation = translation_of "in:services !name:%ssh% timeFrame:\"7 Days\"" in
   let sql = translation.sql in
-  contains "not like emitted" sql "NOT name LIKE {{";
+  contains "not like emitted" sql "NOT name ILIKE {{";
   contains "7 days timeframe" sql "INTERVAL 7 DAY"
 
 let suite_neg =
@@ -161,7 +231,7 @@ let test_devices_boundary_alias () =
 let test_services_like_positive () =
   let translation = translation_of "in:services name:%ssh%" in
   let sql = translation.sql in
-  contains "like emitted" sql "name LIKE {{";
+  contains "like emitted" sql "name ILIKE {{";
   check bool "ssh pattern param" true
     (List.exists (function _, Column.String "%ssh%" -> true | _ -> false) translation.params)
 
@@ -203,8 +273,7 @@ let test_devices_discovery_sources_both () =
     (List.exists (function _, Column.String "armis" -> true | _ -> false) translation.params);
   contains "both AND" sql "AND"
 
-let suite_arrays =
-  [ ("devices discovery_sources both", `Quick, test_devices_discovery_sources_both) ]
+let suite_arrays = [ ("devices discovery_sources both", `Quick, test_devices_discovery_sources_both) ]
 
 let () = Alcotest.run "asq_arrays" [ ("arrays", suite_arrays) ]
 
@@ -213,14 +282,14 @@ let () = Alcotest.run "asq_arrays" [ ("arrays", suite_arrays) ]
 let test_devices_like_hostname () =
   let translation = translation_of "in:devices hostname:%cam%" in
   let sql = translation.sql in
-  contains "hostname LIKE" sql "hostname LIKE {{";
+  contains "hostname LIKE" sql "hostname ILIKE {{";
   check bool "hostname pattern param" true
     (List.exists (function _, Column.String "%cam%" -> true | _ -> false) translation.params)
 
 let test_devices_not_like_hostname () =
   let translation = translation_of "in:devices !hostname:%cam%" in
   let sql = translation.sql in
-  contains "hostname NOT LIKE" sql "NOT hostname LIKE {{";
+  contains "hostname NOT LIKE" sql "NOT hostname ILIKE {{";
   check bool "hostname not pattern param" true
     (List.exists (function _, Column.String "%cam%" -> true | _ -> false) translation.params)
 
@@ -228,14 +297,14 @@ let test_activity_like_nested_decision_host () =
   let translation = translation_of "in:activity decisionData:(host:(%ipinfo.%))" in
   let sql = translation.sql in
   contains "events table" sql "from table(events)";
-  contains "nested LIKE" sql "decisionData_host LIKE {{";
+  contains "nested LIKE" sql "decisionData_host ILIKE {{";
   check bool "decision host param" true
     (List.exists (function _, Column.String "%ipinfo.%" -> true | _ -> false) translation.params)
 
 let test_activity_not_like_nested_decision_host () =
   let translation = translation_of "in:activity decisionData:(host:(!%ipinfo.%))" in
   let sql = translation.sql in
-  contains "nested NOT LIKE" sql "NOT decisionData_host LIKE {{";
+  contains "nested NOT LIKE" sql "NOT decisionData_host ILIKE {{";
   check bool "decision host not param" true
     (List.exists (function _, Column.String "%ipinfo.%" -> true | _ -> false) translation.params)
 

--- a/pkg/sweeper/availability_logic_test.go
+++ b/pkg/sweeper/availability_logic_test.go
@@ -42,6 +42,7 @@ func TestDeviceAvailabilityLogic(t *testing.T) {
 		config:        config,
 		logger:        logger.NewTestLogger(),
 		deviceResults: make(map[string]*DeviceResultAggregator),
+		kvBackoff:     defaultKVWatchBackoffSettings(),
 	}
 
 	t.Run("single IP available - device should be available", func(t *testing.T) {
@@ -329,6 +330,7 @@ func TestEndToEndAvailabilityFlow(t *testing.T) {
 		deviceRegistry: mockDeviceRegistry,
 		logger:         logger.NewTestLogger(),
 		deviceResults:  make(map[string]*DeviceResultAggregator),
+		kvBackoff:      defaultKVWatchBackoffSettings(),
 	}
 
 	t.Run("end-to-end: only last IP responds - device available", func(t *testing.T) {
@@ -557,6 +559,7 @@ func TestTCPOnlyArmisScenarios(t *testing.T) {
 		deviceRegistry: mockDeviceRegistry,
 		logger:         logger.NewTestLogger(),
 		deviceResults:  make(map[string]*DeviceResultAggregator),
+		kvBackoff:      defaultKVWatchBackoffSettings(),
 	}
 
 	t.Run("TCP-only: single port success marks device available", func(t *testing.T) {

--- a/pkg/sweeper/base_processor_test.go
+++ b/pkg/sweeper/base_processor_test.go
@@ -205,7 +205,7 @@ func testMemoryReleaseAfterCleanup(t *testing.T, config *models.Config) {
 
 	// Force GC and minimal wait
 	runtime.GC()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 
 	var memBefore runtime.MemStats
 
@@ -229,7 +229,7 @@ func testMemoryReleaseAfterCleanup(t *testing.T, config *models.Config) {
 
 	// Force GC after cleanup with minimal wait
 	runtime.GC()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 
 	var memAfter runtime.MemStats
 

--- a/pkg/sweeper/sticky_availability_test.go
+++ b/pkg/sweeper/sticky_availability_test.go
@@ -1,81 +1,83 @@
 package sweeper
 
 import (
-    "context"
-    "testing"
-    "time"
+	"context"
+	"testing"
+	"time"
 
-    "github.com/carverauto/serviceradar/pkg/logger"
-    "github.com/carverauto/serviceradar/pkg/models"
+	"github.com/carverauto/serviceradar/pkg/logger"
+	"github.com/carverauto/serviceradar/pkg/models"
 )
 
 // Demonstrates sticky availability when an old successful TCP result persists while
 // subsequent sweeps stop scanning that port (e.g., port list change) and only produce
 // failures for other modes/ports. Without pruning, availability remains true.
 func TestStickyAvailability_WhenPortListChanges_WithoutPrune(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    log := logger.NewTestLogger()
+	log := logger.NewTestLogger()
 
-    cfg := &models.Config{SweepModes: []models.SweepMode{models.ModeTCP, models.ModeICMP}}
-    processor := NewBaseProcessor(cfg, log)
-    store := NewInMemoryStore(processor, log)
+	cfg := &models.Config{SweepModes: []models.SweepMode{models.ModeTCP, models.ModeICMP}}
+	processor := NewBaseProcessor(cfg, log)
+	store := NewInMemoryStore(processor, log)
+	if closer, ok := store.(interface{ Close() error }); ok {
+		t.Cleanup(func() { _ = closer.Close() })
+	}
 
-    ctx := context.Background()
-    host := "10.0.0.1"
+	ctx := context.Background()
+	host := "10.0.0.1"
 
-    // Prior sweep: TCP 80 was open (success)
-    resOld := &models.Result{
-        Target:   models.Target{Host: host, Port: 80, Mode: models.ModeTCP},
-        Available: true,
-        LastSeen: time.Now().Add(-time.Hour),
-    }
-    if err := store.SaveResult(ctx, resOld); err != nil {
-        t.Fatalf("save old result: %v", err)
-    }
+	// Prior sweep: TCP 80 was open (success)
+	resOld := &models.Result{
+		Target:    models.Target{Host: host, Port: 80, Mode: models.ModeTCP},
+		Available: true,
+		LastSeen:  time.Now().Add(-time.Hour),
+	}
+	if err := store.SaveResult(ctx, resOld); err != nil {
+		t.Fatalf("save old result: %v", err)
+	}
 
-    // New sweep: port list changed (80 not scanned); only ICMP scanned and blocked (failure)
-    resNew := &models.Result{
-        Target:   models.Target{Host: host, Mode: models.ModeICMP},
-        Available: false,
-        LastSeen: time.Now(),
-    }
-    if err := store.SaveResult(ctx, resNew); err != nil {
-        t.Fatalf("save new result: %v", err)
-    }
+	// New sweep: port list changed (80 not scanned); only ICMP scanned and blocked (failure)
+	resNew := &models.Result{
+		Target:    models.Target{Host: host, Mode: models.ModeICMP},
+		Available: false,
+		LastSeen:  time.Now(),
+	}
+	if err := store.SaveResult(ctx, resNew); err != nil {
+		t.Fatalf("save new result: %v", err)
+	}
 
-    summary, err := store.GetSweepSummary(ctx)
-    if err != nil {
-        t.Fatalf("get summary: %v", err)
-    }
+	summary, err := store.GetSweepSummary(ctx)
+	if err != nil {
+		t.Fatalf("get summary: %v", err)
+	}
 
-    if len(summary.Hosts) == 0 {
-        t.Fatalf("expected host in summary")
-    }
+	if len(summary.Hosts) == 0 {
+		t.Fatalf("expected host in summary")
+	}
 
-    if !summary.Hosts[0].Available {
-        t.Fatalf("expected sticky availability true due to old TCP:80 success persisting")
-    }
+	if !summary.Hosts[0].Available {
+		t.Fatalf("expected sticky availability true due to old TCP:80 success persisting")
+	}
 
-    // Now prune (simulating our fix) and re-add only the current (failing) result
-    if err := store.PruneResults(ctx, 0); err != nil {
-        t.Fatalf("prune: %v", err)
-    }
-    if err := store.SaveResult(ctx, resNew); err != nil {
-        t.Fatalf("save new result after prune: %v", err)
-    }
+	// Now prune (simulating our fix) and re-add only the current (failing) result
+	if err := store.PruneResults(ctx, 0); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if err := store.SaveResult(ctx, resNew); err != nil {
+		t.Fatalf("save new result after prune: %v", err)
+	}
 
-    summary2, err := store.GetSweepSummary(ctx)
-    if err != nil {
-        t.Fatalf("get summary2: %v", err)
-    }
+	summary2, err := store.GetSweepSummary(ctx)
+	if err != nil {
+		t.Fatalf("get summary2: %v", err)
+	}
 
-    if len(summary2.Hosts) == 0 {
-        t.Fatalf("expected host in summary2")
-    }
+	if len(summary2.Hosts) == 0 {
+		t.Fatalf("expected host in summary2")
+	}
 
-    if summary2.Hosts[0].Available {
-        t.Fatalf("expected availability false after pruning old successes")
-    }
+	if summary2.Hosts[0].Available {
+		t.Fatalf("expected availability false after pruning old successes")
+	}
 }
-

--- a/pkg/sweeper/sweeper.go
+++ b/pkg/sweeper/sweeper.go
@@ -42,16 +42,18 @@ const (
 	defaultInterval      = 5 * time.Minute
 	scanTimeout          = 20 * time.Minute // Timeout for individual scan operations - increased for large-scale TCP scanning
 	defaultResultTimeout = 500 * time.Millisecond
-	// KV Watch auto-reconnect parameters
-	kvWatchInitialBackoff = 1 * time.Second
-	kvWatchMaxBackoff     = 5 * time.Minute
-	kvWatchBackoffFactor  = 2.0
-	kvWatchJitterFactor   = 0.1 // 10% jitter
-
 	// Deployment size thresholds
 	smallScaleThreshold  = 100
 	mediumScaleThreshold = 10000
 	largeScaleThreshold  = 100000
+)
+
+var (
+	// KV Watch auto-reconnect parameters (overridable in tests)
+	kvWatchInitialBackoff = 1 * time.Second
+	kvWatchMaxBackoff     = 5 * time.Minute
+	kvWatchBackoffFactor  = 2.0
+	kvWatchJitterFactor   = 0.1 // 10% jitter
 )
 
 // minInt returns the minimum of two integers

--- a/pkg/sweeper/sweeper.go
+++ b/pkg/sweeper/sweeper.go
@@ -38,6 +38,9 @@ var (
 	ErrFailedToReadChunk = errors.New("failed to read chunk")
 )
 
+// Option configures a NetworkSweeper instance.
+type Option func(*NetworkSweeper)
+
 const (
 	defaultInterval      = 5 * time.Minute
 	scanTimeout          = 20 * time.Minute // Timeout for individual scan operations - increased for large-scale TCP scanning
@@ -48,13 +51,62 @@ const (
 	largeScaleThreshold  = 100000
 )
 
-var (
-	// KV Watch auto-reconnect parameters (overridable in tests)
-	kvWatchInitialBackoff = 1 * time.Second
-	kvWatchMaxBackoff     = 5 * time.Minute
-	kvWatchBackoffFactor  = 2.0
-	kvWatchJitterFactor   = 0.1 // 10% jitter
-)
+type kvWatchBackoffSettings struct {
+	initial time.Duration
+	max     time.Duration
+	factor  float64
+	jitter  float64
+}
+
+func defaultKVWatchBackoffSettings() kvWatchBackoffSettings {
+	return kvWatchBackoffSettings{
+		initial: 1 * time.Second,
+		max:     5 * time.Minute,
+		factor:  2.0,
+		jitter:  0.1, // 10% jitter
+	}
+}
+
+func sanitizeKVWatchBackoffSettings(cfg kvWatchBackoffSettings) kvWatchBackoffSettings {
+	defaults := defaultKVWatchBackoffSettings()
+
+	if cfg.initial <= 0 {
+		cfg.initial = defaults.initial
+	}
+
+	if cfg.max <= 0 || cfg.max < cfg.initial {
+		cfg.max = defaults.max
+	}
+
+	if cfg.factor <= 1 {
+		cfg.factor = defaults.factor
+	}
+
+	if cfg.jitter < 0 {
+		cfg.jitter = defaults.jitter
+	}
+
+	return cfg
+}
+
+// WithKVWatchBackoff overrides the KV watch backoff behaviour (primarily used in tests).
+func WithKVWatchBackoff(initial, max time.Duration, factor, jitter float64) Option {
+	return func(ns *NetworkSweeper) {
+		ns.kvBackoff = sanitizeKVWatchBackoffSettings(kvWatchBackoffSettings{
+			initial: initial,
+			max:     max,
+			factor:  factor,
+			jitter:  jitter,
+		})
+	}
+}
+
+func (s *NetworkSweeper) kvWatchBackoff() kvWatchBackoffSettings {
+	cfg := sanitizeKVWatchBackoffSettings(s.kvBackoff)
+	s.kvBackoff = cfg
+
+	return cfg
+}
 
 // minInt returns the minimum of two integers
 func minInt(a, b int) int {
@@ -86,6 +138,7 @@ type NetworkSweeper struct {
 	deviceRegistry    DeviceRegistryService
 	configKey         string
 	logger            logger.Logger
+	kvBackoff         kvWatchBackoffSettings
 	mu                sync.RWMutex
 	done              chan struct{}
 	watchDone         chan struct{}
@@ -131,7 +184,8 @@ func NewNetworkSweeper(
 	kvStore KVStore,
 	deviceRegistry DeviceRegistryService,
 	configKey string,
-	log logger.Logger) (*NetworkSweeper, error) {
+	log logger.Logger,
+	opts ...Option) (*NetworkSweeper, error) {
 	if config == nil {
 		return nil, errNilConfig
 	}
@@ -147,7 +201,7 @@ func NewNetworkSweeper(
 
 	log.Info().Dur("interval", config.Interval).Msg("Creating NetworkSweeper")
 
-	return &NetworkSweeper{
+	ns := &NetworkSweeper{
 		config:            config,
 		icmpScanner:       icmpScanner,
 		tcpScanner:        tcpScanner,
@@ -158,10 +212,17 @@ func NewNetworkSweeper(
 		deviceRegistry:    deviceRegistry,
 		configKey:         configKey,
 		logger:            log,
+		kvBackoff:         defaultKVWatchBackoffSettings(),
 		done:              make(chan struct{}),
 		watchDone:         make(chan struct{}),
 		deviceResults:     make(map[string]*DeviceResultAggregator),
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(ns)
+	}
+
+	return ns, nil
 }
 
 // initializeICMPScanner creates an ICMP scanner if needed based on config
@@ -707,9 +768,11 @@ func (s *NetworkSweeper) handleCancellation(ctx context.Context, initialConfigRe
 func (s *NetworkSweeper) handleBackoffWait(
 	ctx context.Context, backoff time.Duration, initialConfigReceived bool, configReady chan<- struct{},
 ) bool {
+	cfg := s.kvWatchBackoff()
+
 	// Reset backoff on successful initial config to avoid long delays on subsequent reconnects
 	if initialConfigReceived {
-		backoff = kvWatchInitialBackoff
+		backoff = cfg.initial
 	}
 
 	// Add jitter to prevent thundering herd
@@ -759,7 +822,8 @@ func (s *NetworkSweeper) watchConfigWithInitialSignal(ctx context.Context, confi
 	s.logger.Info().Str("configKey", s.configKey).Msg("Starting KV watch with auto-reconnect")
 
 	initialConfigReceived := false
-	backoff := kvWatchInitialBackoff
+	cfg := s.kvWatchBackoff()
+	backoff := cfg.initial
 	// Auto-reconnect loop with exponential backoff and jitter
 	for {
 		// Check for cancellation
@@ -788,8 +852,8 @@ func (s *NetworkSweeper) watchConfigWithInitialSignal(ctx context.Context, confi
 
 			// Exponentially increase backoff, capped at maximum
 			backoff = time.Duration(math.Min(
-				float64(backoff)*kvWatchBackoffFactor,
-				float64(kvWatchMaxBackoff),
+				float64(backoff)*cfg.factor,
+				float64(cfg.max),
 			))
 		}
 	}
@@ -859,8 +923,8 @@ func (s *NetworkSweeper) performKVWatch(ctx context.Context, initialConfigReceiv
 }
 
 // addJitter adds random jitter to backoff duration to prevent thundering herd
-func (*NetworkSweeper) addJitter(backoff time.Duration) time.Duration {
-	jitter := time.Duration(float64(backoff) * kvWatchJitterFactor * (rand.Float64()*2 - 1))
+func (s *NetworkSweeper) addJitter(backoff time.Duration) time.Duration {
+	jitter := time.Duration(float64(backoff) * s.kvBackoff.jitter * (rand.Float64()*2 - 1))
 	jitteredBackoff := backoff + jitter
 
 	// Ensure jittered backoff is positive

--- a/pkg/sync/service_test.go
+++ b/pkg/sync/service_test.go
@@ -41,6 +41,11 @@ var (
 	errStreamSend = errors.New("stream send error")
 )
 
+const (
+	testOperationDelay = 5 * time.Millisecond
+	testWaitTimeout    = 250 * time.Millisecond
+)
+
 func expectNoopBatchGet(kv *MockKVClient) {
 	kv.EXPECT().BatchGet(gomock.Any(), gomock.Any()).Return(&proto.BatchGetResponse{}, nil).AnyTimes()
 }
@@ -951,7 +956,7 @@ func TestSimpleSyncService_runArmisUpdates_OverlapPrevention(t *testing.T) {
 
 		// Simulate slow operation - use shorter duration for tests
 		select {
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(testOperationDelay):
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -985,14 +990,14 @@ func TestSimpleSyncService_runArmisUpdates_OverlapPrevention(t *testing.T) {
 	select {
 	case err := <-firstCallDone:
 		require.NoError(t, err, "First call should succeed")
-	case <-time.After(1 * time.Second):
+	case <-time.After(testWaitTimeout):
 		t.Fatal("First call did not complete in time")
 	}
 
 	select {
 	case err := <-secondCallDone:
 		require.NoError(t, err, "Second call should return nil (skipped due to overlap prevention)")
-	case <-time.After(1 * time.Second):
+	case <-time.After(testWaitTimeout):
 		t.Fatal("Second call did not complete in time")
 	}
 

--- a/web/src/components/Devices/Dashboard.tsx
+++ b/web/src/components/Devices/Dashboard.tsx
@@ -23,6 +23,7 @@ import {Server, Search, Loader2, AlertTriangle, CheckCircle, XCircle} from 'luci
 import DeviceTable from './DeviceTable';
 import { useDebounce } from 'use-debounce';
 type SortableKeys = 'ip' | 'hostname' | 'last_seen' | 'first_seen' | 'poller_id';
+
 const StatCard = ({ title, value, icon, isLoading, colorScheme = 'blue' }: { title: string; value: string | number; icon: React.ReactNode; isLoading: boolean; colorScheme?: 'blue' | 'green' | 'red' }) => {
     const bgColors = {
         blue: 'bg-blue-50 dark:bg-blue-900/30',
@@ -128,9 +129,10 @@ const Dashboard = () => {
                 queryParts.push(`is_available:${filterStatus === 'online'}`);
             }
 
-            if (debouncedSearchTerm) {
-                const escapedTerm = escapeSrqlValue(debouncedSearchTerm);
-                queryParts.push(`hostname:%${escapedTerm}%`);
+            const trimmedSearch = debouncedSearchTerm.trim();
+            if (trimmedSearch) {
+                const escapedTerm = escapeSrqlValue(trimmedSearch);
+                queryParts.push(`search:"${escapedTerm}"`);
             }
 
             const query = queryParts.join(' ');


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed web UI device search to use unified `search` filter instead of hostname-only matching

- Enhanced SRQL query planner with smart IP/MAC address search across multiple device fields

- Optimized test timeouts and added proper cleanup handlers to prevent flakiness

- Added case-insensitive LIKE operations (ILIKE) for improved search matching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Web UI Search"] -- "uses search filter" --> B["SRQL Query Planner"]
  B -- "expands to multiple fields" --> C["hostname/ip/mac/device_id"]
  C -- "ILIKE operator" --> D["Case-insensitive matching"]
  B -- "detects IP literals" --> E["Exact + wildcard IP search"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Dashboard.tsx</strong><dd><code>Replace hostname filter with unified search parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-da1f03ea181f8f19b672164eb86b914cef8bcef6ea7df61d174e3c19421a3461">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>query_planner.ml</strong><dd><code>Add smart device search with IP detection and multi-field matching</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-b215cfcd9aca2dc66252f05b2e2c2a39cde9d86744ee5f87b935077ed3863b06">+61/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translator.ml</strong><dd><code>Switch to case-insensitive LIKE and improve array field detection</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-c33a65c30e4433358fbe3a1806b6c35291fd999f3abfdaad0ca38419e94764b9">+21/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>field_mapping.ml</strong><dd><code>Add ipaddress and macaddress field aliases for devices</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-202ecb348ad59ad7d01c3319a6719ffcb0d04acc7d7b4a8ec5b69c825513fca9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>test_query_engine.ml</strong><dd><code>Add comprehensive tests for device search and IP filtering</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-0c1dcb695d94269d0e3f899c01455e21cb50242b4665e3a0ef5f2b198c5cbe2f">+78/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sweeper_test.go</strong><dd><code>Reduce test timeouts and add proper cleanup handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-7714a2d9e6f06cd0d5944247437dda7796228b95a507478e92f0fc6e09179424">+83/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sweeper.go</strong><dd><code>Make KV watch backoff parameters overridable for testing</code>&nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-d11dee1504de681453c5a04e22ae44d64820221ac6b84a1630d3a3929dace47a">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base_processor_test.go</strong><dd><code>Reduce memory test sleep durations for faster execution</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-4ed190a88d8cbc2a1111b5e1ea955789305c1198baf80e33e2a4d0fb74fca627">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sticky_availability_test.go</strong><dd><code>Fix formatting and add cleanup handler for store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-2f0503b2d4b07c57bf1e7f979f2d700fae0e680ae3eea8e7a9ce5f9a3be08eb4">+72/-70</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>circuit_breaker_test.go</strong><dd><code>Replace retry loops with Eventually assertion for reliability</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-ad013257ec45e4158dbc1a5cca84ab158db4271198f40d4ec4c3aef269033d46">+11/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>service_error_handling_test.go</strong><dd><code>Extract timeout constants and reduce test durations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-d0105ea2cc75138b515ca8bf402050cfc718bd0688de8e62e866538da1adc609">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_test.go</strong><dd><code>Reduce operation delays and wait timeouts in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1771/files#diff-1775a061aca7003b65ee5bac4510511d264530cadb4939909327db56f6163092">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

