### PR TITLE
fixing md

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -203,7 +203,7 @@ Conflicts are also logged with the key path and gRPC status code whenever JetStr
 ### Rollout checklist
 
 1. **Staging seed:** run `serviceradar-core --config /etc/serviceradar/core.json --backfill-identities --seed-kv-only --backfill-dry-run` to pre-populate NATS KV without mutating history. Watch `identitymap_kv_publish_total{outcome="dry_run"}` to confirm keys are enumerated.
-2. **Validate signals:** scrape `identitymap_lookup_latency_seconds` and `identitymap_conflict_total` for at least one sweep interval. Conflicts should stay at zero and lookup latency below the alert threshold (<250 ms p95).
+2. **Validate signals:** scrape `identitymap_lookup_latency_seconds` and `identitymap_conflict_total` for at least one sweep interval. Conflicts should stay at zero and keep lookup latency below the alert threshold (p95 under 250 ms).
 3. **Commit the backfill:** rerun the job without `--backfill-dry-run` (and optionally with `--seed-kv-only=false`) to emit the tombstones and fold historical rows.
 4. **Flip the feature flag:** deploy the updated core configuration so the registry publishes canonical IDs by default (keeping the legacy tombstone path as a safety net). Repeat the same sequence in production once staging metrics hold steady.
 5. **Post-rollout watch:** leave the Prometheus alerts in place for at least one week; any sustained rise in `identitymap_conflict_total{reason="retry_exhausted"}` should trigger an incident to investigate duplicate identifiers.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Clarified alert threshold phrasing in rollout checklist

- Improved readability of latency metric specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original phrasing:<br/>below the alert threshold<br/>(&lt;250 ms p95)"] -- "Reword for clarity" --> B["Updated phrasing:<br/>keep lookup latency<br/>below alert threshold<br/>(p95 under 250 ms)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>architecture.md</strong><dd><code>Improve latency threshold documentation clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/docs/architecture.md

<ul><li>Rephrased latency threshold description in rollout checklist step 2<br> <li> Changed from "below the alert threshold (<250 ms p95)" to "keep lookup <br>latency below the alert threshold (p95 under 250 ms)"<br> <li> Improved clarity and consistency of metric specification language</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1798/files#diff-90abd06467420fd89391fd1a4d75ceb1f6a9381de4d13a95fffe606abff38d37">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

