### PR TITLE
wip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,15 +216,6 @@ jobs:
               "${extra_args[@]}"
           fi
 
-      - name: Disable remote exec/cache for packaging
-        run: |
-          # Clear remote settings so packaging runs entirely on the runner.
-          cat > .bazelrc.remote <<'EOF'
-          build --remote_executor=
-          build --remote_cache=
-          build --remote_download_minimal
-          EOF
-
       - name: Publish Debian and RPM packages
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
@@ -263,14 +254,31 @@ jobs:
             args+=("--overwrite_assets=${OVERWRITE_ASSETS}")
           fi
 
-          bazel run \
-            --config=remote \
-            --host_platform=@local_config_platform//:host \
-            --platforms=//build/platforms:linux_pkg_local \
-            --//toolchains/rpm:is_rpmbuild_available=1 \
-            --stamp \
-            //release:publish_packages \
-            -- "${args[@]}"
+          run_remote() {
+            bazel run \
+              --config=remote \
+              --platforms=//build/platforms:linux_pkg_local \
+              --@rules_pkg//toolchains/rpm:is_rpmbuild_available=1 \
+              --stamp \
+              //release:publish_packages \
+              -- "${args[@]}"
+          }
+
+          run_local() {
+            bazel run \
+              --config=no_remote \
+              --host_platform=@local_config_platform//:host \
+              --platforms=//build/platforms:linux_pkg_local \
+              --@rules_pkg//toolchains/rpm:is_rpmbuild_available=1 \
+              --stamp \
+              //release:publish_packages \
+              -- "${args[@]}"
+          }
+
+          if ! run_remote; then
+            echo "Remote packaging failed; retrying locally without remote executor/cache" >&2
+            run_local
+          fi
 
       - name: Verify uploaded release assets via API
         env:


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor RPM packaging to support fallback to local execution

- Remove hardcoded remote cache disabling step

- Add retry logic for remote packaging failures

- Update Bazel RPM toolchain flag to use rules_pkg namespace


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remote packaging attempt"] -->|Success| B["Publish packages"]
  A -->|Failure| C["Local packaging fallback"]
  C --> B
  D["Remove cache disable step"] -.-> A
  E["Update toolchain flags"] -.-> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Implement fallback mechanism for RPM packaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Removed the separate step that disabled remote executor/cache settings<br> <li> Refactored packaging logic into two functions: <code>run_remote()</code> and <br><code>run_local()</code><br> <li> Updated Bazel RPM toolchain flag from <br><code>--//toolchains/rpm:is_rpmbuild_available=1</code> to <br><code>--@rules_pkg//toolchains/rpm:is_rpmbuild_available=1</code><br> <li> Added conditional retry logic to attempt local packaging if remote <br>execution fails</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/1987/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+25/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

