### PR TITLE
fix(core): serialize AGE graph writes to prevent deadlocks (#2058)

### DIFF
--- a/openspec/changes/fix-age-graph-deadlock-handling/proposal.md
+++ b/openspec/changes/fix-age-graph-deadlock-handling/proposal.md
@@ -1,0 +1,45 @@
+# Change: Fix AGE graph deadlock handling with write serialization
+
+## Why
+Core in the demo namespace is emitting deadlock errors (`deadlock detected` / SQLSTATE 40P01) and entity update failures (`Entity failed to be updated: 3` / SQLSTATE XX000) during AGE graph merges. Investigation of issue #2058 reveals:
+
+1. **Multiple concurrent database connections executing MERGE queries**: With `AGE_GRAPH_WORKERS=4`, up to 4 workers execute MERGE batches simultaneously against the same graph. CNPG logs show 3+ concurrent processes hitting the same timestamp with XX000 errors.
+
+2. **Failure rate approaching 50%**: Logs show `270 failures vs 304 successes` - nearly half of all graph writes are failing.
+
+3. **Deadlocks not classified as transient errors**: The `classifyAGEError()` function only treats XX000 and 57014 as transient. Deadlock (40P01) and serialization failure (40001) errors cause immediate batch failure without retry.
+
+4. **Circular lock dependencies from parallel MERGE**: When two workers update overlapping nodes (e.g., same Collector referenced by multiple devices), they create lock contention:
+   - Worker A locks Node X, waits for Node Y
+   - Worker B locks Node Y, waits for Node X
+   - Result: PostgreSQL aborts one as deadlock victim (40P01) or raises XX000
+
+## What Changes
+
+### 1. Write Serialization with Mutex (Root Cause Fix)
+Add a Go-level mutex (`writeMu`) in `ageGraphWriter` to serialize all AGE graph MERGE operations. Multiple workers can still process the queue (for responsiveness), but only one can execute a database query at a time. This eliminates the concurrent write contention that causes deadlocks.
+
+### 2. Expanded Transient Error Classification
+Add SQLSTATE 40P01 (deadlock_detected) and 40001 (serialization_failure) to the list of transient errors that trigger retry with backoff. Includes string fallback patterns for wrapped errors.
+
+### 3. Improved Backoff Strategy for Deadlocks
+Implement separate backoff timing for deadlock errors (500ms base vs 150ms for other errors) with exponential growth and randomized jitter to break lock acquisition synchronization.
+
+### 4. Deadlock-Specific Metrics
+Add new OTel metrics to track deadlock and serialization failure frequency:
+- `age_graph_deadlock_total`: Count of deadlock errors encountered
+- `age_graph_serialization_failure_total`: Count of serialization failures
+- `age_graph_transient_retry_total`: Count of all transient retries
+
+## Impact
+- Affected specs: device-relationship-graph
+- Affected code:
+  - `pkg/registry/age_graph_writer.go` (writeMu, classifyAGEError, backoffDelay)
+  - `pkg/registry/age_graph_metrics.go` (new metrics)
+- Risk: Low - serialization may reduce throughput but eliminates failures
+- Performance: Graph writes become sequential but reliable. Queue depth may increase temporarily during bursts but will drain successfully.
+
+## Trade-offs
+- **Throughput vs Reliability**: Serializing writes reduces parallel throughput but ensures ~100% success rate vs ~50% with concurrent writes.
+- **Queue Latency**: Individual batches may wait longer in queue, but total time to completion improves due to elimination of failed retries.
+- **Worker Count**: Multiple workers still provide value for queue responsiveness even though writes are serialized.

--- a/openspec/changes/fix-age-graph-deadlock-handling/specs/device-relationship-graph/spec.md
+++ b/openspec/changes/fix-age-graph-deadlock-handling/specs/device-relationship-graph/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: AGE graph writes are serialized to prevent deadlocks
+The system SHALL serialize AGE graph MERGE operations using a mutex so that only one write executes against the graph at any time, eliminating concurrent write contention that causes deadlocks and lock conflicts.
+
+#### Scenario: Concurrent batches do not deadlock
+- **GIVEN** multiple workers processing the AGE graph queue
+- **WHEN** two workers attempt to execute MERGE batches simultaneously
+- **THEN** the mutex ensures only one executes at a time and the other waits, preventing deadlock.
+
+#### Scenario: Queue processing remains responsive
+- **GIVEN** a burst of graph updates arriving in the queue
+- **WHEN** writes are serialized via mutex
+- **THEN** multiple workers can still accept work from the queue, only serializing at the database execution point.
+
+### Requirement: AGE graph writes handle deadlocks with retry
+The system SHALL classify PostgreSQL deadlock errors (SQLSTATE 40P01) and serialization failures (SQLSTATE 40001) as transient errors that trigger retry with backoff, so any residual concurrent conflicts do not permanently fail batches.
+
+#### Scenario: Deadlock triggers retry instead of failure
+- **GIVEN** a MERGE batch that encounters a deadlock error
+- **WHEN** PostgreSQL returns SQLSTATE 40P01
+- **THEN** the batch retries with exponential backoff and eventually commits without data loss.
+
+#### Scenario: Serialization failure triggers retry
+- **GIVEN** a MERGE batch that encounters a serialization failure
+- **WHEN** PostgreSQL returns SQLSTATE 40001
+- **THEN** the batch retries with exponential backoff and eventually commits.
+
+### Requirement: Deadlock backoff uses longer delays with randomized jitter
+The system SHALL use a longer base backoff (500ms) for deadlock and serialization errors compared to other transient errors (150ms), with exponential growth and randomized jitter to break lock acquisition synchronization patterns.
+
+#### Scenario: Deadlock retries use appropriate backoff
+- **GIVEN** a batch that fails with deadlock error
+- **WHEN** the batch prepares to retry
+- **THEN** the backoff delay starts at 500ms (vs 150ms for other errors) with randomized jitter.
+
+### Requirement: Deadlock metrics are tracked separately
+The system SHALL expose distinct metrics for deadlock and serialization failure occurrences to enable monitoring and alerting on contention-specific issues.
+
+#### Scenario: Operator monitors deadlock frequency
+- **GIVEN** the Prometheus/OTel metrics endpoint is scraped
+- **WHEN** the operator queries `age_graph_deadlock_total`
+- **THEN** they can see the count of deadlock errors and alert if frequency increases.
+
+## MODIFIED Requirements
+
+### Requirement: AGE graph writes tolerate contention with retries and backpressure (MODIFIED)
+The system SHALL process AGE graph merges through a serialized, backpressure-aware writer that:
+1. Serializes writes via mutex to prevent concurrent MERGE conflicts
+2. Retries transient AGE errors including:
+   - SQLSTATE XX000 "Entity failed to be updated" (lock contention)
+   - SQLSTATE 57014 statement timeout
+   - SQLSTATE 40P01 deadlock_detected (NEW)
+   - SQLSTATE 40001 serialization_failure (NEW)
+
+So overlapping registry/backfill writes do not drop batches due to concurrency conflicts.
+
+#### Scenario: High-volume writes succeed without deadlocks
+- **WHEN** pollers and agents generate bursts of device updates
+- **THEN** writes are serialized, queue drains successfully, and no deadlock or XX000 errors occur in logs.

--- a/openspec/changes/fix-age-graph-deadlock-handling/tasks.md
+++ b/openspec/changes/fix-age-graph-deadlock-handling/tasks.md
@@ -1,0 +1,28 @@
+## 1. Write Serialization (Root Cause Fix)
+- [x] 1.1 Add `writeMu sync.Mutex` to `ageGraphWriter` struct to serialize database writes.
+- [x] 1.2 Wrap `ExecuteQuery` call in `processRequest` with mutex lock/unlock.
+- [x] 1.3 Document the serialization approach in code comments.
+
+## 2. Expand transient error classification
+- [x] 2.1 Add SQLSTATE 40P01 (deadlock_detected) to `classifyAGEError()` as a transient error.
+- [x] 2.2 Add SQLSTATE 40001 (serialization_failure) to `classifyAGEError()` as a transient error.
+- [x] 2.3 Add string fallback patterns for "deadlock detected" and "could not serialize access" in wrapped errors.
+- [x] 2.4 Define named constants for SQLSTATE codes for clarity.
+
+## 3. Improve backoff strategy for deadlocks
+- [x] 3.1 Add `defaultAgeGraphDeadlockBackoff` constant (500ms) for deadlock-specific backoff.
+- [x] 3.2 Update `backoffDelay()` to accept SQLSTATE code and use longer backoff for deadlocks.
+- [x] 3.3 Implement exponential backoff with randomized jitter.
+- [x] 3.4 Add `AGE_GRAPH_DEADLOCK_BACKOFF_MS` environment variable for tuning.
+
+## 4. Add deadlock-specific metrics
+- [x] 4.1 Add `age_graph_deadlock_total` counter metric.
+- [x] 4.2 Add `age_graph_serialization_failure_total` counter metric.
+- [x] 4.3 Add `age_graph_transient_retry_total` counter metric.
+- [x] 4.4 Record metrics in `processRequest` when corresponding errors occur.
+
+## 5. Testing and validation
+- [ ] 5.1 Build and lint verification (completed).
+- [ ] 5.2 Deploy to demo namespace and verify deadlocks/XX000 errors are eliminated.
+- [ ] 5.3 Monitor metrics to confirm near-zero deadlock rate.
+- [ ] 5.4 Verify queue drains successfully under load.


### PR DESCRIPTION
### **User description**
- Add writeMu mutex to serialize MERGE operations
- Add 40P01 (deadlock) and 40001 (serialization_failure) as transient errors
- Implement longer backoff (500ms) for deadlock errors with exponential growth
- Add deadlock-specific metrics for monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Serialize AGE graph MERGE operations with mutex to eliminate concurrent write deadlocks

- Classify deadlock (40P01) and serialization failure (40001) as transient errors with retry

- Implement longer backoff (500ms) for deadlock errors with exponential growth and jitter

- Add deadlock-specific metrics for monitoring contention issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple Workers<br/>Processing Queue"] -->|"Serialize with<br/>writeMu Mutex"| B["Single MERGE<br/>Execution"]
  B -->|"Deadlock/Serialization<br/>Error"| C["Classify as<br/>Transient"]
  C -->|"Retry with<br/>500ms Backoff"| B
  B -->|"Success"| D["Record Metrics<br/>deadlock_total<br/>serialization_failure_total"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>age_graph_metrics.go</strong><dd><code>Add deadlock and serialization failure metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/age_graph_metrics.go

<ul><li>Add three new metric constants for deadlock, serialization failure, <br>and transient retry tracking<br> <li> Add three new atomic counters to ageGraphMetrics struct for the new <br>metrics<br> <li> Register three new Int64ObservableGauge metrics in initAgeMetrics <br>function<br> <li> Add three new helper functions to record deadlock, serialization <br>failure, and transient retry events<br> <li> Update metric callback to observe the new metrics</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2064/files#diff-2d400ecd96ff77c1379e4a8681763f9ba2dc22790e31a445b7e3ce716e8fbb15">+68/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>age_graph_writer.go</strong><dd><code>Serialize writes and handle deadlock errors with retry</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/age_graph_writer.go

<ul><li>Add writeMu sync.Mutex to serialize AGE graph MERGE operations and <br>prevent concurrent write deadlocks<br> <li> Add defaultAgeGraphDeadlockBackoff constant (500ms) for longer backoff <br>on deadlock errors<br> <li> Add ageGraphDeadlockBackoffEnv environment variable for tuning <br>deadlock backoff<br> <li> Define SQLSTATE constants for transient errors (XX000, 57014, 40P01, <br>40001)<br> <li> Expand classifyAGEError to recognize deadlock (40P01) and <br>serialization failure (40001) as transient errors with string fallback <br>patterns<br> <li> Update backoffDelay function to accept SQLSTATE code and use <br>exponential backoff with longer base for deadlocks<br> <li> Wrap ExecuteQuery call with writeMu lock/unlock to serialize database <br>writes<br> <li> Record error-specific metrics when deadlock or serialization failures <br>occur</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2064/files#diff-2e6c0a5c048582201ffb983889ab9fab6fb1f8d64b91ee3fb65479b2fb2c6195">+59/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Proposal for AGE graph deadlock handling fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-age-graph-deadlock-handling/proposal.md

<ul><li>Document root cause of deadlocks: multiple concurrent workers <br>executing MERGE queries causing lock contention<br> <li> Explain 50% failure rate and circular lock dependencies from parallel <br>MERGE operations<br> <li> Describe write serialization solution using mutex to eliminate <br>concurrent write contention<br> <li> Detail expanded transient error classification for deadlock and <br>serialization failures<br> <li> Outline improved backoff strategy with longer delays and exponential <br>growth for deadlocks<br> <li> List new metrics for monitoring deadlock and serialization failure <br>frequency<br> <li> Analyze trade-offs between throughput reduction and reliability <br>improvement</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2064/files#diff-7af7b9e5ec186b60f6082c416f1cf7fa777e26c7b67aa7a2fe5f582f3c558813">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add AGE graph deadlock handling requirements and scenarios</code></dd></summary>
<hr>

openspec/changes/fix-age-graph-deadlock-handling/specs/device-relationship-graph/spec.md

<ul><li>Add requirement for serialized AGE graph writes using mutex to prevent <br>deadlocks<br> <li> Add requirement for classifying deadlock and serialization failures as <br>transient errors with retry<br> <li> Add requirement for longer backoff delays with randomized jitter for <br>deadlock errors<br> <li> Add requirement for separate deadlock and serialization failure <br>metrics<br> <li> Modify existing requirement to include new SQLSTATE codes (40P01, <br>40001) in transient error handling<br> <li> Include scenarios demonstrating queue responsiveness, retry behavior, <br>and metric monitoring</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2064/files#diff-860d8d8d95eb220b8d6e5590df8982fec404e52dea8565587343d431998e54bb">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Task checklist for deadlock handling implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-age-graph-deadlock-handling/tasks.md

<ul><li>Document completed tasks for write serialization with mutex <br>implementation<br> <li> Document completed tasks for expanding transient error classification <br>with SQLSTATE constants<br> <li> Document completed tasks for improving backoff strategy with <br>exponential growth<br> <li> Document completed tasks for adding deadlock-specific metrics<br> <li> List pending validation tasks for deployment and monitoring in demo <br>namespace</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2064/files#diff-9031f16c5cff8b7150870d905750fef62ad51f9ec20faec52aa62a74efcb79a9">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

