### PR TITLE
chore: release v1.0.54

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+# ServiceRadar v1.0.54
+
+TimescaleDB extension rebuild for CNPG image.
+
+## Whats New
+
+**1.0.54**
+- Bundled a hermetic CMake into the TimescaleDB extension layer build so Bazel releases succeed even when executors lack cmake, re-cutting the v1.0.54 tag.
+
 # ServiceRadar v1.0.54-pre6
 
 Core admin UI polish and onboarding fixes.


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add hermetic CMake bundling to TimescaleDB extension layer build

- Enables Bazel releases without requiring cmake on executors

- Update CHANGELOG with v1.0.54 release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TimescaleDB Extension Build"] -- "Add hermetic CMake" --> B["Bazel Release Success"]
  B -- "No executor cmake required" --> C["v1.0.54 Release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG</strong><dd><code>Add v1.0.54 release notes to CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG

<ul><li>Added v1.0.54 release section with new features<br> <li> Documented hermetic CMake bundling in TimescaleDB extension layer<br> <li> Explained fix for Bazel releases on executors without cmake<br> <li> Positioned new release notes before v1.0.54-pre6 entry</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1971/files#diff-ecec88c33adb7591ee6aa88e29b62ad52ef443611cba5e0f0ecac9b5725afdba">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

