### PR TITLE
initial

### DIFF
--- a/openspec/changes/fix-identity-batch-lookup-partition/design.md
+++ b/openspec/changes/fix-identity-batch-lookup-partition/design.md
@@ -1,0 +1,32 @@
+## Context
+`IdentityEngine.lookupByStrongIdentifiers` correctly filters identifier lookups by `partition`, but `IdentityEngine.batchLookupByStrongIdentifiers` does not. This creates cross-partition identity assignment when identifier values collide across partitions within the same batch.
+
+## Goals / Non-Goals
+- Goals:
+  - Guarantee partition isolation for all strong-identifier lookups, including batch paths.
+  - Preserve batch-mode performance characteristics for single-partition batches.
+- Non-Goals:
+  - Data repair/migration of previously-corrupted device identities (out of scope for this change; handled operationally if needed).
+
+## Decisions
+- Decision: Group updates by partition and run per-partition batch queries.
+  - Rationale: Minimizes SQL complexity, keeps the lookup API stable (single partition per call), and naturally matches the correctness constraint.
+
+## Alternatives Considered
+- Single query across partitions using composite keys (e.g., `UNNEST(partitions, values)` and joining on both columns).
+  - Rejected: Higher SQL complexity and more complicated result mapping; can be revisited if per-partition query counts become a bottleneck.
+- Disable batch lookup when mixed partitions are present (fall back to single lookups).
+  - Rejected: Correct but loses the optimization exactly when batch sizes are large and mixed partitions are common.
+
+## Risks / Trade-offs
+- More queries when a batch spans many partitions.
+  - Mitigation: Partition count per batch is typically small; deduplicate identifier values within each partition and type to reduce query payload.
+
+## Migration Plan
+1. Update DB API + SQL to require partition for batch lookups.
+2. Update IdentityEngine to group-by-partition and call the new API.
+3. Add regression tests for mixed-partition batches.
+
+## Open Questions
+- Should we add an explicit metric for identifier collisions across partitions to aid detection of multi-tenant environments with common MAC reuse?
+

--- a/openspec/changes/fix-identity-batch-lookup-partition/proposal.md
+++ b/openspec/changes/fix-identity-batch-lookup-partition/proposal.md
@@ -1,0 +1,22 @@
+# Change: Fix partition-scoped batch identifier lookup
+
+## Why
+GitHub issue `#2140` reports that `IdentityEngine.batchLookupByStrongIdentifiers` performs batch identifier lookups without filtering by `partition`. In a multi-tenant deployment, two partitions can legitimately contain the same identifier value (e.g., MAC address). When updates from different partitions land in the same batch, the current implementation can assign the first-matched `device_id` to all updates, violating partition isolation and silently corrupting device identity.
+
+This is a security-relevant correctness issue: cross-partition identity assignment can leak inventory and telemetry between tenants and break the integrity of the canonical device model.
+
+## What Changes
+- Add a `partition` parameter to the DB batch lookup API and filter the underlying SQL query by partition.
+- Update `IdentityEngine.batchLookupByStrongIdentifiers` to preserve correctness when a batch contains multiple partitions by grouping updates by partition and performing per-partition batch lookups.
+- Add regression tests to ensure mixed-partition batches resolve to partition-correct device IDs (no cross-partition matches).
+
+## Impact
+- Affected specs: `device-identity-reconciliation`
+- Affected code:
+  - `pkg/registry/identity_engine.go`
+  - `pkg/db/interfaces.go`
+  - `pkg/db/cnpg_identity_engine.go`
+  - `pkg/db/mock_db.go`
+  - `pkg/registry/*_test.go` (new regression coverage)
+- Behavior change: only for mixed-partition batches with colliding identifier values; fixes prior incorrect cross-partition assignment.
+

--- a/openspec/changes/fix-identity-batch-lookup-partition/specs/device-identity-reconciliation/spec.md
+++ b/openspec/changes/fix-identity-batch-lookup-partition/specs/device-identity-reconciliation/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Partition-Scoped Batch Identifier Lookup
+The system MUST resolve strong identifiers in batch mode within the update's partition, and MUST NOT match identifiers across partitions.
+
+#### Scenario: Same identifier in different partitions
+- **WHEN** two device updates in the same batch share the same strong identifier value but have different partitions
+- **THEN** each update resolves to the device ID that matches its own partition
+
+#### Scenario: Empty partition defaults consistently
+- **WHEN** a device update has an empty partition value
+- **THEN** identifier resolution treats it as partition `default` for both single and batch lookup paths
+

--- a/openspec/changes/fix-identity-batch-lookup-partition/tasks.md
+++ b/openspec/changes/fix-identity-batch-lookup-partition/tasks.md
@@ -1,0 +1,17 @@
+## 1. Database Layer
+- [x] 1.1 Update `BatchGetDeviceIDsByIdentifier` to accept a `partition` parameter
+- [x] 1.2 Add `AND partition = $3` to `batchGetDeviceIDsByIdentifierSQL`
+- [x] 1.3 Update DB interface and gomock mocks/callers for the new signature
+
+## 2. Identity Engine
+- [x] 2.1 Group batch updates by partition (defaulting empty to `default`)
+- [x] 2.2 For each partition: batch query strong identifiers by type using the partition-aware DB API
+- [x] 2.3 Map identifier hits back to updates using the existing strong-ID priority order
+
+## 3. Tests
+- [x] 3.1 Add regression test: two partitions with the same MAC in the same batch resolve to different device IDs
+- [x] 3.2 Update existing tests/mocks that expect `BatchGetDeviceIDsByIdentifier` calls
+- [x] 3.3 Run `go test ./pkg/registry/...` and `go test ./pkg/db/...`
+
+## 4. Validation
+- [x] 4.1 Run `openspec validate fix-identity-batch-lookup-partition --strict`

--- a/pkg/db/interfaces.go
+++ b/pkg/db/interfaces.go
@@ -177,7 +177,7 @@ type Service interface {
 
 	// Device identifier lookup operations (for IdentityEngine).
 	GetDeviceIDByIdentifier(ctx context.Context, identifierType, identifierValue, partition string) (string, error)
-	BatchGetDeviceIDsByIdentifier(ctx context.Context, identifierType string, identifierValues []string) (map[string]string, error)
+	BatchGetDeviceIDsByIdentifier(ctx context.Context, identifierType string, identifierValues []string, partition string) (map[string]string, error)
 }
 
 // SysmonMetricsProvider interface defines operations for system monitoring metrics.

--- a/pkg/db/mock_db.go
+++ b/pkg/db/mock_db.go
@@ -1254,6 +1254,7 @@ func (mr *MockServiceMockRecorder) WithTx(ctx, fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTx", reflect.TypeOf((*MockService)(nil).WithTx), ctx, fn)
 }
+
 // QueryRegistryRows mocks base method.
 func (m *MockService) QueryRegistryRows(ctx context.Context, query string, args ...interface{}) (Rows, error) {
 	m.ctrl.T.Helper()
@@ -1290,18 +1291,18 @@ func (mr *MockServiceMockRecorder) GetDeviceIDByIdentifier(ctx, identifierType, 
 }
 
 // BatchGetDeviceIDsByIdentifier mocks base method.
-func (m *MockService) BatchGetDeviceIDsByIdentifier(ctx context.Context, identifierType string, identifierValues []string) (map[string]string, error) {
+func (m *MockService) BatchGetDeviceIDsByIdentifier(ctx context.Context, identifierType string, identifierValues []string, partition string) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BatchGetDeviceIDsByIdentifier", ctx, identifierType, identifierValues)
+	ret := m.ctrl.Call(m, "BatchGetDeviceIDsByIdentifier", ctx, identifierType, identifierValues, partition)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BatchGetDeviceIDsByIdentifier indicates an expected call of BatchGetDeviceIDsByIdentifier.
-func (mr *MockServiceMockRecorder) BatchGetDeviceIDsByIdentifier(ctx, identifierType, identifierValues any) *gomock.Call {
+func (mr *MockServiceMockRecorder) BatchGetDeviceIDsByIdentifier(ctx, identifierType, identifierValues, partition any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchGetDeviceIDsByIdentifier", reflect.TypeOf((*MockService)(nil).BatchGetDeviceIDsByIdentifier), ctx, identifierType, identifierValues)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchGetDeviceIDsByIdentifier", reflect.TypeOf((*MockService)(nil).BatchGetDeviceIDsByIdentifier), ctx, identifierType, identifierValues, partition)
 }
 
 // MockRows is a mock of Rows interface.

--- a/pkg/registry/canon_simulation_test.go
+++ b/pkg/registry/canon_simulation_test.go
@@ -300,11 +300,11 @@ func TestDIREIdentityResolution(t *testing.T) {
 func setupDIREMockDB(mockDB *db.MockService, identifierStore map[string]string) {
 	// Mock BatchGetDeviceIDsByIdentifier to check if identifier already exists
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, identifierType string, identifierValues []string) (map[string]string, error) {
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, identifierType string, identifierValues []string, partition string) (map[string]string, error) {
 			result := make(map[string]string)
 			for _, val := range identifierValues {
-				key := identifierType + ":" + val
+				key := strongIdentifierCacheKey(partition, identifierType, val)
 				if deviceID, ok := identifierStore[key]; ok {
 					result[val] = deviceID
 				}
@@ -318,7 +318,7 @@ func setupDIREMockDB(mockDB *db.MockService, identifierStore map[string]string) 
 		UpsertDeviceIdentifiers(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, identifiers []*models.DeviceIdentifier) error {
 			for _, id := range identifiers {
-				key := id.IDType + ":" + id.IDValue
+				key := strongIdentifierCacheKey(id.Partition, id.IDType, id.IDValue)
 				identifierStore[key] = id.DeviceID
 			}
 			return nil

--- a/pkg/registry/identity_engine_partition_test.go
+++ b/pkg/registry/identity_engine_partition_test.go
@@ -1,0 +1,51 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/carverauto/serviceradar/pkg/db"
+	"github.com/carverauto/serviceradar/pkg/logger"
+	"github.com/carverauto/serviceradar/pkg/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBatchLookupByStrongIdentifiers_PartitionScoped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := db.NewMockService(ctrl)
+	engine := NewIdentityEngine(mockDB, logger.NewTestLogger())
+
+	mac := "AA:BB:CC:DD:EE:FF"
+	normalizedMAC := NormalizeMAC(mac)
+
+	updateA := &models.DeviceUpdate{Partition: "tenant-a", MAC: stringPtr(mac)}
+	updateB := &models.DeviceUpdate{Partition: "tenant-b", MAC: stringPtr(mac)}
+
+	updateIdentifiers := map[*models.DeviceUpdate]*StrongIdentifiers{
+		updateA: engine.ExtractStrongIdentifiers(updateA),
+		updateB: engine.ExtractStrongIdentifiers(updateB),
+	}
+
+	mockDB.EXPECT().
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), IdentifierTypeMAC, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, identifierType string, identifierValues []string, partition string) (map[string]string, error) {
+			require.Equal(t, IdentifierTypeMAC, identifierType)
+			require.ElementsMatch(t, []string{normalizedMAC}, identifierValues)
+
+			switch partition {
+			case "tenant-a":
+				return map[string]string{normalizedMAC: "sr:tenant-a-device-123"}, nil
+			case "tenant-b":
+				return map[string]string{normalizedMAC: "sr:tenant-b-device-456"}, nil
+			default:
+				return map[string]string{}, nil
+			}
+		}).
+		Times(2)
+
+	matches := engine.batchLookupByStrongIdentifiers(context.Background(), []*models.DeviceUpdate{updateA, updateB}, updateIdentifiers)
+
+	require.Equal(t, "sr:tenant-a-device-123", matches[updateA])
+	require.Equal(t, "sr:tenant-b-device-456", matches[updateB])
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -47,7 +47,7 @@ func allowCanonicalizationQueries(mockDB *db.MockService) {
 		AnyTimes()
 	// IdentityEngine calls BatchGetDeviceIDsByIdentifier to resolve strong identifiers
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		AnyTimes()
 	// IdentityEngine calls UpsertDeviceIdentifiers to persist identifier mappings
@@ -1285,7 +1285,7 @@ func TestProcessBatchDeviceUpdates_MergesSweepIntoCanonicalDevice(t *testing.T) 
 
 	// IdentityEngine mocks
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		AnyTimes()
 	mockDB.EXPECT().
@@ -1345,7 +1345,7 @@ func TestReconcileSightingsMergesSweepSightingsByIP(t *testing.T) {
 
 	// IdentityEngine mocks
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		AnyTimes()
 	mockDB.EXPECT().
@@ -1451,7 +1451,7 @@ func TestReconcileSightingsPromotesEligibleSightings(t *testing.T) {
 		Return([]*models.UnifiedDevice{}, nil).
 		AnyTimes()
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		AnyTimes()
 
@@ -1732,7 +1732,7 @@ func TestProcessBatchDeviceUpdates_SweepAttachedToCanonicalGetsMetadata(t *testi
 		AnyTimes()
 
 	mockDB.EXPECT().
-		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any()).
+		BatchGetDeviceIDsByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).
 		AnyTimes()
 


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Add partition parameter to batch identifier lookup to prevent cross-tenant device merging

- Group batch updates by partition before querying to maintain isolation

- Update database layer SQL and API to filter identifiers by partition

- Add regression test for mixed-partition batch identifier resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Batch Device Updates"] -->|Group by Partition| B["Per-Partition Update Groups"]
  B -->|Query with Partition Filter| C["Database Layer"]
  C -->|Return Partition-Scoped Results| D["Identity Matches"]
  D -->|Map to Correct Devices| E["Partition-Isolated Device IDs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>cnpg_identity_engine.go</strong><dd><code>Add partition filter to batch identifier SQL query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-756702fbe82153fa86ae9b6bd6e5b109901d5fb8ee27cb9bc19f51277d3632f0">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>interfaces.go</strong><dd><code>Add partition parameter to batch lookup interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-c230fe0c315251837357bfde4ae7f7b34080398d8e48af6bf78badb2124271f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity_engine.go</strong><dd><code>Implement partition-grouped batch identifier lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-496f24b3784656e1d6bb97cafe5c528bbecea5a0b74b4be578d3b83e858038c7">+124/-54</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>mock_db.go</strong><dd><code>Update mock to accept partition parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-30e38f888d4849fc40d7ebb1559c2a84c43aa8cd13b3b89fd7ec6cf873b243c7">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>canon_simulation_test.go</strong><dd><code>Update mock setup to use partition-aware cache keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-73b73409b3941af4ac860561c87772763feca734fd8ab597f36e5e4047c6bf3c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identity_engine_partition_test.go</strong><dd><code>Add regression test for partition-scoped batch lookups</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-77aee244beb622dec723a0a62d2d11785b5b76a9fe5df912ba559227d3f4ba70">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry_test.go</strong><dd><code>Update test mocks for new partition parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-f010972d104404be52d2a8e6e784cb56e31194f90795a69571a12696bcbdc075">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>proposal.md</strong><dd><code>Document change rationale and impact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-cd52b3fd553ef7792c277ff50c4e9a9e1f3499b62def55e845f1311f5da7eb0d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong><dd><code>Document design decisions and alternatives</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-7120eaa6a5f458aa2e1649559057f77ecd7355c3eb9079a3cbe53fdfac97b93b">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Add partition-scoped batch lookup requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-a212262a53d3ee2d68753329b05835cd20f2aa7671ffa686b4a6083f1d330256">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong><dd><code>Document implementation tasks and checklist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2155/files#diff-0b26ad240d4dcd68f67721a1352e54bcf78ee404d2ee167feca6675008466f61">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

