### PR TITLE
initial

### DIFF
--- a/openspec/changes/fix-snmp-pdu-string-conversion/proposal.md
+++ b/openspec/changes/fix-snmp-pdu-string-conversion/proposal.md
@@ -1,0 +1,17 @@
+# Change: Fix SNMP PDU string conversion panics
+
+## Why
+GitHub issue `#2154` reports the SNMP client conversion layer panicking when decoding `gosnmp.SnmpPDU` values for `OctetString` and `ObjectDescription`. The gosnmp library returns these values as `[]byte`, but `pkg/checker/snmp/client.go` currently asserts `byte`, causing `interface conversion: interface {} is []uint8, not uint8` panics. This breaks common OIDs like `sysDescr` and can crash SNMP polling in normal configurations.
+
+## What Changes
+- Fix `OctetString` and `ObjectDescription` conversions to correctly decode `[]byte` into Go `string`.
+- Ensure unexpected `Value` types for these ASN.1 types do not panic; conversion MUST fail with an error that callers can handle.
+- Add regression tests covering `convertVariable()` for `OctetString` and `ObjectDescription` (and the non-panicking error case).
+
+## Impact
+- Affected specs: `snmp-checker`
+- Affected code:
+  - `pkg/checker/snmp/client.go`
+  - `pkg/checker/snmp/*_test.go`
+- Risk: low; change is localized to SNMP value decoding and is covered by focused regression tests.
+

--- a/openspec/changes/fix-snmp-pdu-string-conversion/specs/snmp-checker/spec.md
+++ b/openspec/changes/fix-snmp-pdu-string-conversion/specs/snmp-checker/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: SNMP PDU string types convert without panics
+The SNMP checker MUST convert gosnmp PDU values of type `OctetString` and `ObjectDescription` into Go strings without panicking.
+
+#### Scenario: Convert OctetString value returned as bytes
+- **GIVEN** an SNMP response variable with Type `OctetString` and Value `[]byte("Test SNMP String")`
+- **WHEN** the SNMP client converts the variable
+- **THEN** the conversion result is the string `"Test SNMP String"` and conversion returns no error
+
+#### Scenario: Convert ObjectDescription value returned as bytes
+- **GIVEN** an SNMP response variable with Type `ObjectDescription` and Value `[]byte("Device OS v1.2.3")`
+- **WHEN** the SNMP client converts the variable
+- **THEN** the conversion result is the string `"Device OS v1.2.3"` and conversion returns no error
+
+#### Scenario: Unexpected value type does not crash the checker
+- **GIVEN** an SNMP response variable with Type `OctetString` or `ObjectDescription` and a Value that is not a `[]byte`
+- **WHEN** the SNMP client converts the variable
+- **THEN** conversion returns an error and the checker does not panic
+

--- a/openspec/changes/fix-snmp-pdu-string-conversion/tasks.md
+++ b/openspec/changes/fix-snmp-pdu-string-conversion/tasks.md
@@ -1,0 +1,13 @@
+## 1. Fix
+- [x] 1.1 Update SNMP PDU conversion for `gosnmp.OctetString` and `gosnmp.ObjectDescription` to decode `[]byte` into `string` without panicking
+- [x] 1.2 Ensure conversion returns an error (not a panic) when `variable.Value` is not the expected Go type for `OctetString`/`ObjectDescription`
+
+## 2. Tests
+- [x] 2.1 Add a regression test for `convertVariable()` converting `OctetString` values returned as `[]byte`
+- [x] 2.2 Add a regression test for `convertVariable()` converting `ObjectDescription` values returned as `[]byte`
+- [x] 2.3 Add a regression test that an unexpected `Value` type for these string ASN.1 types returns an error and does not panic
+
+## 3. Validation
+- [x] 3.1 Run `go test ./pkg/checker/snmp/...`
+- [x] 3.2 Run `make lint`
+- [x] 3.3 Run `openspec validate fix-snmp-pdu-string-conversion --strict`

--- a/pkg/checker/snmp/BUILD.bazel
+++ b/pkg/checker/snmp/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     name = "snmp_test",
     srcs = [
         "aggregator_test.go",
+        "client_conversion_test.go",
         "collector_test.go",
         "service_deadlock_test.go",
         "service_test.go",

--- a/pkg/checker/snmp/client_conversion_test.go
+++ b/pkg/checker/snmp/client_conversion_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package snmp
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertVariable_OctetStringBytes(t *testing.T) {
+	client := &SNMPClientImpl{}
+
+	variable := gosnmp.SnmpPDU{
+		Name:  ".1.3.6.1.2.1.1.1.0",
+		Type:  gosnmp.OctetString,
+		Value: []byte("Test SNMP String"),
+	}
+
+	value, err := client.convertVariable(variable)
+	require.NoError(t, err)
+	require.Equal(t, "Test SNMP String", value)
+}
+
+func TestConvertVariable_ObjectDescriptionBytes(t *testing.T) {
+	client := &SNMPClientImpl{}
+
+	variable := gosnmp.SnmpPDU{
+		Name:  ".1.3.6.1.2.1.1.1.0",
+		Type:  gosnmp.ObjectDescription,
+		Value: []byte("Device OS v1.2.3"),
+	}
+
+	value, err := client.convertVariable(variable)
+	require.NoError(t, err)
+	require.Equal(t, "Device OS v1.2.3", value)
+}
+
+func TestConvertVariable_StringTypesUnexpectedValueDoNotPanic(t *testing.T) {
+	client := &SNMPClientImpl{}
+
+	testCases := []struct {
+		name     string
+		variable gosnmp.SnmpPDU
+	}{
+		{
+			name: "OctetString byte",
+			variable: gosnmp.SnmpPDU{
+				Name:  ".1.3.6.1.2.1.1.1.0",
+				Type:  gosnmp.OctetString,
+				Value: byte('x'),
+			},
+		},
+		{
+			name: "ObjectDescription string",
+			variable: gosnmp.SnmpPDU{
+				Name:  ".1.3.6.1.2.1.1.1.0",
+				Type:  gosnmp.ObjectDescription,
+				Value: "not-bytes",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				value interface{}
+				err   error
+			)
+
+			require.NotPanics(t, func() {
+				value, err = client.convertVariable(tc.variable)
+			})
+
+			require.Nil(t, value)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrSNMPConvert)
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix SNMP PDU string conversion panics for `OctetString` and `ObjectDescription` types
  - Corrected type assertions from `byte` to `[]byte` to match gosnmp library behavior
  - Added proper error handling instead of panicking on unexpected value types

- Add comprehensive regression tests for string type conversions
  - Tests cover successful `[]byte` conversion to string
  - Tests verify error handling for unexpected value types without panicking

- Document fix with specification and change proposal
  - Added requirement specs and task tracking for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SNMP PDU with OctetString/ObjectDescription"] -->|"Previously: byte assertion"| B["PANIC: interface conversion error"]
  A -->|"Now: []byte assertion + error handling"| C["String conversion or error return"]
  D["Regression tests"] -->|"Verify correct behavior"| C
  D -->|"Verify no panics"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.go</strong><dd><code>Fix byte string type assertions and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/client.go

<ul><li>Removed <code>ObjectDescription</code> and <code>OctetString</code> from conversion map to <br>handle them explicitly<br> <li> Added explicit type checks for <code>ObjectDescription</code> and <code>OctetString</code> <br>before map lookup<br> <li> Fixed <code>convertObjectDescription()</code> to accept <code>[]byte</code> instead of <code>byte</code> and <br>return error on type mismatch<br> <li> Fixed <code>convertOctetString()</code> to accept <code>[]byte</code> instead of <code>byte</code> and return <br>error on type mismatch<br> <li> Both functions now return <code>(interface{}, error)</code> tuple for proper error <br>handling</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-b5e92490b688495a040a2f6f5227dc83c46fc5e7ea59885f8285a3d6c868bd87">+37/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_conversion_test.go</strong><dd><code>Add SNMP string type conversion regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/client_conversion_test.go

<ul><li>Added test for <code>OctetString</code> conversion with <code>[]byte</code> value<br> <li> Added test for <code>ObjectDescription</code> conversion with <code>[]byte</code> value<br> <li> Added parametrized test cases for unexpected value types that should <br>error without panicking<br> <li> Tests verify both successful conversions and error handling paths</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-e382a2bd9f2612005f0a6239ae6a30272af91d68a70e25b7ac3c0ed8da3211cc">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Add change proposal documentation for fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-pdu-string-conversion/proposal.md

<ul><li>Documents the bug: gosnmp returns <code>[]byte</code> but code asserts <code>byte</code>, <br>causing panics<br> <li> Describes the fix: correct type assertions and add error handling<br> <li> Lists affected code and risk assessment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-8bad22e013f99a913f7db91e78970c89634e94cd39262d339a06e72734531ee4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add specification requirements for string conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-pdu-string-conversion/specs/snmp-checker/spec.md

<ul><li>Defines requirement for SNMP PDU string types to convert without <br>panics<br> <li> Specifies scenarios for successful <code>OctetString</code> and <code>ObjectDescription</code> <br>conversion<br> <li> Specifies scenario for error handling with unexpected value types</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-fa51756b168cdca03f99da7568ffe261ea59b0b33f5c7ac1de4781af378f55fc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Add task tracking for the fix implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-snmp-pdu-string-conversion/tasks.md

<ul><li>Documents completed tasks for fixing the conversion logic<br> <li> Lists completed test cases for regression coverage<br> <li> Tracks validation steps including tests, linting, and spec validation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-b18156d1b4a0904f964884f6642aae45fd88d0ddcab58b0c699d236e34be3cee">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BUILD.bazel</strong><dd><code>Register new test file in build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/BUILD.bazel

- Added `client_conversion_test.go` to the test sources list


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2160/files#diff-bf78b9b2c6f1b0b501487be34f583e55b0735ad601abb7c7e9d27cb55a0ef57f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

