### PR TITLE
removing local auth requirement, didnt take in k8s though

### DIFF
--- a/k8s/demo/base/serviceradar-srql.yaml
+++ b/k8s/demo/base/serviceradar-srql.yaml
@@ -28,12 +28,12 @@ spec:
               value: "1"
             - name: PROTON_INSECURE_SKIP_VERIFY
               value: "1"
-        - name: PROTON_VERIFY_HOSTNAME
-          value: "0"
-        - name: AUTH_ENABLED
-          value: "false"
-        - name: SRQL_REQUIRE_BEARER
-          value: "true"
+            - name: PROTON_VERIFY_HOSTNAME
+              value: "0"
+            - name: AUTH_ENABLED
+              value: "true"
+            - name: SRQL_REQUIRE_BEARER
+              value: "true"
             - name: PROTON_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k8s/demo/base/serviceradar-web.yaml
+++ b/k8s/demo/base/serviceradar-web.yaml
@@ -38,14 +38,14 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
-        - name: NEXT_PUBLIC_API_URL
-          value: "http://localhost/api"
-        - name: NEXT_INTERNAL_API_URL
-          value: "http://serviceradar-core:8090"
-        - name: NEXT_INTERNAL_SRQL_URL
-          value: "http://serviceradar-kong:8000"
-        - name: AUTH_ENABLED
-          value: "false"
+            - name: NEXT_PUBLIC_API_URL
+              value: "http://localhost/api"
+            - name: NEXT_INTERNAL_API_URL
+              value: "http://serviceradar-core:8090"
+            - name: NEXT_INTERNAL_SRQL_URL
+              value: "http://serviceradar-kong:8000"
+            - name: AUTH_ENABLED
+              value: "true"
             - name: API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Disable authentication in Kubernetes demo deployment

- Set `AUTH_ENABLED` to `false` in both SRQL and Web services

- Fix YAML indentation formatting for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["K8s Demo Config"] -->|"AUTH_ENABLED: true"| B["Previous State"]
  A -->|"AUTH_ENABLED: false"| C["Updated State"]
  B -->|"SRQL Service"| D["Authentication Required"]
  B -->|"Web Service"| E["Authentication Required"]
  C -->|"SRQL Service"| F["Authentication Disabled"]
  C -->|"Web Service"| G["Authentication Disabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serviceradar-srql.yaml</strong><dd><code>Disable auth and fix YAML formatting in SRQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-srql.yaml

<ul><li>Changed <code>AUTH_ENABLED</code> environment variable from <code>"true"</code> to <code>"false"</code><br> <li> Fixed YAML indentation formatting for containers, env, ports, <br>volumeMounts, and volumes sections<br> <li> Standardized nested structure indentation throughout the deployment <br>manifest</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1797/files#diff-671bb3bfd8bad4c29730ae3c96b9b78e1d446fa378742bd2091b1edad63fec87">+69/-69</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-web.yaml</strong><dd><code>Disable auth and fix YAML formatting in Web</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-web.yaml

<ul><li>Changed <code>AUTH_ENABLED</code> environment variable from <code>"true"</code> to <code>"false"</code><br> <li> Fixed YAML indentation formatting for containers, args, ports, env, <br>and service sections<br> <li> Standardized nested structure indentation throughout the deployment <br>manifest</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1797/files#diff-38e9af448fa50de08128d5acfd59f72c662a2a89c2da2bd418dc1eedcd6b4679">+63/-63</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

