### PR TITLE
fixing spire

### DIFF
--- a/k8s/demo/base/spire/server-statefulset.yaml
+++ b/k8s/demo/base/spire/server-statefulset.yaml
@@ -101,11 +101,11 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 300m
+              memory: 512Mi
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 100m
+              memory: 256Mi
       volumes:
         - name: spire-config-template
           configMap:


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Increase SPIRE server CPU and memory resource limits

- Raise CPU limit from 200m to 300m for better performance

- Raise memory limit from 256Mi to 512Mi for stability

- Increase CPU request from 50m to 100m

- Increase memory request from 128Mi to 256Mi


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SPIRE Server Resources"] -->|"CPU limit"| B["200m → 300m"]
  A -->|"Memory limit"| C["256Mi → 512Mi"]
  A -->|"CPU request"| D["50m → 100m"]
  A -->|"Memory request"| E["128Mi → 256Mi"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server-statefulset.yaml</strong><dd><code>Increase SPIRE server resource allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/spire/server-statefulset.yaml

<ul><li>Increased CPU limit from 200m to 300m<br> <li> Increased memory limit from 256Mi to 512Mi<br> <li> Increased CPU request from 50m to 100m<br> <li> Increased memory request from 128Mi to 256Mi</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2054/files#diff-ec0e246a770d0e9b28d6b6b39db5fd05e1d767b2da456ecd2d9e13bba59da7db">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

