### PR TITLE
wip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Ensure rpmbuild available for rules_pkg toolchain
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y rpm rpm2cpio
+          if ! command -v rpmbuild >/dev/null 2>&1; then
+            echo "rpmbuild not found after install" >&2
+            exit 1
+          fi
+          rpmbuild --version
+
+      - name: Refresh Bazel externals after rpm install
+        run: |
+          # Force the rules_pkg rpmbuild toolchain to re-detect the system rpmbuild binary.
+          bazel clean --expunge
+
       - name: Configure BuildBuddy remote cache
         if: ${{ env.BUILDBUDDY_ORG_API_KEY != '' }}
         run: |
@@ -197,6 +212,15 @@ jobs:
               "${extra_args[@]}"
           fi
 
+      - name: Disable remote exec/cache for packaging
+        run: |
+          # Clear remote settings so packaging runs entirely on the runner.
+          cat > .bazelrc.remote <<'EOF'
+          build --remote_executor=
+          build --remote_cache=
+          build --remote_download_minimal
+          EOF
+
       - name: Publish Debian and RPM packages
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
@@ -235,9 +259,12 @@ jobs:
             args+=("--overwrite_assets=${OVERWRITE_ASSETS}")
           fi
 
-          # Build and upload packages using the RBE executor (rpmbuild is baked into the toolchain image).
+          # Build and upload packages locally so rpmbuild is guaranteed to be present on the runner.
           bazel run \
-            --config=remote \
+            --config=no_remote \
+            --host_platform=@local_config_platform//:host \
+            --platforms=//build/platforms:linux_pkg_local \
+            --@rules_pkg//toolchains/rpm:is_rpmbuild_available=1 \
             --stamp \
             //release:publish_packages \
             -- "${args[@]}"

--- a/build/platforms/BUILD.bazel
+++ b/build/platforms/BUILD.bazel
@@ -36,6 +36,17 @@ platform(
     visibility = ["//visibility:public"],
 )
 
+# Local Linux platform that explicitly satisfies rules_pkg's rpm compatibility gate.
+platform(
+    name = "linux_pkg_local",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+        "@rules_pkg//pkg:not_compatible",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # Remote execution platforms for BuildBuddy
 platform(
     name = "rbe_linux_amd64",


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add rpmbuild installation and Bazel cache refresh in release workflow

- Disable remote execution/cache for packaging to ensure local rpmbuild availability

- Switch package publishing from RBE to local execution with platform constraints

- Create new linux_pkg_local platform with rules_pkg rpm compatibility gate


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Workflow"] -->|Install rpmbuild| B["System Setup"]
  B -->|Clean Bazel cache| C["Refresh Externals"]
  C -->|Disable remote exec| D["Local Config"]
  D -->|Use local platform| E["Publish Packages"]
  F["New linux_pkg_local Platform"] -->|Satisfies rpm gate| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Configure local rpmbuild execution for package publishing</code></dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Add step to install rpmbuild and rpm2cpio packages with verification<br> <li> Add step to refresh Bazel externals via <code>bazel clean --expunge</code> after <br>rpm install<br> <li> Add step to disable remote executor and cache for packaging builds<br> <li> Change package publishing from <code>--config=remote</code> to <code>--config=no_remote</code> <br>with local platform and rpmbuild availability flag</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1981/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Add linux_pkg_local platform for rpm packaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/platforms/BUILD.bazel

<ul><li>Add new <code>linux_pkg_local</code> platform targeting x86_64 Linux<br> <li> Include <code>@rules_pkg//pkg:not_compatible</code> constraint to satisfy rules_pkg <br>rpm compatibility requirements<br> <li> Set visibility to public for use in release workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1981/files#diff-d7da264d8f13c39aafc9e2343c3f9649ee1b143f653edda46521f21378a8467e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

