### PR TITLE
increase from 5g to 100g for cnpg

### DIFF
--- a/helm/serviceradar/templates/spire-postgres.yaml
+++ b/helm/serviceradar/templates/spire-postgres.yaml
@@ -103,7 +103,7 @@ spec:
     {{- end }}
   {{- end }}
   storage:
-    size: {{ default "5Gi" $pg.storageSize }}
+    size: {{ default "100Gi" $pg.storageSize }}
     {{- if $pg.storageClass }}
     storageClass: {{ $pg.storageClass }}
     {{- end }}

--- a/helm/serviceradar/values.yaml
+++ b/helm/serviceradar/values.yaml
@@ -180,7 +180,7 @@ spire:
     database: spire
     instances: 3
     storageClass: local-path
-    storageSize: 5Gi
+    storageSize: 100Gi
     secretName: spire-db-credentials
     username: spire
     password: changeme

--- a/k8s/demo/DEPLOYMENT.md
+++ b/k8s/demo/DEPLOYMENT.md
@@ -198,7 +198,7 @@ kubectl scale deployment serviceradar-web --replicas=2 -n <namespace>
 ## Persistence
 
 ### Persistent Volumes
-- **CNPG Data**: 5Gi per instance (local-path by default); resize via `k8s/demo/resize-cnpg-pvc.sh` which patches the `Cluster` storage size
+- **CNPG Data**: 100Gi per instance (local-path by default); resize via `k8s/demo/resize-cnpg-pvc.sh` which patches the `Cluster` storage size
 - **Core Data**: 5Gi for application metadata
 - **NATS Data**: 30Gi for message persistence
 - **Certificates**: 1Gi shared TLS material

--- a/k8s/demo/base/spire/cnpg-cluster.yaml
+++ b/k8s/demo/base/spire/cnpg-cluster.yaml
@@ -10,7 +10,7 @@ spec:
     - name: ghcr-io-cred
 
   storage:
-    size: 5Gi
+    size: 100Gi
     storageClass: local-path
 
   bootstrap:


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Increase CNPG PostgreSQL storage from 5Gi to 100Gi

- Updates default storage size across Helm templates

- Updates base Kubernetes deployment configuration

- Updates documentation to reflect new storage allocation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CNPG Storage Config"] -->|"5Gi → 100Gi"| B["Helm values.yaml"]
  A -->|"5Gi → 100Gi"| C["Helm spire-postgres.yaml"]
  A -->|"5Gi → 100Gi"| D["K8s cnpg-cluster.yaml"]
  E["Documentation"] -->|"Updated"| F["DEPLOYMENT.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update default CNPG storage size to 100Gi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/values.yaml

<ul><li>Updated default CNPG storage size from 5Gi to 100Gi<br> <li> Changes the <code>storageSize</code> parameter in postgres configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2005/files#diff-d4449c7cb70362554b274f81eae5a4b81a8e81df494282e383d1b7ea3871c452">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spire-postgres.yaml</strong><dd><code>Update Helm template storage default to 100Gi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/spire-postgres.yaml

<ul><li>Updated default storage size in Helm template from 5Gi to 100Gi<br> <li> Affects the storage specification for CNPG cluster deployment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2005/files#diff-1ca173bb2b8cb20ea64a4f1901850a229c0c9f40286f074e00b3301be99299bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cnpg-cluster.yaml</strong><dd><code>Update base K8s CNPG storage to 100Gi</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/spire/cnpg-cluster.yaml

<ul><li>Updated CNPG cluster storage size from 5Gi to 100Gi<br> <li> Modifies base Kubernetes deployment configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2005/files#diff-7295774b8f05fee8f0f2b054f94381aa4c2581344117e9386f62c50baf64de53">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DEPLOYMENT.md</strong><dd><code>Update documentation for new storage size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/DEPLOYMENT.md

<ul><li>Updated documentation to reflect new 100Gi storage allocation<br> <li> Clarifies CNPG data persistence size in deployment guide</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2005/files#diff-5f3fed1076fa76a981a6d79e8047dfdb15c6f53c62790064823bb9fd3548c315">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

