### PR TITLE
Bug/upgrade clobbering configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,15 @@ help: ## Show this help message
 	@echo "$(COLOR_BOLD)Available targets:$(COLOR_RESET)"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(COLOR_CYAN)%-20s$(COLOR_RESET) %s\n", $$1, $$2}'
 
+.PHONY: compose-up
+compose-up: ## Start Docker Compose stack
+	@docker compose up -d
+
+.PHONY: compose-upgrade
+compose-upgrade: ## Pull images and recreate containers without destroying volumes
+	@docker compose pull
+	@docker compose up -d --force-recreate
+
 .PHONY: build
 build: ## Build the full workspace with Bazel (remote)
 	@bazel build --config=remote //...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,8 @@ services:
       - ./docker/compose:/templates:ro
       - ./docker/compose/update-config.sh:/usr/local/bin/update-config.sh:ro
     environment:
-      - SYSMON_VM_ADDRESS=${SYSMON_VM_ADDRESS:-192.168.1.218:50110}
-      - SYSMON_VM_SECURITY_MODE=mtls
+      - EDGE_DEFAULT_CHECKER_ENDPOINT=${EDGE_DEFAULT_CHECKER_ENDPOINT:-}
+      - EDGE_DEFAULT_CHECKER_SECURITY_MODE=${EDGE_DEFAULT_CHECKER_SECURITY_MODE:-}
       - POLLERS_SECURITY_MODE=mtls
       - CORE_SECURITY_MODE=mtls
       - CNPG_HOST=${CNPG_HOST:-cnpg}
@@ -342,6 +342,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     depends_on:
       config-updater:
+        condition: service_completed_successfully
+      cert-permissions-fixer:
         condition: service_completed_successfully
       core:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -826,13 +826,17 @@ services:
 
 volumes:
   cert-data:
+    name: "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_cert-data"
   generated-config:
+    name: "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_generated-config"
   credentials:
+    name: "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_credentials"
   core-data:
   cnpg-data:
   poller-data:
   datasvc-data:
   nats-data:
+    name: "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_nats-data"
   logs:
   agent-data:
   sync-data:

--- a/docker/compose/fix-cert-permissions.sh
+++ b/docker/compose/fix-cert-permissions.sh
@@ -5,9 +5,14 @@ echo "Fixing certificate permissions..."
 
 CERT_DIR="/etc/serviceradar/certs"
 
-# Owner: app user (uid 1000), group: db user (gid 999) so both can read; no world access
-chown -R 1000:999 "${CERT_DIR}"
-find "${CERT_DIR}" -type d -exec chmod 750 {} \;
+# Default to the poller image user/group (serviceradar:serviceradar = 1001:1001).
+APP_UID="${SERVICERADAR_UID:-1001}"
+APP_GID="${SERVICERADAR_GID:-1001}"
+
+# Owner/group: ServiceRadar runtime user so non-root containers (notably poller) can read.
+chown -R "${APP_UID}:${APP_GID}" "${CERT_DIR}"
+# Allow other service users to traverse the cert dir (but not list contents).
+find "${CERT_DIR}" -type d -exec chmod 711 {} \;
 
 # Public certs are non-sensitive; private keys stay owner/group readable only
 find "${CERT_DIR}" -type f -name '*.pem' ! -name '*-key.pem' -exec chmod 644 {} \;
@@ -15,9 +20,9 @@ find "${CERT_DIR}" -type f -name '*-key.pem' -exec chmod 640 {} \;
 
 # CNPG (PostgreSQL) key needs postgres user ownership (uid 26 in serviceradar-cnpg image)
 if [ -f "${CERT_DIR}/cnpg-key.pem" ]; then
-  chown 26:999 "${CERT_DIR}/cnpg-key.pem"
+  chown 26:26 "${CERT_DIR}/cnpg-key.pem"
   chmod 600 "${CERT_DIR}/cnpg-key.pem"
   echo "  CNPG key: uid 26, mode 600"
 fi
 
-echo "✅ Certificate permissions fixed (uid 1000, gid 999, keys 640)"
+echo "✅ Certificate permissions fixed (uid ${APP_UID}, gid ${APP_GID}, keys 640)"

--- a/docker/compose/poller.docker.json
+++ b/docker/compose/poller.docker.json
@@ -75,11 +75,6 @@
                 },
                 {
                     "service_type": "grpc",
-                    "service_name": "sysmon-osx",
-                    "details": "${SYSMON_OSX_ADDRESS:-sysmon-osx:50110}"
-                },
-                {
-                    "service_type": "grpc",
                     "service_name": "nats",
                     "details": "nats:4222"
                 },

--- a/docker/compose/poller.mtls.json
+++ b/docker/compose/poller.mtls.json
@@ -79,11 +79,6 @@
                 },
                 {
                     "service_type": "grpc",
-                    "service_name": "sysmon-osx",
-                    "details": "${SYSMON_OSX_ADDRESS:-sysmon-osx:50110}"
-                },
-                {
-                    "service_type": "grpc",
                     "service_name": "nats",
                     "details": "nats:4222"
                 },

--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -568,11 +568,16 @@ Notes:
 - `docker/compose/update-config.sh` preserves existing configs by default; set `FORCE_REGENERATE_CONFIG=true` only if you intentionally want to overwrite generated configs.
 - Equivalent one-liner: `make compose-upgrade`
 
-Verification (optional):
+Verification (optional): confirm your poller KV entry still contains your checker after an upgrade.
 ```bash
-docker run --rm \
-  -v "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_generated-config:/etc/serviceradar/config" \
-  alpine:3.20 sh -c "apk add --no-cache jq >/dev/null && jq -r '.agents[].checks[] | select(.service_name==\"sysmon-osx\").details' /etc/serviceradar/config/poller.json"
+docker run --rm --network serviceradar_serviceradar-net \
+  -v "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_cert-data:/etc/serviceradar/certs" \
+  ghcr.io/carverauto/serviceradar-tools:${APP_TAG:-v1.0.65} \
+  nats --server tls://nats:4222 \
+       --tlsca /etc/serviceradar/certs/root.pem \
+       --tlscert /etc/serviceradar/certs/poller.pem \
+       --tlskey /etc/serviceradar/certs/poller-key.pem \
+       kv get --raw serviceradar-datasvc config/pollers/docker-poller.json
 ```
 
 ### Data Migration

--- a/docs/docs/docker-setup.md
+++ b/docs/docs/docker-setup.md
@@ -112,9 +112,9 @@ PROTON_LOG_LEVEL=error
 
 ServiceRadar uses the following Docker volumes:
 
-- `cert-data`: mTLS certificates and API keys
-- `credentials`: Database passwords and secrets
-- `generated-config`: Generated configuration files
+- `cert-data`: mTLS certificates and API keys (named `${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_cert-data`)
+- `credentials`: Database passwords and secrets (named `${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_credentials`)
+- `generated-config`: Generated configuration files (named `${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_generated-config`)
 - `*-data`: Service-specific data storage
 
 ### Ports
@@ -152,7 +152,7 @@ Docker Compose now starts KV-backed config watchers. After the first `docker com
 
 ```bash
 docker run --rm --network serviceradar_serviceradar-net \
-  -v serviceradar_cert-data:/etc/serviceradar/certs \
+  -v "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_cert-data:/etc/serviceradar/certs" \
   ghcr.io/carverauto/serviceradar-tools:${APP_TAG:-v1.0.65} \
   nats --server tls://nats:4222 \
        --tlsca /etc/serviceradar/certs/root.pem \
@@ -453,7 +453,7 @@ If you see certificate-related errors:
 1. **Regenerate certificates**:
    ```bash
    docker-compose down
-   docker volume rm serviceradar_cert-data
+   docker volume rm "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_cert-data"
    docker-compose up cert-generator
    ```
 
@@ -550,18 +550,30 @@ services:
 ### Version Upgrades
 
 1. **Backup current installation**
-2. **Update version in environment**:
+2. **Update the Compose image tag** (the stack uses `APP_TAG`):
    ```bash
-   export SERVICERADAR_VERSION=v1.1.0
+   export APP_TAG=v1.1.0
    ```
 3. **Pull new images**:
    ```bash
-   docker-compose pull
+   docker compose pull
    ```
-4. **Restart services**:
+4. **Restart services (safe upgrade)**:
    ```bash
-   docker-compose up -d
+   docker compose up -d --force-recreate
    ```
+
+Notes:
+- Compose stateful volumes are explicitly named using `${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_...` so upgrades (even with a different Compose project name) reuse the same configuration/KV/certs.
+- `docker/compose/update-config.sh` preserves existing configs by default; set `FORCE_REGENERATE_CONFIG=true` only if you intentionally want to overwrite generated configs.
+- Equivalent one-liner: `make compose-upgrade`
+
+Verification (optional):
+```bash
+docker run --rm \
+  -v "${SERVICERADAR_VOLUME_PREFIX:-serviceradar}_generated-config:/etc/serviceradar/config" \
+  alpine:3.20 sh -c "apk add --no-cache jq >/dev/null && jq -r '.agents[].checks[] | select(.service_name==\"sysmon-osx\").details' /etc/serviceradar/config/poller.json"
+```
 
 ### Data Migration
 

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/proposal.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/proposal.md
@@ -7,8 +7,7 @@
 
 ### Observed regression (example)
 - After a Compose upgrade, System Metrics pages show “Last data: 3h ago” and “No system metrics…”.
-- The local Compose `poller.json` includes a sysmon check (`service_name: sysmon-osx`) whose `details` field is blank, which prevents the poller from contacting the sysmon endpoint and results in `available=false` for the sysmon check.
-- Root cause is in Compose bootstrap tooling (`docker/compose/update-config.sh`): it writes the sysmon check `details` using `SYSMON_OSX_ADDRESS`, but that variable is not consistently set by Compose (Compose currently sets `SYSMON_VM_ADDRESS`). The script therefore writes an empty string and clobbers the sysmon endpoint whenever it regenerates configs.
+- The poller configuration stored in KV can lose user-added checks during upgrade/recreate if bootstrap/repair paths rewrite KV from on-disk defaults.
 - A second (related) issue can occur when poller configuration is stored as a partial KV overlay (common for UI edits). The KV placeholder-repair logic treats missing critical fields as “placeholder”, and overwrites the KV entry from on-disk defaults during restarts/upgrades—dropping user-added checks.
 
 ## What Changes
@@ -18,8 +17,7 @@
    - Update `docker/compose/update-config.sh` to be idempotent and safe on reruns:
      - Never write empty values over existing non-empty config fields.
      - Only set defaults when missing.
-     - Fix sysmon endpoint wiring by consistently deriving the sysmon address/security mode from a single source of truth (`SYSMON_OSX_ADDRESS` + fallback to `SYSMON_VM_ADDRESS`, and `SYSMON_OSX_SECURITY_MODE` + fallback to `SYSMON_VM_SECURITY_MODE`).
-     - Optionally emit a one-time warning when the sysmon endpoint is unset (so the failure mode is visible).
+     - Avoid checker-specific “magic” in bootstrap; checkers are configured via KV/UI and templates.
    - Update KV placeholder-repair logic so missing critical fields do not trigger destructive rewrites of partial overlays during upgrades.
 3. **Define an upgrade contract**
    - Document and enforce a “safe upgrade” path for Compose:
@@ -31,9 +29,9 @@
 - Affected specs: `kv-configuration`
 - Affected code:
   - `docker-compose.yml` (volume naming)
-  - `docker/compose/update-config.sh` (bootstrap behavior + sysmon endpoint handling)
+  - `docker/compose/update-config.sh` (bootstrap behavior)
   - `docs/docs/docker-setup.md` (upgrade guidance)
 
 ## Non-Goals
 - Changing the system-metrics data model, retention, or UI rendering logic.
-- Redesigning sysmon naming (`sysmon-osx` vs `sysmon`) beyond what is required for stable Compose behavior.
+- Adding new checker types or changing checker semantics.

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/proposal.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/proposal.md
@@ -1,0 +1,38 @@
+# Change: Fix Docker Compose upgrade config clobbering
+
+## Why
+- Docker Compose upgrades (especially `docker compose up -d --force-recreate` or running the stack under a different project name) can result in ServiceRadar starting with missing or reset configuration state.
+- When configuration state is lost or reset, core/poller/agent fall back to default bootstrap templates, which can silently disable monitoring. In the UI this shows up as device pages reporting stale/no data (e.g., “No system metrics are currently available…”).
+- This is unacceptable UX: upgrading images should not overwrite or “forget” existing config.
+
+### Observed regression (example)
+- After a Compose upgrade, System Metrics pages show “Last data: 3h ago” and “No system metrics…”.
+- The local Compose `poller.json` includes a sysmon check (`service_name: sysmon-osx`) whose `details` field is blank, which prevents the poller from contacting the sysmon endpoint and results in `available=false` for the sysmon check.
+- Root cause is in Compose bootstrap tooling (`docker/compose/update-config.sh`): it writes the sysmon check `details` using `SYSMON_OSX_ADDRESS`, but that variable is not consistently set by Compose (Compose currently sets `SYSMON_VM_ADDRESS`). The script therefore writes an empty string and clobbers the sysmon endpoint whenever it regenerates configs.
+
+## What Changes
+1. **Make Compose persistence stable**
+   - Explicitly name Compose volumes that contain configuration state (notably `nats-data` and `generated-config`) so running Compose from a different directory/project name cannot silently create new, empty volumes.
+2. **Make Compose bootstrap non-destructive**
+   - Update `docker/compose/update-config.sh` to be idempotent and safe on reruns:
+     - Never write empty values over existing non-empty config fields.
+     - Only set defaults when missing.
+     - Fix sysmon endpoint wiring by consistently deriving the sysmon address/security mode from a single source of truth (`SYSMON_OSX_ADDRESS` + fallback to `SYSMON_VM_ADDRESS`, and `SYSMON_OSX_SECURITY_MODE` + fallback to `SYSMON_VM_SECURITY_MODE`).
+     - Optionally emit a one-time warning when the sysmon endpoint is unset (so the failure mode is visible).
+3. **Define an upgrade contract**
+   - Document and enforce a “safe upgrade” path for Compose:
+     - upgrades MUST preserve KV + config state
+     - bootstrap jobs MUST NOT overwrite existing configs during upgrades
+     - provide a single documented command (e.g., `make compose-upgrade`) that does not destroy volumes and makes config-updater behavior explicit.
+
+## Impact
+- Affected specs: `kv-configuration`
+- Affected code:
+  - `docker-compose.yml` (volume naming)
+  - `docker/compose/update-config.sh` (bootstrap behavior + sysmon endpoint handling)
+  - `docs/docs/docker-setup.md` (upgrade guidance)
+
+## Non-Goals
+- Changing the system-metrics data model, retention, or UI rendering logic.
+- Redesigning sysmon naming (`sysmon-osx` vs `sysmon`) beyond what is required for stable Compose behavior.
+

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/specs/kv-configuration/spec.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/specs/kv-configuration/spec.md
@@ -5,14 +5,13 @@
 Docker Compose upgrades SHALL preserve user-managed configuration state (both persistent config artifacts and KV-backed configuration). Bootstrap jobs used by Compose (e.g., config-updater and KV seeders) MUST NOT overwrite existing non-empty configuration values during routine upgrades.
 
 #### Scenario: Upgrade preserves sysmon endpoint
-- **GIVEN** a running Compose stack with a configured sysmon endpoint in the poller configuration
+- **GIVEN** a running Compose stack with a user-configured checker in the poller configuration
 - **WHEN** the stack is upgraded (images updated and containers recreated)
-- **THEN** the sysmon endpoint remains configured after the upgrade
-- **AND** system metrics continue to populate without requiring manual reconfiguration
+- **THEN** the checker configuration remains present after the upgrade
+- **AND** metrics continue to populate without requiring manual reconfiguration
 
 #### Scenario: Bootstrap does not write empty overrides
 - **GIVEN** a running Compose stack with non-empty configuration values stored in KV and/or persisted config artifacts
 - **AND** a bootstrap script is re-run during upgrade
 - **WHEN** an optional/override env var is unset or empty
 - **THEN** the bootstrap script DOES NOT write empty values into configuration files or KV
-

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/specs/kv-configuration/spec.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/specs/kv-configuration/spec.md
@@ -1,0 +1,18 @@
+# kv-configuration Spec Delta (fix-compose-upgrade-config-clobbering)
+
+## ADDED Requirements
+### Requirement: Non-Destructive Compose Upgrades
+Docker Compose upgrades SHALL preserve user-managed configuration state (both persistent config artifacts and KV-backed configuration). Bootstrap jobs used by Compose (e.g., config-updater and KV seeders) MUST NOT overwrite existing non-empty configuration values during routine upgrades.
+
+#### Scenario: Upgrade preserves sysmon endpoint
+- **GIVEN** a running Compose stack with a configured sysmon endpoint in the poller configuration
+- **WHEN** the stack is upgraded (images updated and containers recreated)
+- **THEN** the sysmon endpoint remains configured after the upgrade
+- **AND** system metrics continue to populate without requiring manual reconfiguration
+
+#### Scenario: Bootstrap does not write empty overrides
+- **GIVEN** a running Compose stack with non-empty configuration values stored in KV and/or persisted config artifacts
+- **AND** a bootstrap script is re-run during upgrade
+- **WHEN** an optional/override env var is unset or empty
+- **THEN** the bootstrap script DOES NOT write empty values into configuration files or KV
+

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
@@ -6,6 +6,7 @@
   - [x] 3.1. Define a single sysmon endpoint source of truth (`SYSMON_OSX_ADDRESS` / `SYSMON_VM_ADDRESS`) and security mode mapping.
   - [x] 3.2. Avoid clobbering existing config with empty values (guarded writes).
   - [x] 3.3. Preserve existing generated configs by default; require an explicit opt-in env (e.g., `FORCE_REGENERATE_CONFIG=true`) to rewrite templates.
+- [x] 3.4. Fix KV placeholder-repair so partial overlays do not get rewritten during restarts/upgrades.
 - [x] 4. Add/extend local verification steps:
   - [x] 4.1. Fresh `docker compose up` produces a poller config with a non-empty sysmon endpoint.
   - [x] 4.2. Upgrade-style `docker compose up -d --force-recreate` preserves sysmon endpoint and does not reset KV-managed config.

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Fix Docker Compose upgrade config clobbering
+
+- [x] 1. Capture current Compose boot/upgrade behavior and identify which volumes/keys are required to preserve sysmon/system metrics.
+- [x] 2. Update `docker-compose.yml` to explicitly name stateful volumes (at minimum `generated-config`, `nats-data`, and `cert-data`).
+- [x] 3. Update `docker/compose/update-config.sh` to:
+  - [x] 3.1. Define a single sysmon endpoint source of truth (`SYSMON_OSX_ADDRESS` / `SYSMON_VM_ADDRESS`) and security mode mapping.
+  - [x] 3.2. Avoid clobbering existing config with empty values (guarded writes).
+  - [x] 3.3. Preserve existing generated configs by default; require an explicit opt-in env (e.g., `FORCE_REGENERATE_CONFIG=true`) to rewrite templates.
+- [x] 4. Add/extend local verification steps:
+  - [x] 4.1. Fresh `docker compose up` produces a poller config with a non-empty sysmon endpoint.
+  - [x] 4.2. Upgrade-style `docker compose up -d --force-recreate` preserves sysmon endpoint and does not reset KV-managed config.
+- [x] 5. Document the safe upgrade procedure in `docs/docs/docker-setup.md`.
+- [x] 6. Run `openspec validate fix-compose-upgrade-config-clobbering --strict`.

--- a/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
+++ b/openspec/changes/fix-compose-upgrade-config-clobbering/tasks.md
@@ -3,10 +3,10 @@
 - [x] 1. Capture current Compose boot/upgrade behavior and identify which volumes/keys are required to preserve sysmon/system metrics.
 - [x] 2. Update `docker-compose.yml` to explicitly name stateful volumes (at minimum `generated-config`, `nats-data`, and `cert-data`).
 - [x] 3. Update `docker/compose/update-config.sh` to:
-  - [x] 3.1. Define a single sysmon endpoint source of truth (`SYSMON_OSX_ADDRESS` / `SYSMON_VM_ADDRESS`) and security mode mapping.
-  - [x] 3.2. Avoid clobbering existing config with empty values (guarded writes).
-  - [x] 3.3. Preserve existing generated configs by default; require an explicit opt-in env (e.g., `FORCE_REGENERATE_CONFIG=true`) to rewrite templates.
-- [x] 3.4. Fix KV placeholder-repair so partial overlays do not get rewritten during restarts/upgrades.
+  - [x] 3.1. Avoid clobbering existing configs during upgrades.
+  - [x] 3.2. Preserve existing generated configs by default; require an explicit opt-in env (e.g., `FORCE_REGENERATE_CONFIG=true`) to rewrite templates.
+  - [x] 3.3. Fix KV placeholder-repair so partial overlays do not get rewritten during restarts/upgrades.
+  - [x] 3.4. Remove checker-specific bootstrap logic (rely on KV/UI + templates instead).
 - [x] 4. Add/extend local verification steps:
   - [x] 4.1. Fresh `docker compose up` produces a poller config with a non-empty sysmon endpoint.
   - [x] 4.2. Upgrade-style `docker compose up -d --force-recreate` preserves sysmon endpoint and does not reset KV-managed config.

--- a/pkg/config/kv_repair.go
+++ b/pkg/config/kv_repair.go
@@ -48,8 +48,10 @@ func needsPlaceholderRepair(desc ServiceDescriptor, raw []byte) bool {
 
 	for _, field := range desc.CriticalFields {
 		val, ok := lookupStringField(doc, field)
+		// Missing critical fields are common when KV stores a partial overlay rather
+		// than a full config document; do not treat "missing" as a placeholder signal.
 		if !ok {
-			return true
+			continue
 		}
 		if isPlaceholderValue(val) {
 			return true

--- a/pkg/config/kv_repair_test.go
+++ b/pkg/config/kv_repair_test.go
@@ -58,8 +58,8 @@ func TestNeedsPlaceholderRepair(t *testing.T) {
 		CriticalFields: []string{"auth.jwt_public_key_pem"},
 	}
 	raw = []byte(`{"auth":{}}`)
-	if !needsPlaceholderRepair(desc, raw) {
-		t.Fatalf("expected missing field to trigger repair")
+	if needsPlaceholderRepair(desc, raw) {
+		t.Fatalf("did not expect missing field to trigger repair")
 	}
 }
 


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Docker Compose upgrades clobbering configuration by explicitly naming stateful volumes

- Prevent bootstrap script from overwriting existing configs with empty values

- Fix KV placeholder-repair logic to preserve partial config overlays during restarts

- Add safe upgrade path with FORCE_REGENERATE_CONFIG flag and make compose-upgrade target

- Stabilize sysmon endpoint wiring by deriving from single source of truth


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Compose Upgrade"] -->|explicit volume naming| B["Preserve Config State"]
  A -->|FORCE_REGENERATE_CONFIG flag| C["Non-Destructive Bootstrap"]
  D["KV Placeholder Repair"] -->|skip missing fields| E["Preserve Partial Overlays"]
  C -->|consistent sysmon wiring| F["Stable Endpoint Config"]
  B --> G["Safe Upgrade Contract"]
  E --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>kv_repair.go</strong><dd><code>Skip missing fields in placeholder repair logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-cf55ade5ae708eee328e7cd48131c8cc5c4b83968511dfebc28ff28809e1d768">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-config.sh</strong><dd><code>Prevent config clobbering and stabilize sysmon endpoint wiring</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-9ae50be83a13010a038389c74407ba1bde8cabcea0944e238c4b3374133f78bf">+87/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>kv_repair_test.go</strong><dd><code>Update test expectations for missing field handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-4d31f0198901fd3994040a41f1c88120720ca717d8c21ae48a3e225e36cfcf5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Add compose-up and compose-upgrade helper targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>docker-compose.yml</strong><dd><code>Explicitly name stateful volumes with prefix variable</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>docker-setup.md</strong><dd><code>Document safe upgrade procedure and volume naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-8604269dffb3ce4133e48cab374ca8e97745d0efbdef67cad792aeb5945fe5ec">+22/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong><dd><code>Add OpenSpec proposal for config clobbering fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-d4f7fb7aaeb9384efaf2ec505c9e73e6a4405542d9e3c5f64dc736ba8e9e217d">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Add KV configuration spec requirements for non-destructive upgrades</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-b4ce1b71c288e8d4d2d9fce388795c84e0cfc51f0cd66e3e3f7f4767e7890a24">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong><dd><code>Add task checklist for config clobbering fix implementation</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2121/files#diff-cf742869daef1d609cc7849d92f8cdba9eb4d3cd7eb3d403c86bd0a4e8b3ab3b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

