### PR TITLE
sweeper test fixes

### DIFF
--- a/pkg/sweeper/sweeper.go
+++ b/pkg/sweeper/sweeper.go
@@ -771,15 +771,12 @@ func (s *NetworkSweeper) UpdateConfig(config *models.Config) error {
 }
 
 // configReadySignal ensures the channel is only closed once even if multiple goroutines race to signal readiness.
-func newConfigReadySignal(ch chan<- struct{}) func() {
+func newConfigReadySignal(ch chan struct{}) func() {
 	var once sync.Once
 
 	return func() {
 		once.Do(func() {
-			select {
-			case ch <- struct{}{}:
-			default:
-			}
+			close(ch)
 		})
 	}
 }


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix channel signal mechanism in `newConfigReadySignal` function

- Replace send-with-default pattern with proper channel close

- Change channel parameter from send-only to bidirectional type

- Simplify synchronization logic using sync.Once


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Send-with-default pattern"] -- "Replace with" --> B["Channel close"]
  C["Send-only channel type"] -- "Change to" --> D["Bidirectional channel"]
  B -- "Maintains" --> E["sync.Once safety"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sweeper.go</strong><dd><code>Simplify channel signal with close instead of send</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/sweeper.go

<ul><li>Changed <code>newConfigReadySignal</code> channel parameter from send-only (<code>chan<- </code><br><code>struct{}</code>) to bidirectional (<code>chan struct{}</code>)<br> <li> Replaced select statement with default case with direct <code>close(ch)</code> call<br> <li> Simplified signal mechanism while maintaining thread-safety via <br><code>sync.Once</code><br> <li> Reduces complexity and potential race conditions in config readiness <br>signaling</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1953/files#diff-d11dee1504de681453c5a04e22ae44d64820221ac6b84a1630d3a3929dace47a">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

