### PR TITLE
fix: update SBOM workflow to use syft config file and fix permissions

### DIFF
--- a/.github/workflows/sbom-syft.yml
+++ b/.github/workflows/sbom-syft.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   generate-sbom:
@@ -14,20 +14,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create syft config
+        run: |
+          cat > .syft.yaml <<EOF
+          exclude:
+            - "**/node_modules/**"
+            - "**/vendor/**"
+            - "**/target/**"
+            - "**/.git/**"
+            - "**/build/**"
+            - "**/release/**"
+          EOF
+
       - name: Generate SPDX SBOM (syft)
         uses: anchore/sbom-action@v0
         with:
           path: .
           format: spdx-json
           output-file: SBOM.spdx
-          exclude: |
-            ./docs/node_modules
-            ./web/node_modules
-            ./vendor
-            ./target
-            ./.git
-            ./build
-            ./release
+          config: .syft.yaml
+          upload-release-assets: ${{ github.event_name == 'release' }}
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### **User description**
## Summary
Fixes the failing SBOM (syft) workflow in CI/CD.

## Changes
- Remove unsupported `exclude` parameter from `anchore/sbom-action@v0`
- Create `.syft.yaml` config file for exclusions instead
- Change permissions from `contents: read` to `contents: write` for release asset uploads
- Only upload to release assets when triggered by release event

## Issue
The workflow was failing with:
```
Warning: Unexpected input(s) 'exclude', valid inputs are [...]
Error: Resource not accessible by integration
```

## Solution
The newer version of `anchore/sbom-action` doesn't support the `exclude` parameter directly. Instead, we need to use a syft config file. Also added write permissions for attaching SBOMs to releases.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unsupported `exclude` parameter with `.syft.yaml` config file

- Upgrade workflow permissions from read to write for release uploads

- Add conditional release asset upload based on event type

- Consolidate SBOM exclusion patterns into dedicated config file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SBOM Workflow"] -->|Remove unsupported exclude| B["Create .syft.yaml config"]
  A -->|Update permissions| C["contents: write"]
  A -->|Conditional upload| D["github.event_name == release"]
  B --> E["Syft action with config"]
  C --> F["Release asset upload"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sbom-syft.yml</strong><dd><code>Migrate to syft config file and fix permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sbom-syft.yml

<ul><li>Upgraded workflow permissions from <code>contents: read</code> to <code>contents: write</code> <br>to enable release asset uploads<br> <li> Added new step to create <code>.syft.yaml</code> config file with exclusion <br>patterns for node_modules, vendor, target, .git, build, and release <br>directories<br> <li> Replaced inline <code>exclude</code> parameter with <code>config: .syft.yaml</code> reference in <br>anchore/sbom-action<br> <li> Added conditional <code>upload-release-assets</code> parameter to only upload when <br>triggered by release event</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1976/files#diff-f79636c7ac6e657fd98f9ead92fd4ffe68b8306a9a329bb602e3d1520b8a8017">+15/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

