### PR TITLE
initial

### DIFF
--- a/openspec/changes/fix-sweeper-summary-shallow-copy/proposal.md
+++ b/openspec/changes/fix-sweeper-summary-shallow-copy/proposal.md
@@ -1,0 +1,28 @@
+# Change: Fix sweeper summary shallow-copy data races
+
+## Why
+Issue #2148 reports data races in `pkg/sweeper` summary collection/streaming caused by shallow-copying `models.HostResult` (`*host`) while holding shard locks, then returning those copies after releasing locks. Because `HostResult` contains pointer/slice/map fields (`PortResults`, `PortMap`, `ICMPStatus`), shallow copies retain references to the underlying shared data, allowing concurrent reads/writes once the lock is released.
+
+This is observable via `go test -race` and can lead to undefined behavior, crashes, or corrupted summary data under concurrent `Process()` + summary access.
+
+## What Changes
+- Introduce a shared deep-copy helper for `models.HostResult` that produces a non-aliased snapshot (including `PortResults`, `PortMap`, and `ICMPStatus`).
+- Update summary collection and streaming paths in `pkg/sweeper/base_processor.go` to use deep copies before releasing shard locks.
+- Update `pkg/sweeper/memory_store.go` host result conversions to use the same deep-copy helper for consistency and to prevent accidental aliasing as the code evolves.
+- Add regression tests (including a race-detector test derived from issue #2148) to ensure summaries are safe under concurrent reads/writes.
+
+## Impact
+- Affected specs: sweeper
+- Affected code:
+  - `pkg/models/sweep.go` (new deep-copy helper adjacent to `HostResult`)
+  - `pkg/sweeper/base_processor.go` (deep-copy in summary collection/stream)
+  - `pkg/sweeper/memory_store.go` (deep-copy in host slice conversion)
+  - `pkg/sweeper/*_test.go` (new regression + race tests)
+- Risk: Low (purely defensive copying); primary risk is increased CPU/memory during summary retrieval for large host sets.
+
+## Trade-offs
+- Deep copying increases per-summary allocation proportional to host/port cardinality, but avoids unsafe aliasing and makes summary consumption lock-free and race-free.
+- Alternatives considered:
+  - Holding locks while callers consume data (not viable; would leak internal locking to callers and degrade concurrency).
+  - Removing `PortMap` from returned objects (would be a behavior change for internal consumers and still leaves `PortResults`/`ICMPStatus` aliasing).
+

--- a/openspec/changes/fix-sweeper-summary-shallow-copy/specs/sweeper/spec.md
+++ b/openspec/changes/fix-sweeper-summary-shallow-copy/specs/sweeper/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Summary snapshot isolation
+ServiceRadar MUST return sweep summaries whose `HostResult` entries do not alias internal mutable state.
+
+#### Scenario: GetSummary returns safe-to-read host snapshots
+- **GIVEN** a sweeper result processor has processed at least one result
+- **WHEN** a caller invokes `GetSummary`
+- **THEN** the returned `SweepSummary.Hosts` entries MUST be safe to read after the call returns (without holding internal shard locks)
+- **AND** concurrent result processing MUST NOT cause data races when the caller reads `PortResults`, `PortMap`, or `ICMPStatus`
+
+#### Scenario: Streamed HostResult values remain safe after shard locks are released
+- **GIVEN** a caller consumes host snapshots from a summary streaming API
+- **WHEN** the streaming method has returned and internal locks have been released
+- **THEN** the previously received `HostResult` values MUST remain safe to read while result processing continues concurrently
+
+#### Scenario: Caller mutation does not affect subsequent summaries
+- **GIVEN** a caller has received a sweep summary containing a `HostResult`
+- **WHEN** the caller mutates the returned host data (e.g., appends to `PortResults` or edits `PortMap`)
+- **THEN** subsequent summaries MUST reflect only internally maintained state, not caller mutations
+

--- a/openspec/changes/fix-sweeper-summary-shallow-copy/tasks.md
+++ b/openspec/changes/fix-sweeper-summary-shallow-copy/tasks.md
@@ -1,0 +1,17 @@
+## 1. Deep-copy helpers
+- [x] 1.1 Add `models.DeepCopyHostResult(*models.HostResult) models.HostResult` that deep-copies `PortResults`, `PortMap`, and `ICMPStatus`
+- [x] 1.2 Ensure copied `PortMap` entries reference the same copied `PortResult` pointers as `PortResults` (no duplicated per-port objects)
+- [x] 1.3 Add unit tests verifying copies do not alias source fields (`PortResults`, `PortMap`, `ICMPStatus`)
+
+## 2. Apply deep-copy to `BaseProcessor` summaries
+- [x] 2.1 Update `collectShardSummaries()` to append deep-copied `HostResult` values
+- [x] 2.2 Update `processShardForSummary()` / `GetSummaryStream()` to send deep-copied `HostResult` values
+- [x] 2.3 Add regression test reproducing issue #2148 and verifying `go test -race` passes
+
+## 3. Apply deep-copy to `InMemoryStore` conversions
+- [x] 3.1 Update `convertToSlice()` to use deep-copied `HostResult` values
+- [x] 3.2 Update `buildSummary()` to use deep-copied `HostResult` values
+
+## 4. Verification
+- [x] 4.1 Run `go test -race ./pkg/sweeper -run TestGetSummary_ConcurrentReadsDoNotPanic`
+- [x] 4.2 Run `go test ./pkg/...`

--- a/pkg/models/sweep_deepcopy_test.go
+++ b/pkg/models/sweep_deepcopy_test.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeepCopyHostResult_NoAliasing(t *testing.T) {
+	icmp := &ICMPStatus{Available: true, RoundTrip: 10 * time.Millisecond, PacketLoss: 0}
+	pr80 := &PortResult{Port: 80, Available: true, RespTime: 5 * time.Millisecond, Service: "http"}
+	pr443 := &PortResult{Port: 443, Available: false, RespTime: 0, Service: "https"}
+
+	src := &HostResult{
+		Host:         "192.168.1.1",
+		Available:    true,
+		FirstSeen:    time.Unix(100, 0),
+		LastSeen:     time.Unix(200, 0),
+		PortResults:  []*PortResult{pr80, pr443},
+		PortMap:      map[int]*PortResult{80: pr80, 443: pr443},
+		ICMPStatus:   icmp,
+		ResponseTime: 11 * time.Millisecond,
+	}
+
+	dst := DeepCopyHostResult(src)
+
+	if dst.Host != src.Host || dst.Available != src.Available || !dst.FirstSeen.Equal(src.FirstSeen) || !dst.LastSeen.Equal(src.LastSeen) || dst.ResponseTime != src.ResponseTime {
+		t.Fatalf("expected scalar fields to match")
+	}
+
+	if dst.ICMPStatus == nil || src.ICMPStatus == nil {
+		t.Fatalf("expected ICMPStatus to be non-nil")
+	}
+	if dst.ICMPStatus == src.ICMPStatus {
+		t.Fatalf("expected ICMPStatus to be deep-copied")
+	}
+	if *dst.ICMPStatus != *src.ICMPStatus {
+		t.Fatalf("expected ICMPStatus values to match")
+	}
+
+	if dst.PortResults == nil || len(dst.PortResults) != len(src.PortResults) {
+		t.Fatalf("expected PortResults to be copied")
+	}
+	if dst.PortMap == nil || len(dst.PortMap) != len(src.PortMap) {
+		t.Fatalf("expected PortMap to be copied")
+	}
+	if &dst.PortResults[0] == &src.PortResults[0] {
+		t.Fatalf("unexpected slice aliasing")
+	}
+
+	for i := range src.PortResults {
+		if src.PortResults[i] == nil || dst.PortResults[i] == nil {
+			t.Fatalf("unexpected nil PortResult at index %d", i)
+		}
+		if src.PortResults[i] == dst.PortResults[i] {
+			t.Fatalf("expected PortResults[%d] to be deep-copied", i)
+		}
+		if *src.PortResults[i] != *dst.PortResults[i] {
+			t.Fatalf("expected PortResults[%d] values to match", i)
+		}
+		if got := dst.PortMap[dst.PortResults[i].Port]; got != dst.PortResults[i] {
+			t.Fatalf("expected PortMap to reference the same copied PortResult for port %d", dst.PortResults[i].Port)
+		}
+	}
+
+	dst.PortResults[0].Available = false
+	dst.PortMap[80].Service = "changed"
+	dst.ICMPStatus.PacketLoss = 50
+
+	if src.PortResults[0].Available == dst.PortResults[0].Available {
+		t.Fatalf("expected PortResults mutation not to affect source")
+	}
+	if src.PortMap[80].Service == dst.PortMap[80].Service {
+		t.Fatalf("expected PortMap mutation not to affect source")
+	}
+	if src.ICMPStatus.PacketLoss == dst.ICMPStatus.PacketLoss {
+		t.Fatalf("expected ICMPStatus mutation not to affect source")
+	}
+}

--- a/pkg/sweeper/base_processor.go
+++ b/pkg/sweeper/base_processor.go
@@ -301,7 +301,7 @@ func (p *BaseProcessor) Process(result *models.Result) error {
 
 	case models.ModeTCP:
 		p.processTCPResult(shard, host, result)
-		
+
 	case models.ModeTCPConnect:
 		p.processTCPResult(shard, host, result)
 	}
@@ -439,7 +439,7 @@ func (p *BaseProcessor) collectShardSummaries() []shardSummary {
 					summary.icmpHosts++
 				}
 
-				summary.hosts = append(summary.hosts, *host)
+				summary.hosts = append(summary.hosts, models.DeepCopyHostResult(host))
 			}
 
 			summary.totalHosts = len(shard.hostMap)
@@ -789,7 +789,7 @@ func (p *BaseProcessor) processShardForSummary(
 	// Stream host data and count
 	for _, host := range shard.hostMap {
 		select {
-		case hostCh <- *host:
+		case hostCh <- models.DeepCopyHostResult(host):
 			if host.Available {
 				result.availableHosts++
 			}

--- a/pkg/sweeper/memory_store.go
+++ b/pkg/sweeper/memory_store.go
@@ -89,14 +89,14 @@ func WithoutPreallocation() InMemoryStoreOption {
 // InMemoryStore implements Store interface for temporary storage.
 type InMemoryStore struct {
 	// Sharded to reduce lock contention under high write rates
-	shards      []*storeShard
-	shardCount  int
-	processor   ResultProcessor
-	maxResults  int
-	cleanupDone chan struct{}
-	lastCleanup time.Time
+	shards          []*storeShard
+	shardCount      int
+	processor       ResultProcessor
+	maxResults      int
+	cleanupDone     chan struct{}
+	lastCleanup     time.Time
 	cleanupInterval time.Duration
-	logger      logger.Logger
+	logger          logger.Logger
 }
 
 // storeShard holds a partition of results and its own lock.
@@ -134,13 +134,13 @@ func NewInMemoryStore(processor ResultProcessor, log logger.Logger, opts ...InMe
 	}
 
 	s := &InMemoryStore{
-		shards:      make([]*storeShard, shards),
-		shardCount:  shards,
-		processor:   processor,
-		maxResults:  cfg.maxResults,
-		cleanupDone: cleanupChan,
+		shards:          make([]*storeShard, shards),
+		shardCount:      shards,
+		processor:       processor,
+		maxResults:      cfg.maxResults,
+		cleanupDone:     cleanupChan,
 		cleanupInterval: cfg.cleanupInterval,
-		logger:      log,
+		logger:          log,
 	}
 
 	// Pre-allocate per-shard capacity to reduce growslice.
@@ -405,7 +405,7 @@ func (*InMemoryStore) updateHostTimestamps(host *models.HostResult, r *models.Re
 func (*InMemoryStore) convertToSlice(hostMap map[string]*models.HostResult) []models.HostResult {
 	hosts := make([]models.HostResult, 0, len(hostMap))
 	for _, host := range hostMap {
-		hosts = append(hosts, *host)
+		hosts = append(hosts, models.DeepCopyHostResult(host))
 	}
 
 	return hosts
@@ -508,7 +508,7 @@ func (*InMemoryStore) buildSummary(
 			availableHosts++
 		}
 
-		hosts = append(hosts, *host)
+		hosts = append(hosts, models.DeepCopyHostResult(host))
 	}
 
 	ports := make([]models.PortCount, 0, len(portCounts))

--- a/pkg/sweeper/summary_snapshot_test.go
+++ b/pkg/sweeper/summary_snapshot_test.go
@@ -1,0 +1,157 @@
+package sweeper
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/carverauto/serviceradar/pkg/logger"
+	"github.com/carverauto/serviceradar/pkg/models"
+)
+
+func TestGetSummary_HostResultsDoNotAliasInternalState(t *testing.T) {
+	cfg := &models.Config{Ports: []int{80}}
+	processor := NewBaseProcessor(cfg, logger.NewTestLogger())
+
+	hostAddr := "192.168.1.1"
+
+	if err := processor.Process(&models.Result{
+		Target:    models.Target{Host: hostAddr, Mode: models.ModeICMP},
+		Available: true,
+		RespTime:  10 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("process icmp: %v", err)
+	}
+
+	if err := processor.Process(&models.Result{
+		Target:    models.Target{Host: hostAddr, Port: 80, Mode: models.ModeTCP},
+		Available: true,
+		RespTime:  5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("process tcp: %v", err)
+	}
+
+	internal := processor.GetHostMap()[hostAddr]
+	if internal == nil {
+		t.Fatalf("expected internal host to exist")
+	}
+	if internal.ICMPStatus == nil || internal.PortMap == nil || len(internal.PortResults) == 0 {
+		t.Fatalf("expected internal host to have ICMPStatus and port state")
+	}
+
+	summary, err := processor.GetSummary(context.Background())
+	if err != nil {
+		t.Fatalf("get summary: %v", err)
+	}
+	if len(summary.Hosts) != 1 {
+		t.Fatalf("expected 1 host in summary, got %d", len(summary.Hosts))
+	}
+
+	snapshot := summary.Hosts[0]
+
+	if snapshot.ICMPStatus == nil {
+		t.Fatalf("expected snapshot ICMPStatus to be non-nil")
+	}
+	if snapshot.ICMPStatus == internal.ICMPStatus {
+		t.Fatalf("expected ICMPStatus to be deep-copied")
+	}
+
+	if snapshot.PortMap == nil {
+		t.Fatalf("expected snapshot PortMap to be non-nil")
+	}
+	if len(snapshot.PortResults) == 0 {
+		t.Fatalf("expected snapshot PortResults to be non-empty")
+	}
+
+	for port, internalPR := range internal.PortMap {
+		snapshotPR := snapshot.PortMap[port]
+		if internalPR == nil || snapshotPR == nil {
+			continue
+		}
+		if internalPR == snapshotPR {
+			t.Fatalf("expected PortMap[%d] to be deep-copied", port)
+		}
+	}
+
+	internalPointers := make(map[*models.PortResult]struct{}, len(internal.PortResults))
+	for _, pr := range internal.PortResults {
+		internalPointers[pr] = struct{}{}
+	}
+	for _, pr := range snapshot.PortResults {
+		if _, ok := internalPointers[pr]; ok {
+			t.Fatalf("expected PortResults to be deep-copied (found shared pointer)")
+		}
+	}
+
+	for _, pr := range snapshot.PortResults {
+		if pr == nil {
+			continue
+		}
+		if got := snapshot.PortMap[pr.Port]; got != pr {
+			t.Fatalf("expected snapshot PortMap[%d] to reference the same PortResult pointer as PortResults", pr.Port)
+		}
+	}
+}
+
+func TestGetSummary_ConcurrentReadsDoNotPanic(t *testing.T) {
+	cfg := &models.Config{Ports: []int{80}}
+	processor := NewBaseProcessor(cfg, logger.NewTestLogger())
+
+	hostAddr := "192.168.1.1"
+
+	if err := processor.Process(&models.Result{
+		Target:    models.Target{Host: hostAddr, Port: 80, Mode: models.ModeTCP},
+		Available: true,
+		RespTime:  5 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("process tcp: %v", err)
+	}
+
+	summary, err := processor.GetSummary(context.Background())
+	if err != nil {
+		t.Fatalf("get summary: %v", err)
+	}
+	if len(summary.Hosts) != 1 {
+		t.Fatalf("expected 1 host in summary, got %d", len(summary.Hosts))
+	}
+	snapshot := summary.Hosts[0]
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			if snapshot.PortMap != nil {
+				_ = snapshot.PortMap[80]
+				_ = len(snapshot.PortMap)
+			}
+
+			if len(snapshot.PortResults) > 0 && snapshot.PortResults[0] != nil {
+				_ = snapshot.PortResults[0].Port
+			}
+		}
+	}()
+
+	for i := 0; i < 250; i++ {
+		if err := processor.Process(&models.Result{
+			Target:    models.Target{Host: hostAddr, Port: 10000 + i, Mode: models.ModeTCP},
+			Available: true,
+			RespTime:  1 * time.Millisecond,
+		}); err != nil {
+			close(stop)
+			wg.Wait()
+			t.Fatalf("process tcp iteration %d: %v", i, err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Add `DeepCopyHostResult()` helper to prevent data races from shallow copies

- Update summary collection paths to use deep copies before releasing locks

- Update memory store conversions to use deep copies for consistency

- Add regression tests verifying concurrent read safety and no aliasing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HostResult with pointers<br/>PortResults, PortMap, ICMPStatus"]
  B["DeepCopyHostResult()<br/>helper function"]
  C["BaseProcessor<br/>collectShardSummaries"]
  D["BaseProcessor<br/>processShardForSummary"]
  E["InMemoryStore<br/>convertToSlice/buildSummary"]
  F["Safe snapshots<br/>no aliasing"]
  
  A -->|"deep copy"| B
  B -->|"used by"| C
  B -->|"used by"| D
  B -->|"used by"| E
  C -->|"produces"| F
  D -->|"produces"| F
  E -->|"produces"| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sweep.go</strong><dd><code>Add deep-copy helper for HostResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/models/sweep.go

<ul><li>Add <code>DeepCopyHostResult()</code> function that creates non-aliased snapshots <br>of <code>HostResult</code><br> <li> Deep copies <code>PortResults</code> slice, <code>PortMap</code> map, and <code>ICMPStatus</code> struct<br> <li> Ensures <code>PortMap</code> entries reference the same copied <code>PortResult</code> pointers <br>as <code>PortResults</code><br> <li> Minor formatting fix to <code>ModeTCP</code> constant alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-3cc7dd0e748c9f77be9e384fed2703ab77375716524b70860153b6a1abae27ca">+84/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sweep_deepcopy_test.go</strong><dd><code>Add unit tests for deep-copy function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/models/sweep_deepcopy_test.go

<ul><li>Add comprehensive unit test <code>TestDeepCopyHostResult_NoAliasing</code><br> <li> Verify scalar fields match between source and copy<br> <li> Verify pointer/slice/map fields are deep-copied, not aliased<br> <li> Verify mutations to copy do not affect source<br> <li> Test consistency between <code>PortResults</code> and <code>PortMap</code> references</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-45bfc89e5b79e84e249bab30c33c776bd8465af54f17693e0bbc97c4eed0f003">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>summary_snapshot_test.go</strong><dd><code>Add regression and race detector tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/summary_snapshot_test.go

<ul><li>Add <code>TestGetSummary_HostResultsDoNotAliasInternalState</code> regression test<br> <li> Verify returned summaries have deep-copied <code>ICMPStatus</code>, <code>PortMap</code>, and <br><code>PortResults</code><br> <li> Verify mutations to snapshot do not affect internal state<br> <li> Add <code>TestGetSummary_ConcurrentReadsDoNotPanic</code> race detector test<br> <li> Verify concurrent processing and summary reads do not cause panics or <br>races</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-eb3740146940283b92c377e3c550ebe123ef3e010feaa2974a3029ef9260b08d">+157/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_processor.go</strong><dd><code>Use deep copies in summary collection paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/base_processor.go

<ul><li>Update <code>collectShardSummaries()</code> to use <code>DeepCopyHostResult()</code> when <br>appending hosts<br> <li> Update <code>processShardForSummary()</code> to use <code>DeepCopyHostResult()</code> when <br>streaming hosts<br> <li> Ensures deep copies are made before releasing shard locks<br> <li> Minor whitespace cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-40a89f977fa936cab19d62a659fb835665f646012674fbf3a8b09a8987917fbb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>memory_store.go</strong><dd><code>Use deep copies in memory store conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/memory_store.go

<ul><li>Update <code>convertToSlice()</code> to use <code>DeepCopyHostResult()</code> for consistency<br> <li> Update <code>buildSummary()</code> to use <code>DeepCopyHostResult()</code> for consistency<br> <li> Fix struct field alignment in <code>InMemoryStore</code> definition<br> <li> Prevents accidental aliasing as code evolves</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-54c761e2155455ac0e86e2cf1405610fe315d966ab17d4f008c3dd7227a05389">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Add change proposal documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-sweeper-summary-shallow-copy/proposal.md

<ul><li>Document issue #2148 data race root cause (shallow copies with pointer <br>fields)<br> <li> Describe solution: introduce shared deep-copy helper and apply to <br>summary paths<br> <li> List affected files and low-risk impact assessment<br> <li> Discuss trade-offs: increased allocation vs. lock-free, race-free <br>summaries</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-6303af01f1a835c5774bb184afb2e37b9707b7b7c4283e3ee537b2b221ba614b">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add specification requirements for snapshot isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-sweeper-summary-shallow-copy/specs/sweeper/spec.md

<ul><li>Add requirement: Summary snapshot isolation<br> <li> Define scenario: <code>GetSummary</code> returns safe-to-read host snapshots<br> <li> Define scenario: Streamed <code>HostResult</code> values remain safe after locks <br>released<br> <li> Define scenario: Caller mutations do not affect subsequent summaries</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-34df7c0ca139956ca9981cd0accef64a55838bf3057b72fc9dfcfa77ff19bd82">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Add implementation task checklist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-sweeper-summary-shallow-copy/tasks.md

<ul><li>Document task checklist for deep-copy implementation<br> <li> Track completion of helper function, integration, and verification <br>steps<br> <li> Reference specific test names and verification commands</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2158/files#diff-116bbee895b6dbf4fa6aaa32bd8fa799e2d2181a66071fb5e3129a46cc9154d7">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

