### PR TITLE
adding more tests for devices queries

### DIFF
--- a/rust/srql/tests/fixtures/seed.sql
+++ b/rust/srql/tests/fixtures/seed.sql
@@ -1,39 +1,37 @@
 -- Canonical SRQL device fixture rows.
 TRUNCATE unified_devices RESTART IDENTITY;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO unified_devices (
-    device_id,
-    ip,
-    poller_id,
-    agent_id,
-    hostname,
-    mac,
-    discovery_sources,
-    is_available,
-    first_seen,
-    last_seen,
-    metadata,
-    device_type,
-    service_type,
-    service_status,
-    last_heartbeat,
-    os_info,
-    version_info
-)
-SELECT
-    'device-alpha',
+        device_id,
+        ip,
+        poller_id,
+        agent_id,
+        hostname,
+        mac,
+        discovery_sources,
+        is_available,
+        first_seen,
+        last_seen,
+        metadata,
+        device_type,
+        service_type,
+        service_status,
+        last_heartbeat,
+        os_info,
+        version_info
+    )
+SELECT 'device-alpha',
     '10.10.10.5',
     'poller-1',
     'agent-1',
     'alpha-edge',
     'aa:bb:cc:dd:ee:01',
-    ARRAY['sweep','armis'],
+    ARRAY ['sweep','armis'],
     TRUE,
     base.now_ts - INTERVAL '14 days',
-    base.now_ts - INTERVAL '1 hour',
+    base.now_ts - INTERVAL '30 minutes',
     '{"site":"dfw-edge","packet_loss_bucket":"low"}'::jsonb,
     'network_device',
     'router',
@@ -43,14 +41,13 @@ SELECT
     '17.9.3'
 FROM base
 UNION ALL
-SELECT
-    'device-beta',
+SELECT 'device-beta',
     '10.10.20.6',
     'poller-1',
     'agent-2',
     'beta-core',
     'aa:bb:cc:dd:ee:02',
-    ARRAY['armis'],
+    ARRAY ['armis'],
     FALSE,
     base.now_ts - INTERVAL '10 days',
     base.now_ts - INTERVAL '3 hours',
@@ -63,14 +60,13 @@ SELECT
     '10.2(4)'
 FROM base
 UNION ALL
-SELECT
-    'device-gamma',
+SELECT 'device-gamma',
     '10.10.30.7',
     'poller-2',
     'agent-3',
     'gamma-edge',
     'aa:bb:cc:dd:ee:03',
-    ARRAY['sweep'],
+    ARRAY ['sweep'],
     TRUE,
     base.now_ts - INTERVAL '6 days',
     base.now_ts - INTERVAL '2 hours',
@@ -81,94 +77,251 @@ SELECT
     base.now_ts - INTERVAL '90 minutes',
     'PAN-OS',
     '11.1.0'
+FROM base
+UNION ALL
+SELECT 'device-delta',
+    '10.10.40.8',
+    'poller-2',
+    'agent-3',
+    'delta-legacy',
+    'aa:bb:cc:dd:ee:04',
+    ARRAY ['sweep'],
+    TRUE,
+    base.now_ts - INTERVAL '20 days',
+    base.now_ts - INTERVAL '8 days',
+    '{"site":"phx-edge","packet_loss_bucket":"low"}'::jsonb,
+    'network_device',
+    'switch',
+    'healthy',
+    base.now_ts - INTERVAL '8 days',
+    'IOS',
+    '15.2'
 FROM base;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO pollers (
-    poller_id, component_id, registration_source, status, spiffe_identity,
-    first_registered, first_seen, last_seen, metadata, created_by,
-    is_healthy, agent_count, checker_count, updated_at
-)
-SELECT
-    'poller-1', 'comp-1', 'manual', 'active', 'spiffe://example.org/poller/1',
-    base.now_ts - INTERVAL '30 days', base.now_ts - INTERVAL '30 days', base.now_ts - INTERVAL '1 minute',
-    '{"region":"us-west"}'::jsonb, 'admin', true, 10, 50, base.now_ts
+        poller_id,
+        component_id,
+        registration_source,
+        status,
+        spiffe_identity,
+        first_registered,
+        first_seen,
+        last_seen,
+        metadata,
+        created_by,
+        is_healthy,
+        agent_count,
+        checker_count,
+        updated_at
+    )
+SELECT 'poller-1',
+    'comp-1',
+    'manual',
+    'active',
+    'spiffe://example.org/poller/1',
+    base.now_ts - INTERVAL '30 days',
+    base.now_ts - INTERVAL '30 days',
+    base.now_ts - INTERVAL '1 minute',
+    '{"region":"us-west"}'::jsonb,
+    'admin',
+    true,
+    10,
+    50,
+    base.now_ts
 FROM base
 UNION ALL
-SELECT
-    'poller-2', 'comp-2', 'auto', 'active', 'spiffe://example.org/poller/2',
-    base.now_ts - INTERVAL '15 days', base.now_ts - INTERVAL '15 days', base.now_ts - INTERVAL '2 minutes',
-    '{"region":"us-east"}'::jsonb, 'system', true, 5, 25, base.now_ts
+SELECT 'poller-2',
+    'comp-2',
+    'auto',
+    'active',
+    'spiffe://example.org/poller/2',
+    base.now_ts - INTERVAL '15 days',
+    base.now_ts - INTERVAL '15 days',
+    base.now_ts - INTERVAL '2 minutes',
+    '{"region":"us-east"}'::jsonb,
+    'system',
+    true,
+    5,
+    25,
+    base.now_ts
 FROM base;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO service_status (
-    timestamp, poller_id, agent_id, service_name, service_type,
-    available, message, details, partition, created_at
-)
-SELECT
-    base.now_ts - INTERVAL '5 minutes', 'poller-1', 'agent-1', 'ssh', 'ssh',
-    true, 'SSH service running', 'listening on port 22', 'default', base.now_ts
+        timestamp,
+        poller_id,
+        agent_id,
+        service_name,
+        service_type,
+        available,
+        message,
+        details,
+        partition,
+        created_at
+    )
+SELECT base.now_ts - INTERVAL '5 minutes',
+    'poller-1',
+    'agent-1',
+    'ssh',
+    'ssh',
+    true,
+    'SSH service running',
+    'listening on port 22',
+    'default',
+    base.now_ts
 FROM base
 UNION ALL
-SELECT
-    base.now_ts - INTERVAL '10 minutes', 'poller-1', 'agent-1', 'http', 'http',
-    false, 'HTTP service down', 'connection refused', 'default', base.now_ts
+SELECT base.now_ts - INTERVAL '10 minutes',
+    'poller-1',
+    'agent-1',
+    'http',
+    'http',
+    false,
+    'HTTP service down',
+    'connection refused',
+    'default',
+    base.now_ts
 FROM base;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO cpu_metrics (
-    timestamp, poller_id, agent_id, host_id, core_id,
-    usage_percent, frequency_hz, label, cluster, device_id, partition, created_at
-)
-SELECT
-    base.now_ts - INTERVAL '1 minute', 'poller-1', 'agent-1', 'host-1', 0,
-    45.5, 2400000000, 'cpu0', 'cluster-a', 'device-alpha', 'default', base.now_ts
+        timestamp,
+        poller_id,
+        agent_id,
+        host_id,
+        core_id,
+        usage_percent,
+        frequency_hz,
+        label,
+        cluster,
+        device_id,
+        partition,
+        created_at
+    )
+SELECT base.now_ts - INTERVAL '1 minute',
+    'poller-1',
+    'agent-1',
+    'host-1',
+    0,
+    45.5,
+    2400000000,
+    'cpu0',
+    'cluster-a',
+    'device-alpha',
+    'default',
+    base.now_ts
 FROM base
 UNION ALL
-SELECT
-    base.now_ts - INTERVAL '2 minutes', 'poller-1', 'agent-1', 'host-1', 1,
-    88.2, 2400000000, 'cpu1', 'cluster-a', 'device-alpha', 'default', base.now_ts
+SELECT base.now_ts - INTERVAL '2 minutes',
+    'poller-1',
+    'agent-1',
+    'host-1',
+    1,
+    88.2,
+    2400000000,
+    'cpu1',
+    'cluster-a',
+    'device-alpha',
+    'default',
+    base.now_ts
 FROM base;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO logs (
-    timestamp, trace_id, span_id, severity_text, severity_number,
-    body, service_name, service_version, service_instance, scope_name,
-    scope_version, attributes, resource_attributes, created_at
-)
-SELECT
-    base.now_ts - INTERVAL '1 minute', 'trace-1', 'span-1', 'INFO', 9,
-    'Application started', 'my-service', '1.0.0', 'inst-1', 'my-scope',
-    '1.0', '{"key":"value"}'::text, '{"res":"val"}'::text, base.now_ts
+        timestamp,
+        trace_id,
+        span_id,
+        severity_text,
+        severity_number,
+        body,
+        service_name,
+        service_version,
+        service_instance,
+        scope_name,
+        scope_version,
+        attributes,
+        resource_attributes,
+        created_at
+    )
+SELECT base.now_ts - INTERVAL '1 minute',
+    'trace-1',
+    'span-1',
+    'INFO',
+    9,
+    'Application started',
+    'my-service',
+    '1.0.0',
+    'inst-1',
+    'my-scope',
+    '1.0',
+    '{"key":"value"}'::text,
+    '{"res":"val"}'::text,
+    base.now_ts
 FROM base
 UNION ALL
-SELECT
-    base.now_ts - INTERVAL '5 minutes', 'trace-2', 'span-2', 'ERROR', 17,
-    'Connection failed', 'my-service', '1.0.0', 'inst-1', 'my-scope',
-    '1.0', '{"error":"timeout"}'::text, '{"res":"val"}'::text, base.now_ts
+SELECT base.now_ts - INTERVAL '5 minutes',
+    'trace-2',
+    'span-2',
+    'ERROR',
+    17,
+    'Connection failed',
+    'my-service',
+    '1.0.0',
+    'inst-1',
+    'my-scope',
+    '1.0',
+    '{"error":"timeout"}'::text,
+    '{"res":"val"}'::text,
+    base.now_ts
 FROM base;
-
 WITH base AS (
     SELECT NOW() AS now_ts
 )
 INSERT INTO otel_traces (
-    timestamp, trace_id, span_id, parent_span_id, name, kind,
-    start_time_unix_nano, end_time_unix_nano, service_name, service_version,
-    service_instance, scope_name, scope_version, status_code, status_message,
-    attributes, resource_attributes, events, links, created_at
-)
-SELECT
-    base.now_ts - INTERVAL '1 minute', 'trace-1', 'span-1', NULL, 'handle_request', 1,
-    1600000000000000000, 1600000000100000000, 'api-service', 'v1',
-    'pod-1', 'http-server', '1.0', 1, 'OK',
-    '{"http.method":"GET"}'::text, '{"k8s.pod":"pod-1"}'::text, '[]', '[]', base.now_ts
+        timestamp,
+        trace_id,
+        span_id,
+        parent_span_id,
+        name,
+        kind,
+        start_time_unix_nano,
+        end_time_unix_nano,
+        service_name,
+        service_version,
+        service_instance,
+        scope_name,
+        scope_version,
+        status_code,
+        status_message,
+        attributes,
+        resource_attributes,
+        events,
+        links,
+        created_at
+    )
+SELECT base.now_ts - INTERVAL '1 minute',
+    'trace-1',
+    'span-1',
+    NULL,
+    'handle_request',
+    1,
+    1600000000000000000,
+    1600000000100000000,
+    'api-service',
+    'v1',
+    'pod-1',
+    'http-server',
+    '1.0',
+    1,
+    'OK',
+    '{"http.method":"GET"}'::text,
+    '{"k8s.pod":"pod-1"}'::text,
+    '[]',
+    '[]',
+    base.now_ts
 FROM base;


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Tests


___

### **Description**
- Add seven new device query test cases covering time filters

- Test sorting by last_seen in ascending and descending order

- Test limit functionality and is_available filter conditions

- Add device-delta fixture with 8-day old timestamp for testing

- Reformat SQL seed file with consistent indentation and spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Cases"] -->|"time filters"| B["last_7d, last_1h"]
  A -->|"sorting"| C["last_seen asc/desc"]
  A -->|"filtering"| D["limit, is_available"]
  E["Seed Data"] -->|"new device"| F["device-delta"]
  E -->|"reformatted"| G["SQL consistency"]
  B --> H["Comprehensive Coverage"]
  C --> H
  D --> H
  F --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comprehensive_queries.rs</strong><dd><code>Add device query test cases with validators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/tests/comprehensive_queries.rs

<ul><li>Add seven new test cases for device queries with detailed comments<br> <li> Test time-based filtering with <code>time:last_7d</code> and <code>time:last_1h</code><br> <li> Test sorting functionality with <code>sort:last_seen:desc</code> and <br><code>sort:last_seen:asc</code><br> <li> Test limit and is_available filter conditions with result validation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1959/files#diff-2d17debb1fb0e91ce3a1ec48f779dca4a145489187cd73b1d2848a6312d48c8c">+64/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>seed.sql</strong><dd><code>Add device-delta fixture and reformat SQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/tests/fixtures/seed.sql

<ul><li>Add new <code>device-delta</code> fixture with 8-day old last_seen timestamp<br> <li> Reformat entire SQL file with consistent indentation (4 spaces)<br> <li> Update <code>device-alpha</code> last_seen from 1 hour to 30 minutes<br> <li> Standardize SQL formatting across all INSERT statements and CTEs</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1959/files#diff-1de433f1e0e2be718b04d148299c8f2c8c46a1f9c0b452f55bc1067e82b4edc1">+240/-87</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

