### PR TITLE
2042 bugsysmon metrics not available from sysmon vm collection (#2045)

### DIFF
--- a/pkg/core/api/sysmon.go
+++ b/pkg/core/api/sysmon.go
@@ -394,7 +394,7 @@ func (s *APIServer) getCPUMetricsForDevice(
 	// Query cpu_metrics table directly for per-core data by device_id
 	const cpuQuery = `
 		SELECT timestamp, agent_id, host_id, core_id, usage_percent, frequency_hz, label, cluster
-		FROM cpu_metrics
+		FROM public.cpu_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, core_id ASC`
 
@@ -450,7 +450,7 @@ func (s *APIServer) getCPUMetricsForDevice(
 
 	const clusterQuery = `
 		SELECT timestamp, agent_id, host_id, cluster, frequency_hz
-		FROM cpu_cluster_metrics
+		FROM public.cpu_cluster_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, cluster ASC`
 
@@ -517,7 +517,7 @@ func (s *APIServer) getMemoryMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, used_bytes, total_bytes
-		FROM memory_metrics
+		FROM public.memory_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC`
 
@@ -571,7 +571,7 @@ func (s *APIServer) getDiskMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, mount_point, used_bytes, total_bytes
-		FROM disk_metrics
+		FROM public.disk_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, mount_point ASC`
 
@@ -635,7 +635,7 @@ func (s *APIServer) getProcessMetricsForDevice(
 	ctx context.Context, _ db.SysmonMetricsProvider, deviceID string, start, end time.Time) (interface{}, error) {
 	const query = `
 		SELECT timestamp, agent_id, host_id, pid, name, cpu_usage, memory_usage, status, start_time
-		FROM process_metrics
+		FROM public.process_metrics
 		WHERE device_id = $1 AND timestamp BETWEEN $2 AND $3
 		ORDER BY timestamp DESC, pid ASC`
 


### PR DESCRIPTION
### **User description**
* fix(sysmon): gate sysmonvm to darwin-only and fix metrics availability

- Add target_compatible_with = ["@platforms//os:macos"] to sysmonvm targets to prevent build failures on Linux remote execution
- Add missing @com_github_shirou_gopsutil_v3//mem dependency
- Add sysmon stall detection and logging in core metrics processing
- Add memory metrics support from sysmon-vm collector
- Improve sysmon metrics flush logging for debugging
- Update web API routes for device/poller sysmon metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* fix(db): properly read batch results to detect insert errors

The sendCNPG function was calling br.Close() without reading individual query results, which silently discarded any errors from INSERT statements. Now properly calls br.Exec() for each queued command to surface errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* debug: add logging to cnpgInsertCPUMetrics

* fixed cpu metrics for sysmon-vm

* fix(db): use explicit public schema for metrics tables

The Apache AGE extension adds ag_catalog to the search_path, causing INSERT statements to go to ag_catalog.cpu_metrics instead of the intended public.cpu_metrics table. This fixes the issue by explicitly qualifying all metrics table names with the public schema.

Also fixes linter errors:
- Handle br.Close() error in sendCNPG
- Replace useless uint64 >= 0 assertions in sysmonvm tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* fix(api): use explicit public schema in sysmon metric queries

The SELECT queries for device-centric sysmon metrics were using unqualified table names, causing them to read from ag_catalog schema instead of public schema where the data is now being inserted.

This fixes the UI not showing CPU/memory/disk/process metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---------

## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Explicitly qualify metrics table names with public schema in SELECT queries

- Fix UI not showing CPU/memory/disk/process metrics from sysmon collection

- Resolve Apache AGE extension search_path conflict causing wrong schema reads


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sysmon.go</strong><dd><code>Add explicit public schema to metrics table queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/core/api/sysmon.go

<ul><li>Qualify <code>cpu_metrics</code> table with <code>public</code> schema in getCPUMetricsForDevice<br> <li> Qualify <code>cpu_cluster_metrics</code> table with <code>public</code> schema in <br>getCPUMetricsForDevice<br> <li> Qualify <code>memory_metrics</code> table with <code>public</code> schema in <br>getMemoryMetricsForDevice<br> <li> Qualify <code>disk_metrics</code> table with <code>public</code> schema in <br>getDiskMetricsForDevice<br> <li> Qualify <code>process_metrics</code> table with <code>public</code> schema in <br>getProcessMetricsForDevice</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2046/files#diff-4879e8b367ee55413c6cb006f23bb912261df5310c640d3af352033cf97ffc84">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

