### PR TITLE
sha tag build ids

### DIFF
--- a/docker/compose/entrypoint-web.sh
+++ b/docker/compose/entrypoint-web.sh
@@ -132,14 +132,22 @@ PUBLIC_ROOT="/app/public"
 NESTED_PUBLIC="${PUBLIC_ROOT}/web/public_flat"
 if [ -d "${NESTED_PUBLIC}" ]; then
     echo "Flattening public assets into ${PUBLIC_ROOT}..."
+    rm -f "${NESTED_PUBLIC}/build-info.json"
     cp -R "${NESTED_PUBLIC}/." "${PUBLIC_ROOT}/"
+    if [ -f "${PUBLIC_ROOT}/build-info.json" ]; then
+        cp "${PUBLIC_ROOT}/build-info.json" "${NESTED_PUBLIC}/build-info.json"
+    fi
 fi
 
 STANDALONE_PUBLIC_ROOT="/app/.next/standalone/public"
 NESTED_STANDALONE_PUBLIC="${STANDALONE_PUBLIC_ROOT}/web/public_flat"
 if [ -d "${NESTED_STANDALONE_PUBLIC}" ]; then
     echo "Flattening standalone public assets..."
+    rm -f "${NESTED_STANDALONE_PUBLIC}/build-info.json"
     cp -R "${NESTED_STANDALONE_PUBLIC}/." "${STANDALONE_PUBLIC_ROOT}/"
+    if [ -f "${STANDALONE_PUBLIC_ROOT}/build-info.json" ]; then
+        cp "${STANDALONE_PUBLIC_ROOT}/build-info.json" "${NESTED_STANDALONE_PUBLIC}/build-info.json"
+    fi
 fi
 
 exec "$@"

--- a/docker/images/BUILD.bazel
+++ b/docker/images/BUILD.bazel
@@ -995,7 +995,7 @@ pkg_tar(
 )
 
 oci_image(
-    name = "web_image_amd64",
+    name = "web_image_base_amd64",
     base = "@node_20_alpine_linux_amd64//:node_20_alpine_linux_amd64",
     tars = [
         ":common_tools_amd64",
@@ -1018,6 +1018,113 @@ oci_image(
     labels = {
         "org.opencontainers.image.title": "serviceradar-web",
     },
+)
+
+genrule(
+    name = "web_build_info_json",
+    srcs = [
+        ":web_image_base_amd64.digest",
+        "//docker/images:core_image_amd64.digest",
+        "//:VERSION",
+    ],
+    outs = ["web_build_info.json"],
+    cmd = """
+set -euo pipefail
+
+web_digest_file="$(location :web_image_base_amd64.digest)"
+core_digest_file="$(location //docker/images:core_image_amd64.digest)"
+version_file="$(location //:VERSION)"
+
+web_digest=$$(cat "$$web_digest_file")
+if [[ "$$web_digest" != sha256:* ]]; then
+  echo "unexpected web digest format: $$web_digest" >&2
+  exit 1
+fi
+
+web_short=$${web_digest#sha256:}
+web_short=$$(printf '%s' "$$web_short" | cut -c1-12)
+
+core_digest=$$(cat "$$core_digest_file")
+if [[ "$$core_digest" != sha256:* ]]; then
+  echo "unexpected core digest format: $$core_digest" >&2
+  exit 1
+fi
+
+core_short=$${core_digest#sha256:}
+core_short=$$(printf '%s' "$$core_short" | cut -c1-12)
+
+if [[ -f "$$version_file" ]]; then
+  version=$$(tr -d '\\n' < "$$version_file")
+else
+  version="dev"
+fi
+
+build_time="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+cat > "$@" <<EOF
+{
+  "version": "$$version",
+  "buildTime": "$$build_time",
+  "webBuildId": "sha-$$web_short",
+  "coreBuildId": "sha-$$core_short"
+}
+EOF
+""",
+)
+
+pkg_tar(
+    name = "web_build_info_root_layer_amd64",
+    files = {
+        ":web_build_info_json": "app/public/build-info.json",
+    },
+    modes = {
+        "app/public/build-info.json": "0644",
+    },
+    package_dir = "/",
+)
+
+pkg_tar(
+    name = "web_build_info_root_nested_layer_amd64",
+    files = {
+        ":web_build_info_json": "app/public/web/public_flat/build-info.json",
+    },
+    modes = {
+        "app/public/web/public_flat/build-info.json": "0644",
+    },
+    package_dir = "/",
+)
+
+pkg_tar(
+    name = "web_build_info_standalone_layer_amd64",
+    files = {
+        ":web_build_info_json": "app/.next/standalone/public/build-info.json",
+    },
+    modes = {
+        "app/.next/standalone/public/build-info.json": "0644",
+    },
+    package_dir = "/",
+)
+
+pkg_tar(
+    name = "web_build_info_standalone_nested_layer_amd64",
+    files = {
+        ":web_build_info_json": "app/.next/standalone/public/web/public_flat/build-info.json",
+    },
+    modes = {
+        "app/.next/standalone/public/web/public_flat/build-info.json": "0644",
+    },
+    package_dir = "/",
+)
+
+oci_image(
+    name = "web_image_amd64",
+    base = ":web_image_base_amd64",
+    tars = [
+        ":web_build_info_root_layer_amd64",
+        ":web_build_info_root_nested_layer_amd64",
+        ":web_build_info_standalone_layer_amd64",
+        ":web_build_info_standalone_nested_layer_amd64",
+    ],
 )
 
 oci_load(

--- a/docker/images/push_targets.bzl
+++ b/docker/images/push_targets.bzl
@@ -21,7 +21,7 @@ GHCR_PUSH_TARGETS = [
     ("zen_image_amd64", "ghcr.io/carverauto/serviceradar-zen"),
     ("config_updater_image_amd64", "ghcr.io/carverauto/serviceradar-config-updater"),
     ("nginx_image_amd64", "ghcr.io/carverauto/serviceradar-nginx"),
-    ("web_image_amd64", "ghcr.io/carverauto/serviceradar-web"),
+    ("web_image_amd64", "ghcr.io/carverauto/serviceradar-web", ":web_image_base_amd64.digest"),
     ("srql_image_amd64", "ghcr.io/carverauto/serviceradar-srql"),
     ("kong_config_image_amd64", "ghcr.io/carverauto/serviceradar-kong-config"),
     ("cert_generator_image_amd64", "ghcr.io/carverauto/serviceradar-cert-generator"),
@@ -35,7 +35,12 @@ def declare_ghcr_push_targets():
 
     push_command_targets = []
 
-    for image, repository in GHCR_PUSH_TARGETS:
+    for target in GHCR_PUSH_TARGETS:
+        if len(target) == 2:
+            image, repository = target
+            digest_label = ":{}.digest".format(image)
+        else:
+            image, repository, digest_label = target
         expand_template(
             name = "{}_commit_tag".format(image),
             template = ["sha-{{STABLE_COMMIT_SHA}}"],
@@ -47,7 +52,7 @@ def declare_ghcr_push_targets():
 
         immutable_push_tags(
             name = "{}_push_tags".format(image),
-            digest = ":{}.digest".format(image),
+            digest = digest_label,
             commit_tags = ":{}_commit_tag".format(image),
             static_tags = ["latest"],
         )

--- a/scripts/workspace_status.sh
+++ b/scripts/workspace_status.sh
@@ -28,9 +28,27 @@ echo "GIT_BRANCH $git_branch"
 git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
 echo "GIT_TREE_STATUS $git_tree_status"
 
+if [[ -f VERSION ]]; then
+  version=$(tr -d '\n' < VERSION)
+else
+  version="dev"
+fi
+echo "STABLE_VERSION $version"
+
 # Note: the "STABLE_" suffix causes these to be part of the "stable" workspace
 # status, which may trigger rebuilds of certain targets if these values change
 # and you're building with the "--stamp" flag.
 #latest_version_tag=$(./tools/latest_version_tag.sh)
 #echo "STABLE_VERSION_TAG $latest_version_tag"
 echo "STABLE_COMMIT_SHA $commit_sha"
+
+build_id="${BUILD_ID:-}"
+if [[ -n "$build_id" ]]; then
+  echo "STABLE_BUILD_ID $build_id"
+fi
+
+now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+now_compact=$(date -u +"%Y%m%dT%H%M%SZ")
+
+echo "BUILD_TIMESTAMP $now"
+echo "BUILD_TIMESTAMP_COMPACT $now_compact"

--- a/web/public/build-info.json
+++ b/web/public/build-info.json
@@ -1,5 +1,6 @@
 {
-  "version": "1.0.53",
-  "buildId": "031300f9",
-  "buildTime": "2025-09-03T18:01:00Z"
+  "version": "dev",
+  "buildTime": "1970-01-01T00:00:00Z",
+  "webBuildId": "development",
+  "coreBuildId": "development"
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -38,22 +38,22 @@ const navItems = [
     { href: '/admin', label: 'Settings', icon: Settings },
 ];
 
+type BuildInfo = {
+    version?: string;
+    buildTime?: string;
+    webBuildId?: string;
+    coreBuildId?: string;
+};
+
 export default function Sidebar() {
     const pathname = usePathname();
-    const [buildInfo, setBuildInfo] = React.useState<{version?: string; buildId?: string}>({});
+    const [buildInfo, setBuildInfo] = React.useState<BuildInfo>({});
 
     React.useEffect(() => {
-        // Try to fetch build info from public file
         fetch('/build-info.json')
-            .then(res => res.json())
-            .then(data => setBuildInfo(data))
-            .catch(() => {
-                // Fallback to environment variables if file doesn't exist
-                setBuildInfo({
-                    version: process.env.NEXT_PUBLIC_VERSION || '1.0.0',
-                    buildId: process.env.NEXT_PUBLIC_BUILD_ID || 'dev'
-                });
-            });
+            .then(res => (res.ok ? res.json() : Promise.reject()))
+            .then((data: BuildInfo) => setBuildInfo(data))
+            .catch(() => setBuildInfo({}));
     }, []);
 
     return (
@@ -76,13 +76,19 @@ export default function Sidebar() {
                 })}
             </nav>
             <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
-                <div className="text-xs text-gray-500 dark:text-gray-400">
-                    {buildInfo.version && (
+                <div className="text-[11px] leading-4 text-gray-500 dark:text-gray-400 space-y-1">
+                    {buildInfo.version ? (
                         <div>Version: {buildInfo.version}</div>
-                    )}
-                    {buildInfo.buildId && (
-                        <div>Build: {buildInfo.buildId}</div>
-                    )}
+                    ) : null}
+                    {buildInfo.webBuildId ? (
+                        <div>Web Build: {buildInfo.webBuildId}</div>
+                    ) : null}
+                    {buildInfo.coreBuildId ? (
+                        <div>Core Build: {buildInfo.coreBuildId}</div>
+                    ) : null}
+                    {buildInfo.buildTime ? (
+                        <div>Built: {buildInfo.buildTime}</div>
+                    ) : null}
                 </div>
             </div>
         </aside>


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement SHA-based build IDs for web and core images using digest values

- Add dynamic `build-info.json` generation with web and core build IDs

- Fix build info file handling in entrypoint script to prevent overwrites

- Update sidebar to display separate web and core build identifiers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workspace_status.sh"] -- "generates build metadata" --> B["BUILD.bazel"]
  B -- "creates build-info.json" --> C["web_image layers"]
  C -- "embedded in image" --> D["entrypoint-web.sh"]
  D -- "preserves build-info" --> E["Sidebar.tsx"]
  E -- "displays build IDs" --> F["UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Generate build-info.json from image digests and layer into web image</code></dd></summary>
<hr>

docker/images/BUILD.bazel

<ul><li>Split <code>web_image_amd64</code> into base image and final image with build info <br>layers<br> <li> Add <code>web_build_info_json</code> genrule to generate build-info.json from image <br>digests<br> <li> Create four pkg_tar layers for build-info.json in different public <br>directories<br> <li> Extract short SHA hashes from web and core image digests for build IDs</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-0e4db31c224a8f72ae8e870a849e38a59d74a2c7f7b04347b0b3eb07e20c5a80">+108/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push_targets.bzl</strong><dd><code>Support custom digest labels for image push targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/images/push_targets.bzl

<ul><li>Update <code>GHCR_PUSH_TARGETS</code> to support custom digest labels<br> <li> Modify <code>declare_ghcr_push_targets</code> to handle optional third tuple <br>element<br> <li> Set web image to use <code>web_image_base_amd64.digest</code> instead of default</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-4af33fe62caba04b6d479589c16cfb85babc39bae5c92595d4d4e31660738513">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workspace_status.sh</strong><dd><code>Add version and timestamp variables to workspace status</code>&nbsp; &nbsp; </dd></summary>
<hr>

scripts/workspace_status.sh

<ul><li>Add <code>STABLE_VERSION</code> output from VERSION file or default to "dev"<br> <li> Add optional <code>STABLE_BUILD_ID</code> output from BUILD_ID environment variable<br> <li> Add <code>BUILD_TIMESTAMP</code> and <code>BUILD_TIMESTAMP_COMPACT</code> outputs with current <br>UTC time</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-31442ee54466f451fa76cecc2f586dd19991fbe1eb88a7173afdeddb2b1a2b2c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build-info.json</strong><dd><code>Split build ID into separate web and core identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/public/build-info.json

<ul><li>Change <code>buildId</code> field to separate <code>webBuildId</code> and <code>coreBuildId</code> fields<br> <li> Update default values to "development" for build IDs<br> <li> Set placeholder timestamps for development builds</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-27336c978a24dc1efea27c315b22cea8a6ae27e9db6db4f69abd07faad604ad1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Sidebar.tsx</strong><dd><code>Display separate web and core build IDs in sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/src/components/Sidebar.tsx

<ul><li>Add <code>BuildInfo</code> type with <code>webBuildId</code> and <code>coreBuildId</code> fields<br> <li> Update build info display to show separate web and core build IDs<br> <li> Simplify error handling in build info fetch logic<br> <li> Display build timestamp when available</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-219f9604c678f564c98ff1920201ea980331348dfb5dff7314a34d9fd198f1b1">+24/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint-web.sh</strong><dd><code>Preserve build-info.json during public asset flattening</code>&nbsp; &nbsp; </dd></summary>
<hr>

docker/compose/entrypoint-web.sh

<ul><li>Remove nested <code>build-info.json</code> before flattening public assets<br> <li> Copy root <code>build-info.json</code> back to nested location after flattening<br> <li> Apply same logic to both regular and standalone public directories</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1782/files#diff-cbf60f692a5b524b141bf8b7fcff7abba11038d0b1c5a08378c0fd89e742d74e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

