### PR TITLE
release should use bazel not arc runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install rpmbuild tooling
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y rpm rpm2cpio
-
       - name: Configure BuildBuddy remote cache
         if: ${{ env.BUILDBUDDY_ORG_API_KEY != '' }}
         run: |
@@ -240,40 +235,9 @@ jobs:
             args+=("--overwrite_assets=${OVERWRITE_ASSETS}")
           fi
 
-          sudo apt-get update -y
-          sudo apt-get install -y rpm
-
-          sudo apt-get update -y
-          sudo apt-get install -y rpm rpm2cpio || true
-          if ! command -v rpmbuild >/dev/null 2>&1; then
-            echo "rpmbuild not found after installation" >&2
-            exit 1
-          fi
-          rpmbuild --version
-
-          # Nuking externals so the rpmbuild toolchain repo is regenerated with rpmbuild present.
-          bazel clean --expunge
-
-          # Run locally to ensure rpmbuild is available and avoid executor-specific tool gaps.
-          export OPENSSL_DIR=/usr
-          export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
-          export OPENSSL_INCLUDE_DIR=/usr/include
-
+          # Build and upload packages using the RBE executor (rpmbuild is baked into the toolchain image).
           bazel run \
-            --config=no_remote \
-            --host_platform=@local_config_platform//:host \
-            --platforms=@local_config_platform//:host \
-            --remote_executor= \
-            --remote_cache= \
-            --noremote_accept_cached \
-            --noremote_upload_local_results \
-            --action_env=OPENSSL_DIR=/usr \
-            --action_env=OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu \
-            --action_env=OPENSSL_INCLUDE_DIR=/usr/include \
-            --repo_env=OPENSSL_DIR=/usr \
-            --repo_env=OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu \
-            --repo_env=OPENSSL_INCLUDE_DIR=/usr/include \
-            --jobs=8 \
+            --config=remote \
             --stamp \
             //release:publish_packages \
             -- "${args[@]}"


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify release workflow by removing local rpmbuild installation

- Switch from local execution to RBE executor for package building

- Remove manual OpenSSL environment variable configuration

- Leverage rpmbuild toolchain baked into RBE executor image


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local rpmbuild<br/>installation"] -->|removed| B["RBE executor<br/>with toolchain"]
  C["Manual env<br/>configuration"] -->|removed| B
  D["Local execution<br/>config flags"] -->|replaced| E["Remote config"]
  B --> F["Simplified<br/>release workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Switch release build from local to RBE executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Removed <code>apt-get install rpm rpm2cpio</code> commands from both early checkout <br>step and main build step<br> <li> Removed manual rpmbuild verification and version checking logic<br> <li> Removed OpenSSL environment variable exports and configuration <br>(OPENSSL_DIR, OPENSSL_LIB_DIR, OPENSSL_INCLUDE_DIR)<br> <li> Replaced <code>--config=no_remote</code> with <code>--config=remote</code> and removed all local <br>execution flags (<code>--remote_executor=</code>, <code>--remote_cache=</code>, <code>--noremote_*</code> <br>flags)<br> <li> Removed <code>bazel clean --expunge</code> command and <code>--jobs=8</code> flag<br> <li> Added comment indicating rpmbuild is now provided by RBE executor <br>toolchain image</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1980/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+2/-38</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

