### PR TITLE
missing zlib

### DIFF
--- a/scripts/build-kong-vendor.sh
+++ b/scripts/build-kong-vendor.sh
@@ -138,6 +138,46 @@ ensure_cc() {
   exit 1
 }
 
+ensure_zlib() {
+  if pkg-config --exists zlib 2>/dev/null || [[ -f /usr/include/zlib.h || -f /usr/local/include/zlib.h ]]; then
+    info "Found zlib development files" >&2
+    return
+  fi
+
+  if command -v apt-get >/dev/null 2>&1; then
+    info "Installing zlib via apt-get (zlib1g-dev)" >&2
+    if command -v sudo >/dev/null 2>&1; then
+      sudo apt-get update -y >/dev/null
+      sudo apt-get install -y zlib1g-dev >/dev/null
+    else
+      apt-get update -y >/dev/null
+      apt-get install -y zlib1g-dev >/dev/null
+    fi
+    return
+  fi
+
+  if command -v yum >/dev/null 2>&1; then
+    info "Installing zlib via yum (zlib-devel)" >&2
+    yum install -y zlib-devel >/dev/null
+    return
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    info "Installing zlib via dnf (zlib-devel)" >&2
+    dnf install -y zlib-devel >/dev/null
+    return
+  fi
+
+  if command -v apk >/dev/null 2>&1; then
+    info "Installing zlib via apk (zlib-dev)" >&2
+    apk add --no-progress --update zlib-dev >/dev/null
+    return
+  fi
+
+  echo "[kong] zlib development headers not found. Install zlib-dev (or equivalent) or supply pkg-config zlib before running." >&2
+  exit 1
+}
+
 configure_remote_exec() {
   if [[ -z "${BUILDBUDDY_ORG_API_KEY:-}" ]]; then
     return
@@ -270,6 +310,7 @@ stage_artifacts() {
 main() {
   ensure_clone
   ensure_cc
+  ensure_zlib
   configure_remote_exec
   local bazel_bin
   bazel_bin=$(ensure_bazel)


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add zlib dependency detection and auto-installation

- Support multiple package managers (apt-get, yum, dnf, apk)

- Check for existing zlib headers before attempting install

- Integrate zlib validation into Kong build process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Script"] --> B["ensure_zlib Function"]
  B --> C{"Check pkg-config<br/>or Headers"}
  C -->|Found| D["Continue Build"]
  C -->|Not Found| E["Detect Package Manager"]
  E --> F["Install zlib-dev"]
  F --> D
  E -->|No Manager| G["Exit with Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-kong-vendor.sh</strong><dd><code>Add zlib dependency detection and installation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/build-kong-vendor.sh

<ul><li>Added new <code>ensure_zlib()</code> function to detect and install zlib <br>development files<br> <li> Checks for zlib via pkg-config or header file presence<br> <li> Supports installation via apt-get, yum, dnf, and apk package managers<br> <li> Integrated zlib validation into main build flow by calling <code>ensure_zlib</code> <br>after <code>ensure_cc</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1967/files#diff-60c9831d4f024788268c9fa56e16e212061b7b55939899f04579d8445036df24">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

