### PR TITLE
Blog/live stack elixir phoenix cnpg

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -235,6 +235,126 @@
         "recordedRepoMappingEntries": []
       }
     },
+    "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
+      "general": {
+        "bzlTransitiveDigest": "+l+ZpvciXpW0sjO7OxX1ONadMmAteTthARxosQb7DHk=",
+        "usagesDigest": "nZsztwJYOdbgW8q0XMkWF4tgDJotYArkhTox/UTNYS0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pnpm": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "root_package": "",
+              "link_workspace": "",
+              "link_packages": {},
+              "integrity": "sha512-vRIWpD/L4phf9Bk2o/O2TDR8fFoJnpYrp2TKqTIZF/qZ2/rgL3qKXzHofHgbXsinwMoSEigz28sqk3pQ+yMEQQ==",
+              "url": "",
+              "commit": "",
+              "patch_args": [
+                "-p0"
+              ],
+              "patches": [],
+              "custom_postinstall": "",
+              "npm_auth": "",
+              "npm_auth_basic": "",
+              "npm_auth_username": "",
+              "npm_auth_password": "",
+              "lifecycle_hooks": [],
+              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
+              "generate_bzl_library_targets": false,
+              "extract_full_archive": true,
+              "exclude_package_contents": [],
+              "system_tar": "auto"
+            }
+          },
+          "pnpm__links": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links",
+            "attributes": {
+              "package": "pnpm",
+              "version": "8.6.7",
+              "dev": false,
+              "root_package": "",
+              "link_packages": {},
+              "deps": {},
+              "transitive_closure": {},
+              "lifecycle_build_target": false,
+              "lifecycle_hooks_env": [],
+              "lifecycle_hooks_execution_requirements": [
+                "no-sandbox"
+              ],
+              "lifecycle_hooks_use_default_shell_env": false,
+              "bins": {},
+              "package_visibility": [
+                "//visibility:public"
+              ],
+              "replace_package": "",
+              "exclude_package_contents": []
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_bazel_lib+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "aspect_rules_js+",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "aspect_rules_js",
+            "aspect_rules_js+"
+          ],
+          [
+            "aspect_rules_js+",
+            "aspect_tools_telemetry_report",
+            "aspect_tools_telemetry++telemetry+aspect_tools_telemetry_report"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "aspect_rules_js+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ]
+        ]
+      }
+    },
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "V9ocRlpiXAW8059qU9fAVgAu6rELuOJlkNOG6Jt7cw0=",
@@ -439,6 +559,40 @@
           ],
           [
             "buildifier_prebuilt+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "4rSUGWibZDYLhHR+8eMwTNwAwdIv+xjVrtQ+gHtWHq4=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
             "bazel_tools",
             "bazel_tools"
           ]
@@ -694,6 +848,89 @@
             "rules_foreign_cc+",
             "rules_foreign_cc",
             "rules_foreign_cc+"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "v2H25KPHEkN56IHR41S67Kzp5Xjxd75GBiazhON8jzc=",
+        "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "repoRuleId": "@@rules_fuzzing+//fuzzing/private/oss_fuzz:repository.bzl%oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing+//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing+",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }
@@ -17537,6 +17774,148 @@
             "rules_rust+",
             "rules_rust",
             "rules_rust+"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
+      "general": {
+        "bzlTransitiveDigest": "/0/9Tr7k3IYrvhZS0TYri7ARUh9lE6ODfYSRPFXlOP4=",
+        "usagesDigest": "lAGiU7JGcUJ6BL7JrXrtglO7l/4CfFuSP4+oWoVk9Js=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust+//crate_universe:src/api.rs",
+                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/cli.rs",
+                "@@rules_rust+//crate_universe:src/cli/generate.rs",
+                "@@rules_rust+//crate_universe:src/cli/query.rs",
+                "@@rules_rust+//crate_universe:src/cli/render.rs",
+                "@@rules_rust+//crate_universe:src/cli/splice.rs",
+                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust+//crate_universe:src/config.rs",
+                "@@rules_rust+//crate_universe:src/context.rs",
+                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust+//crate_universe:src/context/platforms.rs",
+                "@@rules_rust+//crate_universe:src/lib.rs",
+                "@@rules_rust+//crate_universe:src/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/main.rs",
+                "@@rules_rust+//crate_universe:src/metadata.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust+//crate_universe:src/rendering.rs",
+                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust+//crate_universe:src/select.rs",
+                "@@rules_rust+//crate_universe:src/splicing.rs",
+                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust+//crate_universe:src/test.rs",
+                "@@rules_rust+//crate_universe:src/utils.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
+              "version": "1.86.0",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",
+              "compressed_windows_toolchain_names": false
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "cargo_bazel_bootstrap"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cui",
+            "rules_rust++cu+cui"
+          ],
+          [
+            "rules_rust+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust_ctve",
+            "rules_rust++i2+rules_rust_ctve"
           ]
         ]
       }

--- a/docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx
+++ b/docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx
@@ -4,84 +4,109 @@ title: "From Fragmented to Fluid: Simplifying ServiceRadar with Elixir, Rustler,
 authors: [mfreeman]
 tags: [elixir, phoenix, rust, rustler, postgres, timescaledb, age, architecture]
 date: 2025-12-16
-description: "How the staging branch replaced a React/Kong/SRQL microservice trio with a Phoenix LiveView UI that embeds the Rust SRQL engine and speaks directly to CNPG (Timescale + Apache AGE)."
+description: "How we simplified ServiceRadar with Elixir/Phoenix LiveView, embedded SRQL NIFs, and a unified Postgres stack."
 ---
 
-In observability, complexity is the enemy. We used to ask a React app to talk through Kong to Go APIs that then called a standalone Rust SRQL service. Every CVE in the JS stack and every hop between services added toil.
+In observability, [complexity is the enemy](https://how.complexsystems.fail/). Our previous architecture asked a React app to hit two APIs (core in Go, SRQL our Domain-Specific Language (DSL) and query engine in Rust) through Nginx/Kong for JWT verification, while a Go-based auth service issued JWKS/OAuth tokens. We'd been wrestling with this stack for a while—[slow initial renders](https://paperclover.net/blog/webdev/one-year-next-app-router), [state management sprawl](https://react.dev/learn/you-might-not-need-an-effect), and the constant churn of keeping dependencies current across a deep node_modules tree.
 
-Staging now runs a very different shape:
+[React2Shell](https://react2shell.com/) forced the conversation we'd been putting off. The vulnerability itself was [bad enough](https://x.com/eastdakota/status/2000622160159887476), but the [follow-up](https://www.vulncheck.com/blog/react2shell-beyond-nextjs) CVEs and the broader pattern they revealed made us take a harder look at what we were signing up for. React is a mature framework carrying years of accumulated complexity and technical debt. That's not a criticism—it's the natural arc of any widely-adopted JS project. But for a team shipping observability tooling, betting on a stack where the next critical CVE feels like a matter of "when" rather than "if" wasn't a trade-off we wanted to keep making.
 
-- **Phoenix + LiveView (`web-ng`)** is the experience layer.
-- **Rustler-embedded SRQL** runs inside the Phoenix app as a NIF, no extra service.
-- **CNPG with TimescaleDB + Apache AGE** is the single data store the UI queries directly.
-- **Go core** still orchestrates agents, pollers, and ingestion into CNPG.
+An upcoming release takes a different shape:
+
+- **Phoenix + LiveView** serves as the experience layer
+- **Rustler-embedded SRQL** runs inside the Phoenix app as a NIF—no extra service
+- **CloudNativePG with TimescaleDB + Apache AGE** provides a single unified data store
+- **Go core** continues to orchestrate agents, pollers, and ingestion
 
 <!-- truncate -->
 
-## What Changed in Staging
+## What's Changing
 
-### 1) Frontend: Phoenix LiveView replaces the React/Kong path
-- Live routes (analytics, devices, pollers, events, logs) are all served from `web-ng` with authenticated `live_session`s, so SRQL traffic stays inside Phoenix and skips the Kong hop in staging.
-- API callers inside the UI use the `/api/query` controller, which runs server-side in the Phoenix process—no client-side SRQL calls or gateway detours.
+### Phoenix LiveView Replaces React
 
-### 2) Query Engine: SRQL lives in-process via Rustler
-- `web-ng/native/srql_nif` wraps `srql::query::translate_request/2` as a NIF scheduled on Dirty CPU threads, so BEAM schedulers stay responsive.
-- `ServiceRadarWebNG.SRQL` decodes the translation, executes the generated SQL through Ecto’s Postgres adapter, and normalizes pagination/cursor results for LiveView.
-- This removed the standalone SRQL microservice and the Kong-secured `/api/query` proxy from the hot path.
+The new UI is built on [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html) with authenticated sessions throughout. Previously, the React app split traffic across two backend APIs and traversed multiple gateways for JWT validation. Now SRQL queries execute server-side within Phoenix—no gateway hop, no separate query service, and no dual-API coordination from the browser.
 
-### 3) Data Store: Everything on CloudNativePG
-- The UI points straight at CNPG; no Proton sidecar. Timescale hypertables back metrics; Apache AGE powers graph queries (`ServiceRadarWebNG.Graph`) with a quick readiness task (`mix graph.ready`).
-- One cluster now serves relational inventory/RBAC, metrics, and topology, so schema changes and migrations stay in one place.
+Beyond the security posture, LiveView solves the performance issues we'd been chasing. Server-rendered HTML over WebSockets eliminates the hydration delays and client-side state bloat that plagued our dashboards. The [BEAM](https://www.erlang.org/blog/a-brief-beam-primer/)'s lightweight processes handle thousands of concurrent connections without the careful optimization React demanded.
 
-### 4) Core Still Runs in Go
-- `serviceradar-core` continues to coordinate pollers/agents and push writes into CNPG (via the existing NATS JetStream + writers), so the LiveView layer reads from the same authoritative store.
+### SRQL Moves In-Process via Rustler
+
+SRQL now runs as a Rust [NIF](https://www.erlang.org/doc/system/nif.html) embedded directly in the Phoenix application. Query translation happens in-process on dedicated CPU threads, keeping the runtime responsive while eliminating a standalone microservice and removing the API gateway from the query hot path.
+
+### Identity and Access: Built-In, Not Bolted-On
+
+[Kong](https://github.com/Kong/kong) previously fronted JWT validation while a custom Go service issued JWKS and OAuth tokens. Phoenix now owns identity end-to-end: [Guardian](https://github.com/ueberauth/guardian) issues and validates JWTs, sessions carry scope, and multi-tenancy and RBAC are first-class concerns in the web layer. Fewer moving parts, clearer boundaries, and no separate JWKS gateway to maintain.
+
+### Everything on CloudNativePG
+
+The UI connects directly to CloudNativePG, retiring the previous Timeplus Proton/ClickHouse datastore. We considered a dedicated graph database and a separate engine for document search, but unifying on Postgres keeps operations simple.
+
+Timescale hypertables back metrics. Apache AGE powers graph queries for topology and dependency mapping. With Timescale's [upcoming](https://www.tigerdata.com/blog/introducing-pg_textsearch-true-bm25-ranking-hybrid-retrieval-postgres) `pg_textsearch` extension (BM25 + hybrid retrieval), we can add document search without introducing another database.
+
+CNPG provides effortless HA and clustering in Kubernetes through operator-managed primaries, replicas, failover, and backups. The same image and migrations run in Docker Compose or as a standalone Postgres install, so development and production deployments share one artifact.
+
+One cluster now serves relational inventory, RBAC, metrics, topology, and future search—keeping schema changes and migrations in one place.
+
+### Go Core: Data Plane, Not Edge Plane
+
+`serviceradar-core` still coordinates pollers and agents. Edge collectors (syslog, SNMP, netflow, etc.) publish to NATS JetStream—either directly or through leaf nodes on the edge. Horizontally scaled DB-writer consumers (subscription queue groups) pull from JetStream and write to CNPG. The gRPC pipeline stays in place for control/updates that don’t belong on NATS. Phoenix reads from the authoritative CNPG store; it no longer sits in the ingestion path.
 
 ## Why This Matters
 
-- **Fewer moving parts:** No Kong hop for SRQL, no extra Rust service to deploy, fewer TLS certs to juggle.
-- **Lower latency:** Queries translate and run in-process—no network round-trips between UI and SRQL.
-- **Operational clarity:** One database (CNPG) with Timescale + AGE means consistent backups, HA, and observability of the observability stack.
-- **Developer focus:** Security patching effort drops without the React dependency stack; the BEAM handles concurrent LiveView sessions with less glue code.
+**Fewer moving parts.** No gateway hop for queries, no extra Rust service to deploy, fewer TLS certificates to manage.
 
-## Shipping and What’s Next
+**Lower latency.** Queries translate and execute in-process without network round-trips.
 
-Available in staging today:
-- Phoenix LiveView UI (`web-ng`)
-- Rustler SRQL NIF and `/api/query` controller
-- Direct CNPG access (Timescale + AGE) with `mix graph.ready`
+**Operational clarity.** One database with Timescale + AGE means consistent backups, HA, and observability of the observability stack.
+
+**Smaller attack surface.** Erlang/OTP has decades of battle-testing in telecom environments. The dependency tree is shallow, and critical vulnerabilities are rare. We're no longer tracking npm advisories weekly.
+
+**Defense in depth.** Identity lives in the application layer where it belongs. Sessions, scopes, and RBAC flow through the same runtime that serves the UI—no external gateway required to enforce access control.
+
+**Simpler IAM.** Guardian-driven JWTs and Phoenix plugs replace Kong + custom JWKS/OAuth, making multi-tenancy a first-class part of the platform rather than an afterthought bolted onto the edge.
+
+## Streaming Without a Separate Engine
+
+Elixir and Phoenix already provide the streaming primitives we need:
+
+**Log tailing.** Postgres `LISTEN/NOTIFY` plus lightweight watchers broadcast to the UI. Payloads stay inside the runtime.
+
+**Metrics windows.** Timescale continuous aggregates keep dashboards fresh without heavy queries.
+
+**Headroom.** If payloads outgrow `NOTIFY`, logical replication slots let us stream WAL changes directly into application processes.
+
+### Real-Time Streaming with `pg_notify`
+
+- **Triggers emit events.** Inserts on hot tables (`logs`, `metrics`) raise `pg_notify` payloads.
+- **Notification workers.** GenServers using `Postgrex.Notifications` fan events into Phoenix PubSub topics; LiveViews subscribe and stream-insert rows.
+- **Backpressure-aware.** Large payloads fall back to ID-only messages plus Ecto hydration with per-tenant RBAC. For extreme volume, logical replication drops in without changing the LiveView consumers.
+
+## API Shift to Elixir
+
+- **Single surface.** The SRQL and domain APIs that React once hit through Kong now live in Phoenix; no dual-API/gateway dance.
+- **MCP in-process.** `hermes_mcp` exposes the MCP contract from Elixir so IDE/CLI agents talk directly to the web app.
+- **Contract-first docs.** `open_api_spex` generates OpenAPI from Phoenix controllers, replacing the hand-rolled Go swagger layer and keeping the contract locked to code.
+
+## Core Becomes the Engine, Not the Edge
+
+`serviceradar-core` remains the orchestration and ingestion engine (pollers, agents, registry) writing into CNPG. Web/API concerns move to Phoenix, tightening separation of concerns: Go owns data-plane coordination; Elixir owns the experience and API surface.
+
+## Why the BEAM Fits
+
+- **GenServers as building blocks.** Notification listeners, SRQL executors, MCP endpoints, and LiveViews are supervised, lightweight, and restartable.
+- **Massive fan-in/out.** BEAM schedulers handle thousands of WebSocket/API clients without head-of-line blocking.
+- **Fault tolerance.** Supervisors contain failures; a bad notification restarts a worker instead of taking down the UI.
+- **Operational ergonomics.** Telemetry hooks and OTP releases make tuning, blue/green, and hot upgrades straightforward.
+
+## What's Included
+
+- [Phoenix](https://www.phoenixframework.org/) LiveView UI (`web-ng`)
+- [Rustler](https://github.com/rusterlium/rustler) SRQL NIF and `/api/query` controller
+- Direct [CNPG](https://cloudnative-pg.io/) access with [TimescaleDB](https://github.com/timescale/timescaledb) + [Apache AGE](https://age.apache.org/) (HA/replicas via CNPG operator)
+- `pg_notify` → LiveView pushes for real-time streaming
+- MCP endpoints in Elixir (hermes_mcp)
+- OpenAPI generation via `open_api_spex`
 - Go core ingestion into the same CNPG cluster
-- **`pg_notify` → LiveView pushes** for “tail -f” style streams; staging already uses notifications to push updates, and this will ship in the next release cut.
-
-We are keeping the legacy Next.js UI around during the cutover; Phoenix is the default in staging and will become the sole UI once the remaining pages are migrated.
-
-## If You Want to Try It
-
-1) Point `web-ng` at CNPG (Docker or k8s):
-```bash
-cd web-ng
-export CNPG_HOST=127.0.0.1
-export CNPG_PORT=5455
-export CNPG_DATABASE=serviceradar
-export CNPG_USERNAME=serviceradar
-export CNPG_PASSWORD=serviceradar
-export CNPG_SSL_MODE=verify-full
-export CNPG_CERT_DIR=/path/to/certs
-mix graph.ready
-mix phx.server
-```
-
-2) Exercise SRQL through the Phoenix API:
-```bash
-curl -s -X POST http://localhost:4000/api/query \
-  -H "content-type: application/json" \
-  -d '{"query":"SHOW devices LIMIT 20"}'
-```
-
-3) Explore the graph path:
-```elixir
-ServiceRadarWebNG.Graph.query("MATCH (d:Device) RETURN d LIMIT 5")
-```
 
 ## Takeaways
 
-We consolidated UI, query planning, and data access into a single Phoenix application while keeping Go focused on orchestration and ingestion. Timescale and AGE live under one CNPG roof, and SRQL now runs as a library, not a microservice. The result is a smaller blast radius, faster queries, and simpler ops—setting us up to layer real-time `pg_notify` updates and more LiveView-native experiences next.
+We consolidated UI, query planning, and data access into a single Phoenix application while keeping Go focused on orchestration and ingestion. TimescaleDB and Apache AGE live under one CloudNativePG roof, and SRQL now runs as a library rather than a microservice. The result is a smaller blast radius, faster queries, simpler IAM, and a streaming model that rides on Postgres + BEAM instead of an external engine.

--- a/docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx
+++ b/docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx
@@ -1,0 +1,87 @@
+---
+slug: simplifying-observability-elixir-rustler-cnpg
+title: "From Fragmented to Fluid: Simplifying ServiceRadar with Elixir, Rustler, and CloudNativePG"
+authors: [mfreeman]
+tags: [elixir, phoenix, rust, rustler, postgres, timescaledb, age, architecture]
+date: 2025-12-16
+description: "How the staging branch replaced a React/Kong/SRQL microservice trio with a Phoenix LiveView UI that embeds the Rust SRQL engine and speaks directly to CNPG (Timescale + Apache AGE)."
+---
+
+In observability, complexity is the enemy. We used to ask a React app to talk through Kong to Go APIs that then called a standalone Rust SRQL service. Every CVE in the JS stack and every hop between services added toil.
+
+Staging now runs a very different shape:
+
+- **Phoenix + LiveView (`web-ng`)** is the experience layer.
+- **Rustler-embedded SRQL** runs inside the Phoenix app as a NIF, no extra service.
+- **CNPG with TimescaleDB + Apache AGE** is the single data store the UI queries directly.
+- **Go core** still orchestrates agents, pollers, and ingestion into CNPG.
+
+<!-- truncate -->
+
+## What Changed in Staging
+
+### 1) Frontend: Phoenix LiveView replaces the React/Kong path
+- Live routes (analytics, devices, pollers, events, logs) are all served from `web-ng` with authenticated `live_session`s, so SRQL traffic stays inside Phoenix and skips the Kong hop in staging.
+- API callers inside the UI use the `/api/query` controller, which runs server-side in the Phoenix process—no client-side SRQL calls or gateway detours.
+
+### 2) Query Engine: SRQL lives in-process via Rustler
+- `web-ng/native/srql_nif` wraps `srql::query::translate_request/2` as a NIF scheduled on Dirty CPU threads, so BEAM schedulers stay responsive.
+- `ServiceRadarWebNG.SRQL` decodes the translation, executes the generated SQL through Ecto’s Postgres adapter, and normalizes pagination/cursor results for LiveView.
+- This removed the standalone SRQL microservice and the Kong-secured `/api/query` proxy from the hot path.
+
+### 3) Data Store: Everything on CloudNativePG
+- The UI points straight at CNPG; no Proton sidecar. Timescale hypertables back metrics; Apache AGE powers graph queries (`ServiceRadarWebNG.Graph`) with a quick readiness task (`mix graph.ready`).
+- One cluster now serves relational inventory/RBAC, metrics, and topology, so schema changes and migrations stay in one place.
+
+### 4) Core Still Runs in Go
+- `serviceradar-core` continues to coordinate pollers/agents and push writes into CNPG (via the existing NATS JetStream + writers), so the LiveView layer reads from the same authoritative store.
+
+## Why This Matters
+
+- **Fewer moving parts:** No Kong hop for SRQL, no extra Rust service to deploy, fewer TLS certs to juggle.
+- **Lower latency:** Queries translate and run in-process—no network round-trips between UI and SRQL.
+- **Operational clarity:** One database (CNPG) with Timescale + AGE means consistent backups, HA, and observability of the observability stack.
+- **Developer focus:** Security patching effort drops without the React dependency stack; the BEAM handles concurrent LiveView sessions with less glue code.
+
+## Shipping and What’s Next
+
+Available in staging today:
+- Phoenix LiveView UI (`web-ng`)
+- Rustler SRQL NIF and `/api/query` controller
+- Direct CNPG access (Timescale + AGE) with `mix graph.ready`
+- Go core ingestion into the same CNPG cluster
+- **`pg_notify` → LiveView pushes** for “tail -f” style streams; staging already uses notifications to push updates, and this will ship in the next release cut.
+
+We are keeping the legacy Next.js UI around during the cutover; Phoenix is the default in staging and will become the sole UI once the remaining pages are migrated.
+
+## If You Want to Try It
+
+1) Point `web-ng` at CNPG (Docker or k8s):
+```bash
+cd web-ng
+export CNPG_HOST=127.0.0.1
+export CNPG_PORT=5455
+export CNPG_DATABASE=serviceradar
+export CNPG_USERNAME=serviceradar
+export CNPG_PASSWORD=serviceradar
+export CNPG_SSL_MODE=verify-full
+export CNPG_CERT_DIR=/path/to/certs
+mix graph.ready
+mix phx.server
+```
+
+2) Exercise SRQL through the Phoenix API:
+```bash
+curl -s -X POST http://localhost:4000/api/query \
+  -H "content-type: application/json" \
+  -d '{"query":"SHOW devices LIMIT 20"}'
+```
+
+3) Explore the graph path:
+```elixir
+ServiceRadarWebNG.Graph.query("MATCH (d:Device) RETURN d LIMIT 5")
+```
+
+## Takeaways
+
+We consolidated UI, query planning, and data access into a single Phoenix application while keeping Go focused on orchestration and ingestion. Timescale and AGE live under one CNPG roof, and SRQL now runs as a library, not a microservice. The result is a smaller blast radius, faster queries, and simpler ops—setting us up to layer real-time `pg_notify` updates and more LiveView-native experiences next.

--- a/openspec/changes/add-blog-elixir-rustler-cnpg/proposal.md
+++ b/openspec/changes/add-blog-elixir-rustler-cnpg/proposal.md
@@ -1,0 +1,14 @@
+# Change: Publish architecture blog for Phoenix + Rustler + CNPG pivot
+
+## Why
+Staging now runs the Phoenix/LiveView `web-ng` app with the SRQL parser embedded via Rustler and targets CNPG (TimescaleDB + Apache AGE) directly. We need a public-facing blog post that explains the consolidation from the old Next.js + Kong + standalone SRQL service to the new, simplified stack and clarifies what is shipped versus still in progress (e.g., `pg_notify`-driven push updates).
+
+## What Changes
+- Add a Docusaurus blog post (`docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx`) with the provided slug/title/tags and an updated narrative that reflects the current staging architecture.
+- Highlight shipped capabilities: Phoenix LiveView UI, Rustler NIF wrapping the SRQL translator, direct CNPG access (Timescale hypertables + AGE graph), and Go core as orchestrator/ingestor.
+- Call out near-term work (pg_notify-driven LiveView pushes) as planned, not yet shipped.
+
+## Impact
+- Affected specs: `docs-blog` (new capability)
+- Affected code: `docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx`
+- No runtime or API changes; documentation-only.

--- a/openspec/changes/add-blog-elixir-rustler-cnpg/specs/docs-blog/spec.md
+++ b/openspec/changes/add-blog-elixir-rustler-cnpg/specs/docs-blog/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+### Requirement: Publish Phoenix + Rustler + CNPG architecture blog
+ServiceRadar MUST publish a Docusaurus blog post titled "From Fragmented to Fluid: Simplifying ServiceRadar with Elixir, Rustler, and CloudNativePG" with slug `simplifying-observability-elixir-rustler-cnpg` that documents the staging move to a Phoenix LiveView UI embedding the SRQL engine via Rustler and targeting CNPG with TimescaleDB + Apache AGE.
+
+#### Scenario: Blog metadata present
+- **WHEN** `docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx` is built
+- **THEN** the frontmatter includes `slug`, `title`, `date: 2025-12-16`, `authors: [mfreeman]`, and tags `[elixir, phoenix, rust, rustler, postgres, timescaledb, age, architecture]`.
+
+#### Scenario: Content reflects shipped staging architecture
+- **WHEN** a reader views the post
+- **THEN** it states that Go remains the orchestration/poller core, Phoenix LiveView is the new UI layer, SRQL runs in-process via a Rustler NIF, and CNPG (Timescale hypertables + Apache AGE graph) is the unified data store, and it notes that `pg_notify`-driven streaming is implemented in staging and rolling into the next release.
+
+#### Scenario: Data consolidation explained
+- **WHEN** the post covers storage
+- **THEN** it explains the migration from the prior Proton/ClickHouse path to CNPG, noting that Timescale handles metrics, AGE handles topology graphs, and standard Postgres handles relational inventory/RBAC in one cluster.

--- a/openspec/changes/add-blog-elixir-rustler-cnpg/tasks.md
+++ b/openspec/changes/add-blog-elixir-rustler-cnpg/tasks.md
@@ -1,0 +1,9 @@
+## 1. Content
+- [x] 1.1 Draft the blog post at `docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx` with frontmatter (slug/title/date/authors/tags/description).
+- [x] 1.2 Cover shipped staging architecture: Phoenix LiveView UI, Rustler-based SRQL NIF, direct CNPG (Timescale + AGE) access, Go core orchestration/ingest.
+- [x] 1.3 Present pg_notify-powered LiveView streaming as implemented in staging and headed for the next release.
+- [x] 1.4 Add concrete examples from staging (SRQL NIF path, AGE graph readiness task, Repo usage) to make the post actionable.
+
+## 2. Validation
+- [x] 2.1 Run `openspec validate add-blog-elixir-rustler-cnpg --strict`.
+- [x] 2.2 Proofread for accuracy against `origin/staging` (represent pg_notify streaming as implemented in staging and release-bound).


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Documentation


___

### **Description**
- Publishes architecture blog post documenting Phoenix/LiveView UI migration

- Explains consolidation from Next.js + Kong + standalone SRQL to unified stack

- Details Rustler-embedded SRQL NIF and CloudNativePG with TimescaleDB + Apache AGE

- Includes OpenSpec change proposal and requirements specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Previous Stack<br/>Next.js + Kong<br/>+ Standalone SRQL"] -->|"Consolidate"| B["New Architecture<br/>Phoenix LiveView<br/>+ Rustler NIF<br/>+ CNPG"]
  B -->|"Unified Data"| C["CloudNativePG<br/>TimescaleDB + AGE"]
  B -->|"Orchestration"| D["Go Core<br/>Pollers & Agents"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx</strong><dd><code>Architecture blog post on stack consolidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/blog/2025-12-16-simplifying-observability-elixir-rustler-cnpg.mdx

<ul><li>New blog post documenting the architectural shift from React/Next.js <br>to Phoenix LiveView<br> <li> Explains SRQL migration to Rustler NIF running in-process within <br>Phoenix<br> <li> Details consolidation to CloudNativePG with TimescaleDB for metrics <br>and Apache AGE for topology graphs<br> <li> Covers identity/access control moving from Kong to Guardian-based <br>Phoenix sessions<br> <li> Discusses real-time streaming via <code>pg_notify</code> and BEAM's advantages for <br>observability</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2159/files#diff-70acd289efff15274939e438d481027a1dc80a399803a2265563e7d66fd9f704">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Change proposal for architecture blog publication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-blog-elixir-rustler-cnpg/proposal.md

<ul><li>Change proposal documenting the need for public-facing blog post<br> <li> Explains staging now runs Phoenix/LiveView with embedded SRQL and CNPG<br> <li> Specifies blog post slug, title, and key topics to cover<br> <li> Notes this is documentation-only with no runtime or API changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2159/files#diff-4c7eba15bd07cd7bda09c3aed6744991d215178f1bf0c39dcbef5949df1268ca">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Requirements specification for blog post</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-blog-elixir-rustler-cnpg/specs/docs-blog/spec.md

<ul><li>Formal requirements specification for blog post publication<br> <li> Defines frontmatter requirements (slug, title, date, authors, tags)<br> <li> Specifies content scenarios covering shipped staging architecture<br> <li> Documents data consolidation explanation from Proton/ClickHouse to <br>CNPG</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2159/files#diff-31c07735883a529a64a3a846f9dc3bb00dec11890833344c48317f138bca6d0f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Task completion checklist for blog publication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-blog-elixir-rustler-cnpg/tasks.md

<ul><li>Task checklist for blog post content and validation<br> <li> Marks all content tasks complete (draft, architecture coverage, <br>examples)<br> <li> Confirms validation tasks completed including OpenSpec validation<br> <li> Verifies accuracy against staging branch</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2159/files#diff-1e97e4a9125ecb93b8e4fff845ea2f39fa17efec699c9209777a0e0b1341000e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

