### PR TITLE
adding actionlint and fixing kong stuff

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Self-hosted runner configuration for actionlint
+self-hosted-runner:
+  labels:
+    - arc-runner-set

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,15 @@ jobs:
             exit 1
           fi
 
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "dry_run=${INPUT_DRY_RUN}" >> "$GITHUB_OUTPUT"
-          echo "append_notes=${INPUT_APPEND_NOTES}" >> "$GITHUB_OUTPUT"
-          echo "prerelease=${INPUT_PRERELEASE}" >> "$GITHUB_OUTPUT"
-          echo "draft=${INPUT_DRAFT}" >> "$GITHUB_OUTPUT"
-          echo "overwrite_assets=${INPUT_OVERWRITE}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=${tag}"
+            echo "version=${version}"
+            echo "dry_run=${INPUT_DRY_RUN}"
+            echo "append_notes=${INPUT_APPEND_NOTES}"
+            echo "prerelease=${INPUT_PRERELEASE}"
+            echo "draft=${INPUT_DRAFT}"
+            echo "overwrite_assets=${INPUT_OVERWRITE}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes from CHANGELOG
         id: notes


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add bazelisk version extraction from Kong Makefile

- Implement fallback bazelisk installation without make dependency

- Support direct binary download for aarch64 and x86_64 architectures

- Configure actionlint for self-hosted GitHub Actions runners

- Fix GitHub Actions output formatting in release workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kong Build Script"] -->|Extract Version| B["bazelisk_version_from_kong"]
  B -->|Default Version| C["DEFAULT_BAZELISK_VERSION"]
  A -->|Check Make| D{Make Available?}
  D -->|Yes| E["Use make check-bazel"]
  D -->|No| F["Download Binary"]
  F -->|Detect OS/Arch| G["Direct Installation"]
  H["GitHub Actions Config"] -->|Self-hosted| I["actionlint.yaml"]
  J["Release Workflow"] -->|Format Output| K["Grouped GITHUB_OUTPUT"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-kong-vendor.sh</strong><dd><code>Add bazelisk fallback installation without make</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build-kong-vendor.sh

<ul><li>Add <code>DEFAULT_BAZELISK_VERSION</code> constant for fallback version<br> <li> Introduce <code>bazelisk_version_from_kong()</code> function to extract version <br>from Kong Makefile<br> <li> Refactor <code>ensure_bazel()</code> to support direct binary download when make is <br>unavailable<br> <li> Add OS and architecture detection (aarch64/arm64, x86_64/amd64 <br>mapping)<br> <li> Download bazelisk binary from GitHub releases as fallback mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1964/files#diff-60c9831d4f024788268c9fa56e16e212061b7b55939899f04579d8445036df24">+27/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionlint.yaml</strong><dd><code>Add actionlint self-hosted runner configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actionlint.yaml

<ul><li>Create new actionlint configuration file for GitHub Actions<br> <li> Configure self-hosted runner with arc-runner-set label</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1964/files#diff-2f3192c2d25d2b15166a77ea94cd49e18cd97a7862b6e3d67ff5062c097bacb4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix GitHub Actions output formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Refactor <code>GITHUB_OUTPUT</code> writes to use grouped command syntax<br> <li> Replace individual echo statements with single grouped block<br> <li> Improves readability and follows GitHub Actions best practices</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1964/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

