### PR TITLE
db pkg cleanup

### DIFF
--- a/docker/compose/edge-e2e/FRICTION_POINTS.md
+++ b/docker/compose/edge-e2e/FRICTION_POINTS.md
@@ -20,13 +20,15 @@ DELETE FROM table(pollers) WHERE poller_id = $1 VALUES
 
 **Original Code**:
 ```go
-batch, err := db.Conn.PrepareBatch(ctx, "DELETE FROM table(pollers) WHERE poller_id = $1")
+if err := db.ExecCNPG(ctx, "DELETE FROM table(pollers) WHERE poller_id = $1", pollerID); err != nil {
+    // ...
+}
 ```
 
 **Fix**:
 ```go
 query := "ALTER TABLE pollers DELETE WHERE poller_id = $1"
-if err := db.Conn.Exec(ctx, query, pollerID); err != nil {
+if err := db.ExecCNPG(ctx, query, pollerID); err != nil {
     return fmt.Errorf("%w: failed to delete poller: %w", ErrFailedToInsert, err)
 }
 ```

--- a/docs/docs/cnpg-monitoring.md
+++ b/docs/docs/cnpg-monitoring.md
@@ -1,0 +1,130 @@
+---
+title: CNPG Monitoring
+---
+
+# CNPG Monitoring and Dashboards
+
+ServiceRadar now stores every telemetry signal (events, OTEL logs/metrics/traces, registry tables) inside the CloudNativePG (CNPG) cluster running TimescaleDB. This guide captures the dashboards and SQL checks operators should wire into Grafana or the toolbox so they can confirm ingestion, retention, and pgx pool health without relying on the retired Proton parity checks.
+
+## Data Source Setup
+
+Add the CNPG reader as a PostgreSQL data source in Grafana (or any SQL-friendly dashboarding tool):
+
+1. **Host / Port**: `cnpg-rw.<namespace>.svc.cluster.local:5432` (the RW service from the demo manifests).
+2. **Database**: `telemetry`.
+3. **User**: `postgres` (or a scoped read-only role).
+4. **TLS**: enable `verify-full` with the CA/cert pair that ships in `/etc/serviceradar/certs` or the `cnpg-ca` secret.
+5. **Connection pooling**: set the maximum concurrent connections to something small (≤5) so Grafana dashboards do not starve the application pool.
+
+Grafana can query Timescale directly, so each panel below simply executes SQL against the hypertables. If you prefer Prometheus, re-export these queries through the `pg_prometheus` or `pgwatch2` exporters—the SQL is identical.
+
+## Ingestion Dashboards
+
+Use the following query to chart OTEL log throughput (works for metrics/traces by swapping the table name):
+
+```sql
+SELECT
+  time_bucket('5 minutes', created_at) AS bucket,
+  COUNT(*) AS rows_ingested
+FROM logs
+WHERE created_at >= now() - INTERVAL '24 hours'
+GROUP BY bucket
+ORDER BY bucket;
+```
+
+Create three panels that hit `logs`, `otel_metrics`, and `otel_traces`. Grafana’s stacked bar visualization makes pipeline gaps obvious—missing buckets mean `serviceradar-db-event-writer` is not keeping up. Keep a single-stat panel that runs `SELECT COUNT(*) FROM events WHERE created_at >= now() - INTERVAL '5 minutes';` to power an alert when ingestion drops to zero.
+
+### db-event-writer Heatmap
+
+Build a table panel from `pg_stat_activity` to watch the pgx consumers:
+
+```sql
+SELECT
+  wait_event_type,
+  wait_event,
+  state,
+  COUNT(*) AS sessions
+FROM pg_stat_activity
+WHERE application_name LIKE 'db-writer%'
+  AND datname = current_database()
+GROUP BY 1,2,3
+ORDER BY sessions DESC;
+```
+
+Add a companion panel that counts `rows_processed` log entries via Loki or `kubectl logs` so operators can compare SQL volume against the application logs the moment a spike appears.
+
+## Retention and Compression Health
+
+Timescale registers background jobs for each hypertable. Surface their state with:
+
+```sql
+SELECT
+  job_id,
+  job_type,
+  hypertable_name,
+  last_run_duration,
+  last_successful_finish
+FROM timescaledb_information.job_stats
+WHERE hypertable_name IN ('events', 'logs', 'otel_metrics', 'otel_traces')
+ORDER BY hypertable_name, job_type;
+```
+
+Color the `last_successful_finish` column red if it is older than 15 minutes to catch stuck retention jobs. Pair this with the chunk/compression dashboard:
+
+```sql
+SELECT
+  h.hypertable_name,
+  round(h.total_bytes / 1024 / 1024, 2) AS mb,
+  c.compression_enabled,
+  c.compressed_chunks,
+  c.uncompressed_chunks
+FROM timescaledb_information.hypertable_detailed_size h
+LEFT JOIN timescaledb_information.hypertable_compression_stats c
+  ON h.hypertable_name = c.hypertable_name
+WHERE h.hypertable_name IN ('events', 'logs', 'otel_metrics', 'otel_traces')
+ORDER BY mb DESC;
+```
+
+Watching the compressed/uncompressed split helps explain PVC growth and ensures operators run `refresh_continuous_aggregate` after backfills.
+
+## Query and pgx Error Watch
+
+Enable `pg_stat_statements` (`CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`) and add a “Top 10 Slow Queries” table:
+
+```sql
+SELECT
+  round(mean_exec_time, 2) AS mean_ms,
+  calls,
+  rows,
+  query
+FROM pg_stat_statements
+WHERE query ILIKE '%otel%' OR query ILIKE '%events%'
+ORDER BY mean_exec_time DESC
+LIMIT 10;
+```
+
+Tie this to an alert that fires if `mean_ms` exceeds your SLA for more than two consecutive scrapes. For connection pool health, track waiters using `pg_stat_activity`:
+
+```sql
+SELECT
+  wait_event_type,
+  wait_event,
+  COUNT(*) AS blocked
+FROM pg_stat_activity
+WHERE wait_event_type IS NOT NULL
+GROUP BY 1,2
+ORDER BY blocked DESC;
+```
+
+Any sustained growth indicates the pgx pool is undersized or a migration locked a hypertable.
+
+## Alert Ideas
+
+| Signal | Query/Metric | Suggested Threshold |
+|--------|--------------|---------------------|
+| Ingestion Stall | `SELECT COUNT(*) FROM logs WHERE created_at >= now() - INTERVAL '5 minutes'` | `< 1` row triggers paging |
+| Retention Lag | `timescaledb_information.job_stats.last_successful_finish` | older than 15 minutes |
+| PVC Growth | `hypertable_detailed_size.total_bytes` | >10% growth per hour |
+| pgx Errors | `kubectl logs deploy/serviceradar-db-event-writer | grep "cnpg"` | any non-zero error rate should alert |
+
+Reuse your existing Prometheus stack to alert on pod restarts (`kube_pod_container_status_restarts_total`) and container CPU saturation (`container_cpu_usage_seconds_total`) for the CNPG and db-event-writer pods. Use this doc in tandem with the **Timescale Retention & Compression Checks** section in `agents.md` for the CLI-based playbook.

--- a/docs/kv-ci-plan.md
+++ b/docs/kv-ci-plan.md
@@ -1,0 +1,58 @@
+# KV Regression Safeguards
+
+We’ve already burned time debugging missing KV wiring (mapper, flowgger, datasvc RBAC). This doc captures a pragmatic plan for catching similar regressions in CI before images reach GHCR.
+
+## 1. Unit Tests Per Binary
+
+- **Go services**: add a `TestKVBootstrap` alongside each `cmd/<service>` package. Use `config.ServiceDescriptorFor(...)`, set `CONFIG_SOURCE=kv`, inject a fake KV client via `withKVClientFactory`, and assert that `config.ServiceWithTemplateRegistration(...)` returns a non-nil manager.  
+- **Rust services** (flowgger, trapd, zen, otel, rperf, etc.): add async tests that instantiate `config_bootstrap::Bootstrap` with `CONFIG_SOURCE=kv` and mock `kvutil::KvClient`. Ensure `Bootstrap::new` succeeds and `load()` attempts a KV overlay instead of silently falling back to files.
+- **Datasvc RBAC check**: table-driven unit test in `pkg/datasvc/rbac_test.go` to confirm every service certificate from `config/service_descriptors` has an entry granting at least `writer` role. Fail if a new descriptor is added without a matching RBAC rule.
+
+## 2. Compose Smoke Tests
+
+- Introduce a lightweight GitHub Action (or Buildkite job) that runs on every PR touching `cmd/` or `docker/compose/`. Steps:
+  1. `docker compose up datasvc nats -d`.
+  2. For each KV-aware service, run `./cmd/tools/config-sync --service <name> --output /tmp/foo --template docker/compose/<service>.docker.json|toml` to seed KV.
+  3. `docker compose up --exit-code-from <service> <service>` to ensure the container reaches its health check without `KV store not initialized` errors.  
+- Cache Bazel layers to keep runtime manageable; gate the matrix to the services touched by the PR (use `paths` filters).
+
+## 3. Template/Key Validation
+
+- Add a Go utility under `cmd/tools/kv-validate` that:
+  - Lists every descriptor from `pkg/config/registry`.
+  - Reads `config/` or `docker/compose/*.json|toml` defaults.
+  - Hits `http://localhost:50057` (datasvc) to confirm `config/<service>` exists after `docker compose up`.
+- Wire it into CI after the compose smoke test. Fail the job if any required key is missing; this prevents silent template regressions.
+
+## 4. RBAC Drift Detection
+
+- Write a script (Bash + `jq`) that parses:
+  - `docker/compose/datasvc.docker.json`
+  - `helm/serviceradar/files/serviceradar-config.yaml`
+  - `k8s/demo/base/serviceradar-config.yaml`
+  - systemd packaging configs
+- Compare the list of identities to `pkg/config/registry.go`. Fail CI if a descriptor has `CONFIG_SOURCE=kv` but lacks writer access in any deployment mode.
+
+## 5. Full Stack Watchdog (Nightly)
+
+- Nightly workflow to run `docker compose up -d`, wait for health checks, then:
+  - `docker compose exec serviceradar-tools nats-kv ls config`
+  - `docker compose exec serviceradar-tools nats-kv get config/<service>`
+  - Verify each service reports `KV update detected` at least once in its logs.
+- Archive logs + KV snapshots as artifacts for forensic diffing.
+
+## 6. Release Checklist Hook
+
+- Extend `scripts/cut-release.sh` to verify:
+  - `config-sync` successfully seeds every descriptor using the templates present in the release branch.
+  - Datasvc RBAC contains the identities we’re about to ship (preventing post-release mapper-style issues).
+- Fail the release script when the check breaks; force maintainers to fix KV before tagging.
+
+## Ownership & Next Actions
+
+1. **Mapper team**: add the Go unit test + docker compose smoke test job (target week 1).  
+2. **Rust platform**: port flowgger/trapd/zen to the new bootstrap tests (target week 2).  
+3. **Infra**: build the RBAC diff + nightly watchdog workflows (target week 3).  
+4. **Release eng**: extend `cut-release.sh` once the validators exist (target week 4).
+
+Once these land, any PR that drops KV wiring will fail before it’s merged, and nightly jobs will alert us if GHCR images regress after the fact.

--- a/openspec/changes/remove-registry-proton-shim/proposal.md
+++ b/openspec/changes/remove-registry-proton-shim/proposal.md
@@ -1,0 +1,17 @@
+# Change: Remove Proton-style registry compatibility shim
+
+## Why
+- The Proton migration spec promised that registry queries would run directly on CNPG/pgx, yet `pkg/registry` still routes every query and insert through `db.Conn`, a compatibility layer that rewrites `?` placeholders and emulates the Proton batch API (`pkg/db/db.go`).
+- This shim is the last code path that references "Proton" inside `pkg/db` (`pkg/db/interfaces.go:34`), keeps the `Service` interface tied to legacy semantics, and makes it harder to reason about prepared statements or benefit from pgx features.
+- Because the compatibility layer lives in `pkg/db`, any future schema work must understand both the typed CNPG helpers *and* the shimmed query flow, increasing maintenance risk.
+
+## What Changes
+- Remove `DB.Conn`/`CompatConn` from `pkg/db` and migrate every `pkg/registry` call site to typed helpers (`ExecCNPG`, `QueryCNPGRows`, or new helper methods dedicated to registry queries/events).
+- Replace the `PrepareBatch` based insert for `service_registration_events` with a pgx `Batch` helper that works natively with `$n` placeholders and typed metadata marshaling.
+- Update the `Service` interface/docs so it clearly describes CNPG responsibilities instead of Proton streams.
+- Expand registry-focused unit tests/mocks so they cover the new helpers and prove no code depends on Proton-style placeholder rewriting.
+
+## Impact
+- Touches `pkg/db` and `pkg/registry`, so we must rerun the Bazel Go tests covering both packages.
+- Slight refactors for callers that expected `db.Conn` to exist; mock generation may need updates after the interface changes.
+- No user-facing behavior change is expected, but the cleanup removes the last Proton references inside the Go data layer and makes future schema or registry work easier.

--- a/openspec/changes/remove-registry-proton-shim/specs/timeseries-storage/spec.md
+++ b/openspec/changes/remove-registry-proton-shim/specs/timeseries-storage/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+### Requirement: Postgres-native unified device and registry tables
+ServiceRadar MUST maintain canonical device inventory, poller/agent/checker registries, and the associated materialized state in ordinary Postgres tables with row-level version metadata instead of relying on Proton’s immutable streams.
+
+#### Scenario: Registry queries keep working
+- **GIVEN** a CLI or API request hits `pkg/registry.ServiceRegistry.GetPoller`/`ListPollers`
+- **WHEN** the request executes
+- **THEN** it reads from the Postgres tables (`pollers`, `agents`, `checkers`, `service_status` history) and returns the same shape/results that the Proton-backed queries produced.
+
+#### Scenario: Registry uses native pgx helpers
+- **GIVEN** any registry read/write (`DeleteService`, `PurgeInactive`, registration events, etc.)
+- **WHEN** it touches the database
+- **THEN** the code calls the shared CNPG helpers (or pgx APIs) directly with `$n` placeholders—no Proton-style `?` rewriting, compatibility shims, or `PrepareBatch` emulation remain in `pkg/db`.

--- a/openspec/changes/remove-registry-proton-shim/tasks.md
+++ b/openspec/changes/remove-registry-proton-shim/tasks.md
@@ -1,0 +1,9 @@
+## 1. Registry compatibility removal
+- [x] 1.1 Inventory `pkg/registry` usages of `db.Conn` (Query/QueryRow/Exec/PrepareBatch) and outline the SQL that needs `$n` placeholder rewrites.
+- [x] 1.2 Introduce CNPG helpers in `pkg/db` (e.g., `InsertServiceRegistrationEvent`, `QueryRegistryRows`) so registry callers can share batching/error handling without rolling their own `pgx` plumbing.
+- [x] 1.3 Update every registry query/write to call the new helpers (or `ExecCNPG`/`QueryCNPGRows`) with `$n` placeholders, ensuring tests cover the new code paths.
+- [x] 1.4 Delete `DB.Conn`, `CompatConn`, and the associated shim errors; regenerate mocks so the `Service` interface no longer exposes Proton-era methods.
+
+## 2. Documentation/tests
+- [x] 2.1 Refresh `pkg/db/interfaces.go` comments (and any developer docs) to describe the CNPG responsibilities instead of Timeplus Proton.
+- [x] 2.2 Extend registry unit tests (and integration tests if needed) to validate the pgx-based implementations, including service event inserts and purge/delete flows.

--- a/pkg/core/api/sysmon.go
+++ b/pkg/core/api/sysmon.go
@@ -396,11 +396,11 @@ func (s *APIServer) getCPUMetricsForDevice(
 	// Query cpu_metrics table directly for per-core data by device_id
 	const cpuQuery = `
 		SELECT timestamp, agent_id, host_id, core_id, usage_percent, frequency_hz, label, cluster
-		FROM table(cpu_metrics)
+		FROM cpu_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, core_id ASC`
 
-	rows, err := s.dbService.(*db.DB).Conn.Query(ctx, cpuQuery, deviceID, start, end)
+	rows, err := s.dbService.(*db.DB).QueryCNPGRows(ctx, cpuQuery, deviceID, start.UTC(), end.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query CPU metrics for device %s: %w", deviceID, err)
 	}
@@ -452,11 +452,11 @@ func (s *APIServer) getCPUMetricsForDevice(
 
 	const clusterQuery = `
 		SELECT timestamp, agent_id, host_id, cluster, frequency_hz
-		FROM table(cpu_cluster_metrics)
+		FROM cpu_cluster_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, cluster ASC`
 
-	clusterRows, err := s.dbService.(*db.DB).Conn.Query(ctx, clusterQuery, deviceID, start, end)
+	clusterRows, err := s.dbService.(*db.DB).QueryCNPGRows(ctx, clusterQuery, deviceID, start.UTC(), end.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query CPU cluster metrics for device %s: %w", deviceID, err)
 	}
@@ -519,11 +519,11 @@ func (s *APIServer) getMemoryMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, used_bytes, total_bytes
-		FROM table(memory_metrics)
+		FROM memory_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC`
 
-	rows, err := s.dbService.(*db.DB).Conn.Query(ctx, query, deviceID, start, end)
+	rows, err := s.dbService.(*db.DB).QueryCNPGRows(ctx, query, deviceID, start.UTC(), end.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query memory metrics for device %s: %w", deviceID, err)
 	}
@@ -573,11 +573,11 @@ func (s *APIServer) getDiskMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, mount_point, used_bytes, total_bytes
-		FROM table(disk_metrics)
+		FROM disk_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, mount_point ASC`
 
-	rows, err := s.dbService.(*db.DB).Conn.Query(ctx, query, deviceID, start, end)
+	rows, err := s.dbService.(*db.DB).QueryCNPGRows(ctx, query, deviceID, start.UTC(), end.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query disk metrics for device %s: %w", deviceID, err)
 	}
@@ -637,11 +637,11 @@ func (s *APIServer) getProcessMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, pid, name, cpu_usage, memory_usage, status, start_time
-		FROM table(process_metrics)
+		FROM process_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, pid ASC`
 
-	rows, err := s.dbService.(*db.DB).Conn.Query(ctx, query, deviceID, start, end)
+	rows, err := s.dbService.(*db.DB).QueryCNPGRows(ctx, query, deviceID, start.UTC(), end.UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query process metrics for device %s: %w", deviceID, err)
 	}

--- a/pkg/db/cnpg_registry_test.go
+++ b/pkg/db/cnpg_registry_test.go
@@ -81,3 +81,40 @@ func TestBuildCNPGServiceArgs(t *testing.T) {
 	assert.Equal(t, service.Partition, args[6])
 	assertJSONRawEquals(t, map[string]string{"interval": "30s"}, args[5])
 }
+
+func TestBuildCNPGServiceRegistrationEventArgs(t *testing.T) {
+	now := time.Date(2025, time.February, 3, 4, 5, 0, 0, time.UTC)
+	event := &ServiceRegistrationEvent{
+		EventID:            "evt-123",
+		EventType:          "deleted",
+		ServiceID:          "svc-1",
+		ServiceType:        "checker",
+		ParentID:           "agent-1",
+		RegistrationSource: "implicit",
+		Actor:              "system",
+		Timestamp:          now,
+		Metadata: map[string]string{
+			"reason": "purged",
+		},
+	}
+
+	args, err := buildCNPGServiceRegistrationEventArgs(event)
+	require.NoError(t, err)
+	require.Len(t, args, 9)
+
+	assert.Equal(t, event.EventID, args[0])
+	assert.Equal(t, event.EventType, args[1])
+	assert.Equal(t, event.ServiceID, args[2])
+	assert.Equal(t, event.ServiceType, args[3])
+	assert.Equal(t, event.ParentID, args[4])
+	assert.Equal(t, event.RegistrationSource, args[5])
+	assert.Equal(t, event.Actor, args[6])
+
+	ts, ok := args[7].(time.Time)
+	require.True(t, ok)
+	assert.Equal(t, now, ts)
+
+	rawMetadata, ok := args[8].(json.RawMessage)
+	require.True(t, ok)
+	assertJSONRawEquals(t, map[string]string{"reason": "purged"}, rawMetadata)
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -45,7 +44,6 @@ const defaultPartitionValue = "default"
 type DB struct {
 	pgPool *pgxpool.Pool
 	logger logger.Logger
-	Conn   *CompatConn
 }
 
 // New creates a new CNPG-backed database connection and initializes the schema.
@@ -76,7 +74,6 @@ func New(ctx context.Context, config *models.CoreServiceConfig, log logger.Logge
 		pgPool: cnpgPool,
 		logger: log,
 	}
-	db.Conn = newCompatConn(db)
 
 	return db, nil
 }
@@ -137,6 +134,11 @@ func (db *DB) QueryCNPGRows(ctx context.Context, query string, args ...interface
 	return &cnpgRows{rows: rows}, nil
 }
 
+// QueryRegistryRows proxies registry reads to the CNPG pool.
+func (db *DB) QueryRegistryRows(ctx context.Context, query string, args ...interface{}) (Rows, error) {
+	return db.QueryCNPGRows(ctx, query, args...)
+}
+
 // ExecCNPG executes a statement against the CNPG pool.
 func (db *DB) ExecCNPG(ctx context.Context, query string, args ...interface{}) error {
 	if !db.cnpgConfigured() {
@@ -195,187 +197,6 @@ func normalizeCNPGValue(value interface{}) interface{} {
 	default:
 		return v
 	}
-}
-
-// CompatConn provides a minimal subset of the old Proton batch/Exec APIs backed by CNPG.
-type CompatConn struct {
-	db *DB
-}
-
-type compatBatch struct {
-	conn       *CompatConn
-	ctx        context.Context
-	columns    []string
-	insertSQL  string
-	rowBuffers [][]interface{}
-}
-
-type errorRow struct {
-	err error
-}
-
-func (r *errorRow) Scan(_ ...interface{}) error {
-	return r.err
-}
-
-func newCompatConn(db *DB) *CompatConn {
-	if db == nil {
-		return nil
-	}
-
-	return &CompatConn{db: db}
-}
-
-// PrepareBatch emulates the Proton driver's insert batch writes by parsing the simple
-// INSERT statement and replaying each appended row through ExecCNPG.
-func (c *CompatConn) PrepareBatch(ctx context.Context, query string) (*compatBatch, error) {
-	if c == nil || c.db == nil {
-		return nil, ErrCNPGCompatUnconfigured
-	}
-
-	table, columns, err := parseInsertStatement(query)
-	if err != nil {
-		return nil, err
-	}
-
-	insertSQL := buildInsertStatement(table, columns)
-
-	return &compatBatch{
-		conn:       c,
-		ctx:        ctx,
-		columns:    columns,
-		insertSQL:  insertSQL,
-		rowBuffers: make([][]interface{}, 0),
-	}, nil
-}
-
-// Append buffers a single row worth of values that will be flushed when Send is invoked.
-func (b *compatBatch) Append(values ...interface{}) error {
-	if len(values) != len(b.columns) {
-		return fmt.Errorf("%w: expected %d values, got %d", ErrBatchValueCountMismatch, len(b.columns), len(values))
-	}
-
-	row := make([]interface{}, len(values))
-	copy(row, values)
-	b.rowBuffers = append(b.rowBuffers, row)
-	return nil
-}
-
-// Send executes the buffered INSERT statements against CNPG.
-func (b *compatBatch) Send() error {
-	if len(b.rowBuffers) == 0 {
-		return nil
-	}
-
-	for _, row := range b.rowBuffers {
-		if err := b.conn.db.ExecCNPG(b.ctx, b.insertSQL, row...); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// QueryRow rewrites '?' placeholders to '$n' and proxies to pgxpool.
-func (c *CompatConn) QueryRow(ctx context.Context, query string, args ...interface{}) pgx.Row {
-	if c == nil || c.db == nil {
-		return &errorRow{err: ErrCNPGCompatUnconfigured}
-	}
-
-	rewritten, err := rewritePlaceholders(query, len(args))
-	if err != nil {
-		return &errorRow{err: err}
-	}
-
-	return c.db.pgPool.QueryRow(ctx, rewritten, args...)
-}
-
-// Query proxies Proton-style queries to CNPG.
-func (c *CompatConn) Query(ctx context.Context, query string, args ...interface{}) (Rows, error) {
-	if c == nil || c.db == nil {
-		return nil, ErrCNPGCompatUnconfigured
-	}
-
-	rewritten, err := rewritePlaceholders(query, len(args))
-	if err != nil {
-		return nil, err
-	}
-
-	return c.db.QueryCNPGRows(ctx, rewritten, args...)
-}
-
-// Exec executes a single statement with Proton-style '?' placeholders.
-func (c *CompatConn) Exec(ctx context.Context, query string, args ...interface{}) error {
-	if c == nil || c.db == nil {
-		return ErrCNPGCompatUnconfigured
-	}
-
-	rewritten, err := rewritePlaceholders(query, len(args))
-	if err != nil {
-		return err
-	}
-
-	return c.db.ExecCNPG(ctx, rewritten, args...)
-}
-
-var insertStmtRegex = regexp.MustCompile(`(?is)insert\s+into\s+([a-zA-Z0-9_\."]+)\s*\(([^)]+)\)`)
-
-func parseInsertStatement(query string) (string, []string, error) {
-	matches := insertStmtRegex.FindStringSubmatch(query)
-	if len(matches) != 3 {
-		return "", nil, fmt.Errorf("%w: %s", ErrUnsupportedInsertStatement, query)
-	}
-
-	table := strings.TrimSpace(matches[1])
-	rawColumns := strings.Split(matches[2], ",")
-	columns := make([]string, 0, len(rawColumns))
-	for _, col := range rawColumns {
-		col = strings.TrimSpace(col)
-		if col != "" {
-			columns = append(columns, col)
-		}
-	}
-
-	if len(columns) == 0 {
-		return "", nil, fmt.Errorf("%w: %s", ErrInsertColumnsMissing, query)
-	}
-
-	return table, columns, nil
-}
-
-func buildInsertStatement(table string, columns []string) string {
-	placeholders := make([]string, len(columns))
-	for i := range columns {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-	}
-
-	return fmt.Sprintf(
-		"INSERT INTO %s (%s) VALUES (%s)",
-		table,
-		strings.Join(columns, ", "),
-		strings.Join(placeholders, ", "),
-	)
-}
-
-func rewritePlaceholders(query string, argCount int) (string, error) {
-	var builder strings.Builder
-	count := 0
-
-	for _, r := range query {
-		if r == '?' {
-			count++
-			builder.WriteString(fmt.Sprintf("$%d", count))
-			continue
-		}
-
-		builder.WriteRune(r)
-	}
-
-	if argCount >= 0 && count != argCount {
-		return "", fmt.Errorf("%w: query expects %d args, got %d", ErrPlaceholderMismatch, count, argCount)
-	}
-
-	return builder.String(), nil
 }
 
 // GetAllMountPoints retrieves all unique mount points for a poller.

--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -75,6 +75,7 @@ var (
 	ErrServiceStatusPollerIDMissing = errors.New("service status poller id is required")
 	ErrServiceNil                   = errors.New("service nil")
 	ErrServicePollerIDMissing       = errors.New("service poller id required")
+	ErrServiceRegistrationEventNil  = errors.New("service registration event is nil")
 
 	// Sweep validation errors.
 
@@ -83,14 +84,9 @@ var (
 	ErrSweepPollerIDMissing = errors.New("poller id is required")
 	ErrSweepAgentIDMissing  = errors.New("agent id is required")
 
-	// Compat connection helpers.
+	// Rows helpers.
 
-	ErrCNPGCompatUnconfigured     = errors.New("cnpg connection not configured")
-	ErrBatchValueCountMismatch    = errors.New("batch append value count mismatch")
-	ErrUnsupportedInsertStatement = errors.New("unsupported insert statement")
-	ErrInsertColumnsMissing       = errors.New("no columns parsed from insert statement")
-	ErrPlaceholderMismatch        = errors.New("placeholder count mismatch")
-	ErrCNPGRowsNotInitialized     = errors.New("cnpg rows not initialized")
+	ErrCNPGRowsNotInitialized = errors.New("cnpg rows not initialized")
 
 	// TLS helpers.
 

--- a/pkg/db/interfaces.go
+++ b/pkg/db/interfaces.go
@@ -31,7 +31,7 @@ type QueryExecutor interface {
 	ExecuteQuery(ctx context.Context, query string, params ...interface{}) ([]map[string]interface{}, error)
 }
 
-// Service represents all database operations for Timeplus Proton.
+// Service represents all CNPG-backed database operations.
 type Service interface {
 	Close() error
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -72,7 +72,7 @@ type DeviceRegistry struct {
 
 type cnpgRegistryClient interface {
 	UseCNPGReads() bool
-	QueryCNPGRows(ctx context.Context, query string, args ...interface{}) (db.Rows, error)
+	QueryRegistryRows(ctx context.Context, query string, args ...interface{}) (db.Rows, error)
 }
 
 // NewDeviceRegistry creates a new, authoritative device registry.
@@ -658,7 +658,7 @@ func (r *DeviceRegistry) queryCNPGRows(ctx context.Context, query string, args .
 		return nil, errCNPGQueryUnsupported
 	}
 
-	return client.QueryCNPGRows(ctx, query, args...)
+	return client.QueryRegistryRows(ctx, query, args...)
 }
 
 func filterIdentifierValues(values []string) []string {

--- a/pkg/registry/registry_cnpg_test.go
+++ b/pkg/registry/registry_cnpg_test.go
@@ -31,7 +31,7 @@ func (m *cnpgMockService) UseCNPGReads() bool {
 	return m.useCNPG
 }
 
-func (m *cnpgMockService) QueryCNPGRows(ctx context.Context, query string, args ...interface{}) (db.Rows, error) {
+func (m *cnpgMockService) QueryRegistryRows(ctx context.Context, query string, args ...interface{}) (db.Rows, error) {
 	if m.queryFn == nil {
 		return nil, errQueryFnNotConfigured
 	}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Remove Proton compatibility shim (`db.Conn`, `CompatConn`) from database layer

- Migrate all registry queries to native CNPG/pgx with `$n` placeholders

- Add typed `ServiceRegistrationEvent` struct and batch insert helper

- Update sysmon API queries to use `QueryCNPGRows` and UTC timestamp normalization

- Simplify registry operations by eliminating placeholder rewriting logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pkg/registry<br/>Query/Insert calls"] -->|"Previously via<br/>db.Conn shim"| B["CompatConn<br/>Placeholder rewrite"]
  B --> C["pgxpool"]
  A -->|"Now direct"| D["QueryCNPGRows<br/>ExecCNPG<br/>InsertServiceRegistrationEvents"]
  D --> C
  E["ServiceRegistrationEvent<br/>struct"] --> D
  F["Sysmon API<br/>metrics queries"] -->|"Updated to<br/>QueryCNPGRows"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>sysmon.go</strong><dd><code>Replace direct Conn.Query with QueryCNPGRows helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-4879e8b367ee55413c6cb006f23bb912261df5310c640d3af352033cf97ffc84">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cnpg_registry.go</strong><dd><code>Add ServiceRegistrationEvent type and batch insert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-e31b8b854d9ba774d2f3ed9899b1f5902462cd0e63990a2898dcaf9bc171d571">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errors.go</strong><dd><code>Remove compat connection errors, add event validation error</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-993d3cbb9129e2dbe72c2785718929ee4a7dc9e3974b73f717f8c83eede44957">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.go</strong><dd><code>Replace QueryCNPGRows with QueryRegistryRows method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-cb61d8f79451b9541de4a8cc0811523a68d15452b2f5971c7618ea5b423cf4ec">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_registry.go</strong><dd><code>Migrate event emission and deletion to native CNPG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-d6d6d09a58edde934a1d3f571ff5ce02f0475c5e85ecdec27888892aff8d9d1d">+112/-111</a></td>

</tr>

<tr>
  <td><strong>service_registry_queries.go</strong><dd><code>Remove Proton-style queries, use CNPG helpers directly</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-3591e8646384be68811f862b986342253cabc23176c6f0e09996453baf88a2e9">+16/-521</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>cnpg_registry_test.go</strong><dd><code>Test ServiceRegistrationEvent argument building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-e38716ee5b3614089e00e851d22d2c61e9934ebcc2b44b7aa4b79623251af869">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry_cnpg_test.go</strong><dd><code>Update mock to use QueryRegistryRows interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-175c7dc3d844415bcdce3b7654e947aec09346eee22ac4e67487b0b491d46e21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_registry_queries_test.go</strong><dd><code>Remove placeholder escaping tests, add event writer tests</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-6375daf4a77f18366326db1ac818f613eea7735f4bdc23c886274edc58826656">+140/-70</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>db.go</strong><dd><code>Remove CompatConn and placeholder rewriting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-5da3684806835246d262230050593f460b12b6c0e3966df174e6061be0e9e575">+5/-184</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>interfaces.go</strong><dd><code>Update Service interface documentation for CNPG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-c230fe0c315251837357bfde4ae7f7b34080398d8e48af6bf78badb2124271f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FRICTION_POINTS.md</strong><dd><code>Update DELETE example to use ExecCNPG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-b0653c58880f810ba832c0500733d63de309db98b43009fe73a1862494cf41bd">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cnpg-monitoring.md</strong><dd><code>Add CNPG monitoring dashboards and retention checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-8c105f73fd3323743d06525e84c5d0c686b447742dca1a5cf2776b1afc9b8ba2">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>kv-ci-plan.md</strong><dd><code>Add KV regression safeguards and CI validation plan</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-60ccc8f58261bec42e9c77f3647e9b40505e2c5c343b5de62add7ff22581c8e7">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong><dd><code>Document rationale for removing Proton compatibility layer</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-9ffe47187efe19b5084ed1a469b3968036d7e8ceaef769941d036d654b875bae">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Define requirements for Postgres-native registry tables</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-d16036359c50038867c508ffd03d819586d7940f78c71e9e964608944b5fd7b4">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong><dd><code>Track completion of registry compatibility removal tasks</code>&nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1946/files#diff-a95a4231cd1c5a744e1cb535f65f8b5567c1a20090792590c4a573962521c4a3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

