### PR TITLE
fixing flakey test

### DIFF
--- a/pkg/config/kv_client_test.go
+++ b/pkg/config/kv_client_test.go
@@ -331,7 +331,7 @@ func TestKVManagerStartWatchReloadsOnAnyChange(t *testing.T) {
 
 	select {
 	case <-reloads:
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatalf("timed out waiting for reload triggered by listen_addr change")
 	}
 
@@ -344,7 +344,7 @@ func TestKVManagerStartWatchReloadsOnAnyChange(t *testing.T) {
 	select {
 	case <-reloads:
 		t.Fatalf("unexpected reload when config payload did not change")
-	case <-time.After(25 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -387,7 +387,7 @@ func TestKVManagerStartWatchReappliesPinnedOverlay(t *testing.T) {
 	select {
 	case <-reloads:
 		t.Fatalf("pinned overlay should keep the effective config stable; reload not expected")
-	case <-time.After(30 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	snap := cfg.snapshot()
@@ -483,7 +483,7 @@ func (s *watchKVStore) Delete(_ context.Context, _ string) error {
 func (s *watchKVStore) Watch(ctx context.Context, _ string) (<-chan []byte, error) {
 	s.mu.Lock()
 	if s.watchCh == nil {
-		s.watchCh = make(chan []byte, 1)
+		s.watchCh = make(chan []byte, 8) // Larger buffer to prevent emit from blocking
 		s.readyOnce.Do(func() {
 			close(s.ready)
 		})


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Tests


___

### **Description**
- Increased timeout values in flaky test cases

- Expanded watch channel buffer from 1 to 8 to prevent blocking

- Adjusted timing thresholds to improve test reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Timeouts"] -->|increased| B["50ms → 500ms<br/>25ms → 100ms<br/>30ms → 100ms"]
  C["Watch Channel"] -->|buffer expanded| D["1 → 8 capacity"]
  B --> E["Improved Test Stability"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kv_client_test.go</strong><dd><code>Increase test timeouts and watch channel buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/config/kv_client_test.go

<ul><li>Increased timeout in <code>TestKVManagerStartWatchReloadsOnAnyChange</code> from <br>50ms to 500ms for reload detection<br> <li> Increased timeout in same test from 25ms to 100ms for no-reload <br>scenario<br> <li> Increased timeout in <code>TestKVManagerStartWatchReappliesPinnedOverlay</code> <br>from 30ms to 100ms<br> <li> Expanded <code>watchKVStore.Watch</code> channel buffer from 1 to 8 to prevent emit <br>operations from blocking</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2111/files#diff-09814dd9ab05f9d40f40974f297806d71fe2eca5f8120492c9f79311153d3aef">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

