### PR TITLE
initial

### DIFF
--- a/openspec/changes/fix-snmp-check-deadlock/proposal.md
+++ b/openspec/changes/fix-snmp-check-deadlock/proposal.md
@@ -1,0 +1,16 @@
+# Change: Fix SNMP checker health check deadlock
+
+## Why
+GitHub issue `#2141` reports a deadlock in the SNMP checker service caused by recursive `sync.RWMutex` read locking: `SNMPService.Check()` acquires `RLock()` and then calls `GetStatus()`, which also calls `RLock()`. If a writer is waiting (e.g., `handleDataPoint()` attempting `Lock()`), Go’s write-preferring `RWMutex` blocks new readers, so the nested `RLock()` blocks indefinitely while still holding the outer `RLock()`. This can hang health checks and make the SNMP checker unresponsive.
+
+## What Changes
+- Update `SNMPService.Check()` and/or `SNMPService.GetStatus()` so health checks cannot deadlock under concurrent datapoint updates.
+- Add regression test coverage that reproduces the deadlock scenario and verifies the fix.
+
+## Impact
+- Affected specs: `snmp-checker`
+- Affected code:
+  - `pkg/checker/snmp/service.go`
+  - `pkg/checker/snmp/*_test.go`
+- Risk: low; change is localized to lock usage in health/status paths.
+

--- a/openspec/changes/fix-snmp-check-deadlock/specs/snmp-checker/spec.md
+++ b/openspec/changes/fix-snmp-check-deadlock/specs/snmp-checker/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: SNMP checker health checks are deadlock-free
+The SNMP checker service MUST allow `Check()` and `GetStatus()` to execute concurrently with datapoint processing without deadlocking.
+
+#### Scenario: Health check during concurrent datapoint updates
+- **GIVEN** the SNMP checker is processing datapoints (updating internal status)
+- **WHEN** a health check calls `Check()` concurrently with datapoint updates
+- **THEN** `Check()` returns a result without blocking indefinitely
+

--- a/openspec/changes/fix-snmp-check-deadlock/tasks.md
+++ b/openspec/changes/fix-snmp-check-deadlock/tasks.md
@@ -1,0 +1,12 @@
+## 1. Fix
+- [x] 1.1 Remove recursive `RWMutex` read locking in `SNMPService.Check()` (do not call `GetStatus()` while holding `RLock()`, or refactor to share a locked snapshot)
+- [x] 1.2 Ensure status snapshot returned by `Check()` remains thread-safe and consistent with `GetStatus()` output expectations
+
+## 2. Tests
+- [x] 2.1 Add a regression test that prevents `Check()` from combining `s.mu.RLock()` with a call to `GetStatus()` (static AST assertion)
+- [x] 2.2 Ensure the regression test fails on the pre-fix implementation and passes post-fix
+
+## 3. Validation
+- [x] 3.1 Run `go test ./pkg/checker/snmp/...`
+- [x] 3.2 Run `make lint`
+- [x] 3.3 Run `openspec validate fix-snmp-check-deadlock --strict`

--- a/pkg/checker/snmp/BUILD.bazel
+++ b/pkg/checker/snmp/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "service_deadlock_test.go",
         "service_test.go",
     ],
+    embedsrcs = ["service.go"],
     embed = [":snmp"],
     deps = [
         "//pkg/logger",

--- a/pkg/checker/snmp/BUILD.bazel
+++ b/pkg/checker/snmp/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     srcs = [
         "aggregator_test.go",
         "collector_test.go",
+        "service_deadlock_test.go",
         "service_test.go",
     ],
     embed = [":snmp"],

--- a/pkg/checker/snmp/service_deadlock_test.go
+++ b/pkg/checker/snmp/service_deadlock_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package snmp pkg/checker/snmp/service_deadlock_test.go
+package snmp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCheckDoesNotRLockAndCallGetStatus(t *testing.T) {
+	t.Helper()
+
+	fileSet := token.NewFileSet()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to locate test file path via runtime.Caller")
+	}
+	filePath := filepath.Join(filepath.Dir(thisFile), "service.go")
+	parsed, err := parser.ParseFile(fileSet, filePath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filePath, err)
+	}
+
+	var checkDecl *ast.FuncDecl
+	for _, decl := range parsed.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok || funcDecl.Recv == nil || funcDecl.Name == nil {
+			continue
+		}
+		if funcDecl.Name.Name == "Check" {
+			checkDecl = funcDecl
+			break
+		}
+	}
+
+	if checkDecl == nil || checkDecl.Body == nil || len(checkDecl.Recv.List) == 0 {
+		t.Fatalf("Check method not found in %s", filePath)
+	}
+
+	if len(checkDecl.Recv.List[0].Names) == 0 || checkDecl.Recv.List[0].Names[0] == nil || checkDecl.Recv.List[0].Names[0].Name == "" {
+		t.Fatalf("unable to determine Check receiver identifier in %s", filePath)
+	}
+	receiverName := checkDecl.Recv.List[0].Names[0].Name
+
+	var hasMuRLock bool
+	var hasGetStatusCall bool
+
+	ast.Inspect(checkDecl.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel == nil {
+			return true
+		}
+
+		if selector.Sel.Name == "GetStatus" {
+			if recv, ok := selector.X.(*ast.Ident); ok && recv.Name == receiverName {
+				hasGetStatusCall = true
+			}
+			return true
+		}
+
+		if selector.Sel.Name != "RLock" {
+			return true
+		}
+
+		muSelector, ok := selector.X.(*ast.SelectorExpr)
+		if !ok || muSelector.Sel == nil || muSelector.Sel.Name != "mu" {
+			return true
+		}
+
+		if recv, ok := muSelector.X.(*ast.Ident); ok && recv.Name == receiverName {
+			hasMuRLock = true
+		}
+
+		return true
+	})
+
+	if hasMuRLock && hasGetStatusCall {
+		t.Fatalf("Check must not call GetStatus while holding s.mu.RLock (recursive RWMutex read locking can deadlock)")
+	}
+}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove recursive RWMutex read locking in `SNMPService.Check()` to prevent deadlock

- `Check()` no longer holds RLock while calling `GetStatus()`, avoiding write-preferring semantics deadlock

- Add AST-based regression test to prevent recursive RWMutex read locking reintroduction

- Document deadlock fix with proposal, requirements, and task tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SNMPService.Check()"] -->|previously held RLock| B["GetStatus()"]
  B -->|nested RLock blocked| C["Waiting Writer"]
  C -->|write-preferring RWMutex| D["Deadlock"]
  A -->|now no RLock| E["GetStatus()"]
  E -->|independent locking| F["No Deadlock"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Remove recursive RWMutex read locking from Check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/service.go

<ul><li>Removed <code>s.mu.RLock()</code> and <code>defer s.mu.RUnlock()</code> from <code>Check()</code> method<br> <li> Added explanatory comment documenting why recursive RWMutex read <br>locking must be avoided<br> <li> <code>Check()</code> now calls <code>GetStatus()</code> without holding a read lock</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-c592649b582c62a85d1dd416ac7fb609e55531cb43c8199a15f4432ce8ae05d8">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_deadlock_test.go</strong><dd><code>Add AST-based regression test for deadlock prevention</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/service_deadlock_test.go

<ul><li>New regression test using AST parsing to verify <code>Check()</code> does not hold <br>RLock while calling <code>GetStatus()</code><br> <li> Test parses <code>service.go</code> at runtime and inspects the <code>Check()</code> method's <br>AST<br> <li> Fails if both <code>s.mu.RLock()</code> and <code>GetStatus()</code> call are detected in the <br>same method<br> <li> Prevents accidental reintroduction of the deadlock bug</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-6a31b13924de8ba2b712fc5deb881056c50f7448bb61eb84efe82850eb08325e">+104/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Document SNMP checker deadlock fix proposal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-check-deadlock/proposal.md

<ul><li>Documents GitHub issue #2141 describing the deadlock scenario<br> <li> Explains root cause: recursive RWMutex read locking with <br>write-preferring semantics<br> <li> Outlines the fix and regression test coverage requirements<br> <li> Assesses risk as low due to localized lock usage changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-0534d758c6b8e27938b14175fe5a6ff9bf0ee3a352da208c3f651cab9a460736">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add deadlock-free health check requirement specification</code>&nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-check-deadlock/specs/snmp-checker/spec.md

<ul><li>Adds new requirement: SNMP checker health checks must be deadlock-free<br> <li> Defines scenario for health check execution during concurrent <br>datapoint updates<br> <li> Specifies that <code>Check()</code> must return without blocking indefinitely</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-5845d29d43f16fd852471b164a176e879de47eb15be4d4bcc32e27130a6095ec">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Document implementation tasks and validation checklist</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-check-deadlock/tasks.md

<ul><li>Documents three task categories: Fix, Tests, and Validation<br> <li> Lists specific implementation tasks including removing recursive RLock <br>and ensuring thread-safety<br> <li> Includes regression test requirements and validation steps<br> <li> All tasks marked as completed</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-f7b9a49b7e16fb0ce430f87e5fe38160d9a072efe92259ca776fe6ee0449a7c9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Include deadlock regression test in build configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/BUILD.bazel

<ul><li>Added <code>service_deadlock_test.go</code> to the test sources list in the <br><code>snmp_test</code> target<br> <li> Ensures the new regression test is included in the build</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2156/files#diff-bf78b9b2c6f1b0b501487be34f583e55b0735ad601abb7c7e9d27cb55a0ef57f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

