### PR TITLE
fixing glibc issue

### DIFF
--- a/cmd/checkers/rperf-client/Dockerfile
+++ b/cmd/checkers/rperf-client/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bullseye AS builder
 
 WORKDIR /usr/src/serviceradar-rperf-checker
 

--- a/cmd/consumers/zen/Dockerfile
+++ b/cmd/consumers/zen/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bullseye AS builder
 
 # Build from workspace root so path deps resolve
 WORKDIR /usr/src/serviceradar

--- a/cmd/ebpf/profiler/Dockerfile
+++ b/cmd/ebpf/profiler/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bookworm AS builder
 
 WORKDIR /usr/src/serviceradar-profiler
 

--- a/cmd/flowgger/Dockerfile
+++ b/cmd/flowgger/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bullseye AS builder
 
 # Build from workspace root so path deps resolve (../../rust/kvutil)
 WORKDIR /usr/src/serviceradar

--- a/cmd/otel/Dockerfile
+++ b/cmd/otel/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bullseye AS builder
 
 # Build from workspace root so path deps resolve (../../rust/kvutil)
 WORKDIR /usr/src/serviceradar

--- a/cmd/trapd/Dockerfile
+++ b/cmd/trapd/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:latest AS builder
+FROM rust:1.78-bullseye AS builder
 
 # Build from workspace root so path deps resolve (../../rust/kvutil)
 WORKDIR /usr/src/serviceradar

--- a/docker/images/BUILD.bazel
+++ b/docker/images/BUILD.bazel
@@ -676,7 +676,7 @@ pkg_tar(
 
 oci_image(
     name = "trapd_image_amd64",
-    base = "@ubuntu_jammy_linux_amd64//:ubuntu_jammy_linux_amd64",
+    base = "@ubuntu_noble_linux_amd64//:ubuntu_noble_linux_amd64",
     tars = [":common_tools_amd64", ":trapd_layer_amd64"],
     entrypoint = ["/usr/local/bin/entrypoint.sh"],
     cmd = ["serviceradar-trapd"],
@@ -718,7 +718,7 @@ pkg_tar(
 
 oci_image(
     name = "otel_image_amd64",
-    base = "@ubuntu_jammy_linux_amd64//:ubuntu_jammy_linux_amd64",
+    base = "@ubuntu_noble_linux_amd64//:ubuntu_noble_linux_amd64",
     tars = [":common_tools_amd64", ":otel_layer_amd64"],
     entrypoint = ["/usr/local/bin/entrypoint.sh"],
     cmd = ["serviceradar-otel"],
@@ -804,7 +804,7 @@ pkg_tar(
 
 oci_image(
     name = "rperf_client_image_amd64",
-    base = "@debian_bookworm_slim_linux_amd64//:debian_bookworm_slim_linux_amd64",
+    base = "@ubuntu_noble_linux_amd64//:ubuntu_noble_linux_amd64",
     tars = [":common_tools_amd64", ":rperf_client_layer_amd64"],
     entrypoint = ["/usr/local/bin/entrypoint.sh"],
     cmd = ["/usr/local/bin/serviceradar-rperf-checker", "--config", "/etc/serviceradar/checkers/rperf.json"],


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Pin Rust base images to version 1.78 with specific OS versions

- Replace Ubuntu Jammy with Ubuntu Noble in Bazel build configuration

- Replace Debian Bookworm Slim with Ubuntu Noble for rperf client image

- Fix missing newline at end of Dockerfile files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rust:latest"] -->|"Pin to 1.78"| B["rust:1.78-bullseye/bookworm"]
  C["Ubuntu Jammy"] -->|"Upgrade to"| D["Ubuntu Noble"]
  E["Debian Bookworm Slim"] -->|"Replace with"| D
  B --> F["Stable build environment"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version and fix formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/checkers/rperf-client/Dockerfile

<ul><li>Pin Rust base image from <code>rust:latest</code> to <code>rust:1.78-bullseye</code><br> <li> Add missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-b75c59bfd6da4d75d80935d556d016c9cd523eaa586387ea20b06924c5f2e04d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version to 1.78-bullseye</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/consumers/zen/Dockerfile

- Pin Rust base image from `rust:latest` to `rust:1.78-bullseye`


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-9f8119755792e77da338d2d29ce5e1bbfeeb8f5816a3233e78a9e206bafb0b53">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version to 1.78-bookworm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ebpf/profiler/Dockerfile

<ul><li>Pin Rust base image from <code>rust:latest</code> to <code>rust:1.78-bookworm</code><br> <li> Add missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-c9344ce151703a12ea1f2521a5647d84122e8daeeb4447f663f8563fc3de9bae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version to 1.78-bullseye</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/flowgger/Dockerfile

- Pin Rust base image from `rust:latest` to `rust:1.78-bullseye`


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-7199f3111d0ff4e1154dd5a0f2250ea0e82c39031abdf7864356570dd1007c87">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version to 1.78-bullseye</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/otel/Dockerfile

- Pin Rust base image from `rust:latest` to `rust:1.78-bullseye`


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-62c9619630b9f9c73e89622525098ec4722282a8499ef89df09116d0840566ae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin Rust version to 1.78-bullseye</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/trapd/Dockerfile

- Pin Rust base image from `rust:latest` to `rust:1.78-bullseye`


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-7ee3f454058c8cf12947948e4f4f302e7a461b9d79bb447c15e68f4b02668647">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Upgrade base OS images to Ubuntu Noble</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/images/BUILD.bazel

<ul><li>Update <code>trapd_image_amd64</code> base from Ubuntu Jammy to Ubuntu Noble<br> <li> Update <code>otel_image_amd64</code> base from Ubuntu Jammy to Ubuntu Noble<br> <li> Update <code>rperf_client_image_amd64</code> base from Debian Bookworm Slim to <br>Ubuntu Noble</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2011/files#diff-0e4db31c224a8f72ae8e870a849e38a59d74a2c7f7b04347b0b3eb07e20c5a80">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

