### PR TITLE
helm chart password changes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -99,7 +99,7 @@ jobs:
           echo "Waiting for API readiness at ${url}..."
           deadline=$((SECONDS+600))
           while true; do
-            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${url}" || true)"
+            code="$(curl -sL -o /dev/null -w '%{http_code}' --max-time 10 "${url}" || true)"
             if [[ "${code}" == "200" || "${code}" == "404" ]]; then
               echo "API ready (HTTP ${code})"
               break

--- a/helm/serviceradar/templates/core.yaml
+++ b/helm/serviceradar/templates/core.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: serviceradar-core
+      annotations:
+        checksum/db-credentials: {{ include "serviceradar.dbCredentialsChecksum" . }}
     spec:
       {{- include "serviceradar.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $coreSA }}

--- a/helm/serviceradar/templates/db-event-writer.yaml
+++ b/helm/serviceradar/templates/db-event-writer.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: serviceradar-db-event-writer
         app.kubernetes.io/part-of: serviceradar
+      annotations:
+        checksum/db-credentials: {{ include "serviceradar.dbCredentialsChecksum" . }}
     spec:
       serviceAccountName: {{ .Values.spire.dbEventWriterServiceAccount | default "serviceradar-db-event-writer" }}
       {{- include "serviceradar.imagePullSecrets" . | nindent 6 }}

--- a/helm/serviceradar/templates/srql.yaml
+++ b/helm/serviceradar/templates/srql.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: serviceradar-srql
         app.kubernetes.io/part-of: serviceradar
+      annotations:
+        checksum/db-credentials: {{ include "serviceradar.dbCredentialsChecksum" . }}
     spec:
       {{- include "serviceradar.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -109,7 +109,7 @@ http_request() {
     local http_code
 
     if [[ -n "$data" ]]; then
-        response=$(curl -s -w "\n%{http_code}" \
+        response=$(curl -sL -w "\n%{http_code}" \
             --max-time "$TIMEOUT" \
             -X "$method" \
             -H "Content-Type: application/json" \
@@ -117,7 +117,7 @@ http_request() {
             -d "$data" \
             "$url" 2>&1) || true
     else
-        response=$(curl -s -w "\n%{http_code}" \
+        response=$(curl -sL -w "\n%{http_code}" \
             --max-time "$TIMEOUT" \
             -X "$method" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add pod restart trigger on database credentials changes via checksum annotation

- Enable curl to follow redirects in e2e tests and health checks

- Apply checksum annotation to core, db-event-writer, and srql deployments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Database Credentials Secret"] -->|"lookup & checksum"| B["dbCredentialsChecksum Helper"]
  B -->|"annotation"| C["Pod Metadata"]
  C -->|"triggers restart"| D["Deployments Updated"]
  E["curl requests"] -->|"add -L flag"| F["Follow Redirects"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add database credentials checksum helper template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/_helpers.tpl

<ul><li>Add new <code>dbCredentialsChecksum</code> template helper function<br> <li> Lookup existing database credentials secret and compute SHA256 <br>checksum<br> <li> Fall back to random alphanumeric string if secret not found<br> <li> Enable automatic pod restart when database credentials change</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-3d59d815f528d134e097ce2c3e830c6eaa738e27b6645df1e9b18136cd5d3c0d">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>core.yaml</strong><dd><code>Add checksum annotation to core deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/core.yaml

<ul><li>Add pod annotation with database credentials checksum<br> <li> Trigger pod restart when secret changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-06ab387d2c169d82a1de28b5e66c86f0417bd81b82a96246d0a2da8bfaa8d224">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db-event-writer.yaml</strong><dd><code>Add checksum annotation to db-event-writer deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/db-event-writer.yaml

<ul><li>Add pod annotation with database credentials checksum<br> <li> Ensure pod restarts when credentials are updated</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-e4f899d11e5720f7049aa6fd632bd6993739410051bf65bc6fc8469739e5d2e4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>srql.yaml</strong><dd><code>Add checksum annotation to srql deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/srql.yaml

<ul><li>Add pod annotation with database credentials checksum<br> <li> Trigger pod restart on credential changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-263ca44548bae4940f960427ba7b95ed0e4a4fa24e342e4b480b0d4b6182f290">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e-test.sh</strong><dd><code>Enable curl redirect following in e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/e2e-test.sh

<ul><li>Add <code>-L</code> flag to curl commands to follow HTTP redirects<br> <li> Apply to both POST and GET request paths<br> <li> Improves reliability of e2e test HTTP requests</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-dfa8a5c1766e059a8823270f22b8bf652b3a34894d9d940e1ac8bbe7ca2a806e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>e2e-tests.yml</strong><dd><code>Enable curl redirect following in health check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/e2e-tests.yml

<ul><li>Add <code>-L</code> flag to curl command in health check<br> <li> Ensures proper handling of redirects during API readiness check</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2115/files#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

