### PR TITLE
adding missing deps for timescale

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -715,6 +715,22 @@ http_file(
     ],
 )
 
+http_archive(
+    name = "cmake_linux_amd64_prebuilt",
+    sha256 = "c959e6d15714f798424960cd296632634f3ef57c2712559a7945170f0bcad205",
+    strip_prefix = "cmake-3.30.4-linux-x86_64",
+    urls = [
+        "https://github.com/Kitware/CMake/releases/download/v3.30.4/cmake-3.30.4-linux-x86_64.tar.gz",
+    ],
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "cmake_bin",
+    srcs = ["bin/cmake"],
+)
+""",
+)
+
 http_file(
     name = "postgresql_server_dev_16_deb",
     sha256 = "032956e4539bbfb9ba56734cb6d28b3e1227c27543e54df02fb172e97b169c09",

--- a/docker/images/BUILD.bazel
+++ b/docker/images/BUILD.bazel
@@ -1524,6 +1524,7 @@ genrule(
         "//docker/images:extract_rootfs.py",
         "//docker/images:overlay_deb_packages.py",
         "//docker/images:pg_config_rewrite.py",
+        "@cmake_linux_amd64_prebuilt//:cmake_bin",
     ],
     cmd = """
 set -euo pipefail
@@ -1553,9 +1554,12 @@ cp "$(location //docker/images:pg_config_wrapper.sh)" "$${OUT_DIR}/pg_config_wra
 chmod +x "$${OUT_DIR}/pg_config_wrapper_ts.sh"
 cp "$(location //docker/images:pg_config_rewrite.py)" "$${OUT_DIR}/pg_config_rewrite.py"
 
+CMAKE_BIN="$(location @cmake_linux_amd64_prebuilt//:cmake_bin)"
+chmod +x "$${CMAKE_BIN}"
+CMAKE_DIR="$$(dirname "$${CMAKE_BIN}")"
 export CNPG_ROOT="$${ROOT_DIR}"
 export CNPG_REAL_PG_CONFIG="$${ROOT_DIR}/usr/lib/postgresql/16/bin/pg_config"
-export PATH="$${ROOT_DIR}/usr/lib/postgresql/16/bin:$${ROOT_DIR}/usr/bin:/usr/bin:/bin"
+export PATH="$${CMAKE_DIR}:$${ROOT_DIR}/usr/lib/postgresql/16/bin:$${ROOT_DIR}/usr/bin:/usr/bin:/bin"
 export PKG_CONFIG_PATH="$${ROOT_DIR}/usr/lib/pkgconfig:$${ROOT_DIR}/usr/lib/x86_64-linux-gnu/pkgconfig"
 cd "$${OUT_DIR}/timescaledb"
 BUILD_FORCE_REMOVE=true ./bootstrap -DREGRESS_CHECKS=OFF -DPROJECT_INSTALL_METHOD=docker -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPG_CONFIG="$${OUT_DIR}/pg_config_wrapper_ts.sh"


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add CMake 3.30.4 prebuilt binary as Bazel dependency

- Include CMake in TimescaleDB extension build tools

- Update PATH to include CMake binary directory

- Enable CMake availability during Docker image build


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MODULE.bazel"] -- "defines cmake_linux_amd64_prebuilt" --> B["CMake 3.30.4 archive"]
  B -- "provides cmake binary" --> C["BUILD.bazel genrule"]
  C -- "uses cmake in PATH" --> D["TimescaleDB extension layer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MODULE.bazel</strong><dd><code>Add CMake prebuilt binary Bazel dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MODULE.bazel

<ul><li>Add <code>http_archive</code> rule for CMake 3.30.4 prebuilt binary<br> <li> Configure archive to extract from GitHub releases<br> <li> Define <code>cmake_bin</code> filegroup pointing to <code>bin/cmake</code><br> <li> Set public visibility for CMake binary access</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1970/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Include CMake in TimescaleDB extension build process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/images/BUILD.bazel

<ul><li>Add <code>@cmake_linux_amd64_prebuilt//:cmake_bin</code> to tools list<br> <li> Extract CMake binary location and make it executable<br> <li> Prepend CMake directory to PATH environment variable<br> <li> Enable CMake availability during TimescaleDB bootstrap build</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1970/files#diff-0e4db31c224a8f72ae8e870a849e38a59d74a2c7f7b04347b0b3eb07e20c5a80">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

