### PR TITLE
fixing datetimes for devices

### DIFF
--- a/pkg/core/performance_integration_test.go
+++ b/pkg/core/performance_integration_test.go
@@ -65,6 +65,10 @@ func TestSyncResultsPerformanceOptimization(t *testing.T) {
 				ExecuteQuery(gomock.Any(), gomock.Any()).
 				Return([]map[string]interface{}{}, nil).
 				AnyTimes()
+			mockDB.EXPECT().
+				GetUnifiedDevicesByIPsOrIDs(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return([]*models.UnifiedDevice{}, nil).
+				AnyTimes()
 			testLogger := logger.NewTestLogger()
 			realRegistry := registry.NewDeviceRegistry(mockDB, testLogger)
 
@@ -128,6 +132,10 @@ func TestRepeatedSyncCallsPerformance(t *testing.T) {
 	mockDB.EXPECT().
 		ExecuteQuery(gomock.Any(), gomock.Any()).
 		Return([]map[string]interface{}{}, nil).
+		AnyTimes()
+	mockDB.EXPECT().
+		GetUnifiedDevicesByIPsOrIDs(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*models.UnifiedDevice{}, nil).
 		AnyTimes()
 	testLogger := logger.NewTestLogger()
 	realRegistry := registry.NewDeviceRegistry(mockDB, testLogger)
@@ -223,6 +231,11 @@ func TestDatabaseCallCounting(t *testing.T) {
 		Times(1)
 
 	// Execute
+	mockDB.EXPECT().
+		GetUnifiedDevicesByIPsOrIDs(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*models.UnifiedDevice{}, nil).
+		AnyTimes()
+
 	err := discoveryService.ProcessSyncResults(ctx, "test-poller", "test", serviceStatus, sightingsJSON, time.Now())
 	require.NoError(t, err)
 

--- a/pkg/sweeper/sticky_availability_test.go
+++ b/pkg/sweeper/sticky_availability_test.go
@@ -19,7 +19,7 @@ func TestStickyAvailability_WhenPortListChanges_WithoutPrune(t *testing.T) {
 
 	cfg := &models.Config{SweepModes: []models.SweepMode{models.ModeTCP, models.ModeICMP}}
 	processor := NewBaseProcessor(cfg, log)
-	store := NewInMemoryStore(processor, log)
+	store := NewInMemoryStore(processor, log, WithoutPreallocation(), WithCleanupInterval(0))
 	if closer, ok := store.(interface{ Close() error }); ok {
 		t.Cleanup(func() { _ = closer.Close() })
 	}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed missing `first_seen` timestamp for devices discovered by sync service

- Added `annotateFirstSeen` function to preserve earliest device discovery time across updates

- Updated database migration to use `_first_seen` metadata field in aggregation queries

- Added comprehensive test coverage for first_seen timestamp preservation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Update"] --> B["annotateFirstSeen()"]
  B --> C["Check existing DB records"]
  B --> D["Parse metadata timestamps"]
  C --> E["Select earliest timestamp"]
  D --> E
  E --> F["Set _first_seen in metadata"]
  F --> G["Publish to unified_devices"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry.go</strong><dd><code>Add first_seen timestamp annotation logic for device updates</code></dd></summary>
<hr>

pkg/registry/registry.go

<ul><li>Added <code>annotateFirstSeen()</code> function to compute and set <code>_first_seen</code> <br>metadata field<br> <li> Implemented <code>parseFirstSeenTimestamp()</code> helper supporting multiple date <br>formats<br> <li> Integrated first_seen annotation into <code>ProcessBatchDeviceUpdates()</code> <br>workflow<br> <li> Logic preserves earliest timestamp from existing records, metadata, or <br>update timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1780/files#diff-cb61d8f79451b9541de4a8cc0811523a68d15452b2f5971c7618ea5b423cf4ec">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry_test.go</strong><dd><code>Add test coverage for first_seen timestamp preservation</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/registry_test.go

<ul><li>Added mock expectations for <code>GetUnifiedDevicesByIPsOrIDs()</code> in test <br>helpers<br> <li> Updated existing tests to validate <code>_first_seen</code> metadata presence and <br>format<br> <li> Added <code>TestDeviceRegistry_FirstSeenPreservedFromExistingRecord()</code> test <br>case</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1780/files#diff-f010972d104404be52d2a8e6e784cb56e31194f90795a69571a12696bcbdc075">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>00000000000001_consolidated_serviceradar_schema.up.sql</strong><dd><code>Update database schema to support _first_seen metadata field</code></dd></summary>
<hr>

pkg/db/migrations/00000000000001_consolidated_serviceradar_schema.up.sql

<ul><li>Added <code>SYNC</code> modifier to all <code>DROP STREAM</code> statements for proper cleanup<br> <li> Dropped dependent materialized views before recreating OCSF streams<br> <li> Updated <code>unified_devices</code> materialized view to use <code>_first_seen</code> from <br>metadata<br> <li> Simplified aggregation logic by removing <code>is_active</code> and <code>has_identity</code> <br>filters<br> <li> Changed <code>first_seen</code> calculation to use <br><code>parse_datetime64_best_effort_or_null()</code> on <code>_first_seen</code> metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1780/files#diff-1e05de747238f2112bb2230aac8db388e4c80eebe84c071eb78e035d64e67eb6">+69/-61</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

