### PR TITLE
initial

### DIFF
--- a/openspec/changes/fix-poller-status-metadata-clobber/design.md
+++ b/openspec/changes/fix-poller-status-metadata-clobber/design.md
@@ -1,0 +1,43 @@
+## Context
+Poller registration metadata (identity/provenance) and poller operational status (health/last-seen) currently share the same `pollers` row in CNPG. Two code paths write that table:
+- Service registry registration/upsert (intended to manage registration metadata).
+- Poller status updates (intended to manage operational state).
+
+Today, the poller status UPSERT overwrites registration columns with defaults during conflict updates, which corrupts explicit registrations.
+
+## Goals / Non-Goals
+- Goals:
+  - Preserve poller registration metadata across status/heartbeat updates.
+  - Keep status updates cheap (no read-before-write required).
+  - Maintain a clear “ownership” boundary between registration writes and status writes.
+- Non-Goals:
+  - Redesign the registry schema (separating operational state into a new table).
+  - Change the edge onboarding data model or token formats.
+
+## Decisions
+- Decision: Treat status/heartbeat writes as *operational-only* updates.
+  - The status update SQL MUST NOT modify registration metadata on conflict.
+  - Registration metadata remains managed by the service registry registration/upsert path.
+
+### Alternatives considered
+- Conditional UPSERT for each column (`CASE`/`COALESCE(NULLIF(...))`).
+  - Pros: single SQL path.
+  - Cons: ambiguous semantics (cannot distinguish “intentionally set empty” vs “unknown”), increases complexity, easy to regress.
+- Read-before-write to preserve fields in application code.
+  - Pros: explicit.
+  - Cons: adds a read on hot path and still cannot preserve fields that are not represented in the status model.
+- Route all heartbeats through the service registry exclusively.
+  - Pros: single write system.
+  - Cons: would require expanding service registry heartbeat semantics to include `is_healthy`, and coordinating ownership across packages.
+
+## Risks / Trade-offs
+- Risk: Call sites that *intended* to update registration metadata via `UpdatePollerStatus` will no longer do so.
+  - Mitigation: Audit call sites and keep registration metadata updates explicit via the service registry.
+
+## Migration Plan
+No data migration. Existing corrupted rows may require re-registration to restore missing metadata; the change prevents future corruption.
+
+## Open Questions
+- Should `UpdatePollerStatus` be renamed/split to make the “operational-only” semantics impossible to misuse?
+- Should we add an integrity check/alert when a poller’s registration metadata changes unexpectedly?
+

--- a/openspec/changes/fix-poller-status-metadata-clobber/proposal.md
+++ b/openspec/changes/fix-poller-status-metadata-clobber/proposal.md
@@ -1,0 +1,20 @@
+# Change: Prevent poller status updates from clobbering registration metadata
+
+## Why
+`UpdatePollerStatus` is called frequently to record operational state (`is_healthy`, `last_seen`) for a poller. Today, that write path overwrites poller registration metadata (`component_id`, `registration_source`, `status`, `spiffe_identity`, `metadata`, and related timestamps) with hardcoded defaults, causing pollers registered via edge onboarding or explicit registration to lose their identity and provenance.
+
+Reference: GitHub issue `#2151` (Poller status updates overwrite registration metadata with defaults).
+
+## What Changes
+- Update the CNPG poller status UPSERT so that conflict updates only touch operational fields (e.g., `last_seen`, `is_healthy`, `updated_at`) and do **not** overwrite registration metadata.
+- Define/clarify write ownership: registration metadata updates flow through the service registry registration path; status/heartbeat updates flow through the poller status path.
+- Add regression coverage to prevent reintroducing metadata clobbering.
+
+## Impact
+- Affected specs: `service-registry` (new delta)
+- Affected code:
+  - `pkg/db/cnpg_registry.go` (poller status UPSERT + args)
+  - `pkg/db/pollers.go` (public DB API semantics)
+  - `pkg/core/pollers.go` and any other callers that update poller health/last-seen
+- No schema changes expected; this is a behavioral fix for write semantics.
+

--- a/openspec/changes/fix-poller-status-metadata-clobber/specs/service-registry/spec.md
+++ b/openspec/changes/fix-poller-status-metadata-clobber/specs/service-registry/spec.md
@@ -1,0 +1,27 @@
+# Service Registry: Poller status vs registration writes
+
+## ADDED Requirements
+
+### Requirement: Poller status updates preserve registration metadata
+When the system records poller operational state (e.g., `is_healthy`, `last_seen`), it SHALL NOT overwrite poller registration metadata (`component_id`, `registration_source`, `status`, `spiffe_identity`, `metadata`, `created_by`, `first_registered`, and `first_seen`).
+
+#### Scenario: Explicitly registered poller retains metadata after status update
+- **GIVEN** poller `edge-poller-01` is explicitly registered with non-default `component_id`, `registration_source`, `spiffe_identity`, and `metadata`
+- **WHEN** the poller reports status updates that update `last_seen` and/or `is_healthy`
+- **THEN** the stored registration metadata remains unchanged
+- **AND** only operational fields (such as `last_seen`, `is_healthy`, `updated_at`) are updated
+
+#### Scenario: Status updates do not clear first-seen timestamps
+- **GIVEN** poller `edge-poller-01` has a non-null `first_registered` and `first_seen`
+- **WHEN** a status update occurs where the caller does not provide `first_seen`
+- **THEN** `first_registered` and `first_seen` remain unchanged
+
+### Requirement: Registration writes remain authoritative for registration metadata
+When the system performs an explicit poller registration or metadata update (e.g., edge onboarding), it SHALL update poller registration metadata and SHALL NOT be overwritten by subsequent status/heartbeat writes.
+
+#### Scenario: Explicit registration after implicit status insert updates metadata
+- **GIVEN** poller `edge-poller-01` first appears via an implicit status insert (defaults applied)
+- **WHEN** an explicit registration is later performed with non-default identity/provenance metadata
+- **THEN** the poller record reflects the explicit registration metadata after registration completes
+- **AND** subsequent status updates preserve those values
+

--- a/openspec/changes/fix-poller-status-metadata-clobber/tasks.md
+++ b/openspec/changes/fix-poller-status-metadata-clobber/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [x] 1.1 Update `pkg/db/cnpg_registry.go:upsertPollerStatusSQL` conflict clause to only update operational columns and preserve registration metadata.
+- [x] 1.2 Ensure `first_registered` / `first_seen` are not cleared or overwritten by status-only calls (especially when callers omit `FirstSeen`).
+- [x] 1.3 Add regression tests that fail if poller registration metadata changes after a status update (explicit registration → status update).
+- [x] 1.4 Audit `UpdatePollerStatus` call sites in `pkg/core/**` (and elsewhere) to confirm they are intended to be status/heartbeat updates only.
+- [x] 1.5 Confirm service registry registration/upsert paths continue to update registration metadata as intended.
+
+## 2. Validation
+- [x] 2.1 Run `openspec validate fix-poller-status-metadata-clobber --strict`.
+- [x] 2.2 Run targeted Go tests for the touched packages (at minimum `go test ./pkg/db/... ./pkg/core/...`).

--- a/pkg/db/cnpg_registry.go
+++ b/pkg/db/cnpg_registry.go
@@ -46,8 +46,7 @@ INSERT INTO pollers (
 ) VALUES (
 	$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
 )
-	ON CONFLICT (poller_id) DO UPDATE SET
-	first_seen = COALESCE(pollers.first_seen, EXCLUDED.first_seen),
+ON CONFLICT (poller_id) DO UPDATE SET
 	last_seen = EXCLUDED.last_seen,
 	is_healthy = EXCLUDED.is_healthy,
 	updated_at = EXCLUDED.updated_at`

--- a/pkg/db/cnpg_registry.go
+++ b/pkg/db/cnpg_registry.go
@@ -46,19 +46,10 @@ INSERT INTO pollers (
 ) VALUES (
 	$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14
 )
-ON CONFLICT (poller_id) DO UPDATE SET
-	component_id = EXCLUDED.component_id,
-	registration_source = EXCLUDED.registration_source,
-	status = EXCLUDED.status,
-	spiffe_identity = EXCLUDED.spiffe_identity,
-	first_registered = EXCLUDED.first_registered,
-	first_seen = EXCLUDED.first_seen,
+	ON CONFLICT (poller_id) DO UPDATE SET
+	first_seen = COALESCE(pollers.first_seen, EXCLUDED.first_seen),
 	last_seen = EXCLUDED.last_seen,
-	metadata = EXCLUDED.metadata,
-	created_by = EXCLUDED.created_by,
 	is_healthy = EXCLUDED.is_healthy,
-	agent_count = EXCLUDED.agent_count,
-	checker_count = EXCLUDED.checker_count,
 	updated_at = EXCLUDED.updated_at`
 
 	insertPollerHistorySQL = `

--- a/pkg/db/cnpg_registry_test.go
+++ b/pkg/db/cnpg_registry_test.go
@@ -17,7 +17,6 @@ func TestUpsertPollerStatusSQL_PreservesRegistrationMetadata(t *testing.T) {
 
 	assert.Contains(t, normalized, "ON CONFLICT (poller_id) DO UPDATE SET")
 
-	assert.Contains(t, normalized, "first_seen = COALESCE(pollers.first_seen, EXCLUDED.first_seen)")
 	assert.Contains(t, normalized, "last_seen = EXCLUDED.last_seen")
 	assert.Contains(t, normalized, "is_healthy = EXCLUDED.is_healthy")
 	assert.Contains(t, normalized, "updated_at = EXCLUDED.updated_at")
@@ -26,6 +25,7 @@ func TestUpsertPollerStatusSQL_PreservesRegistrationMetadata(t *testing.T) {
 	assert.NotContains(t, normalized, "registration_source = EXCLUDED.registration_source")
 	assert.NotContains(t, normalized, "status = EXCLUDED.status")
 	assert.NotContains(t, normalized, "spiffe_identity = EXCLUDED.spiffe_identity")
+	assert.NotContains(t, normalized, "first_seen =")
 	assert.NotContains(t, normalized, "metadata = EXCLUDED.metadata")
 	assert.NotContains(t, normalized, "created_by = EXCLUDED.created_by")
 	assert.NotContains(t, normalized, "agent_count = EXCLUDED.agent_count")

--- a/pkg/db/cnpg_registry_test.go
+++ b/pkg/db/cnpg_registry_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,27 @@ import (
 
 	"github.com/carverauto/serviceradar/pkg/models"
 )
+
+func TestUpsertPollerStatusSQL_PreservesRegistrationMetadata(t *testing.T) {
+	normalized := strings.Join(strings.Fields(upsertPollerStatusSQL), " ")
+
+	assert.Contains(t, normalized, "ON CONFLICT (poller_id) DO UPDATE SET")
+
+	assert.Contains(t, normalized, "first_seen = COALESCE(pollers.first_seen, EXCLUDED.first_seen)")
+	assert.Contains(t, normalized, "last_seen = EXCLUDED.last_seen")
+	assert.Contains(t, normalized, "is_healthy = EXCLUDED.is_healthy")
+	assert.Contains(t, normalized, "updated_at = EXCLUDED.updated_at")
+
+	assert.NotContains(t, normalized, "component_id = EXCLUDED.component_id")
+	assert.NotContains(t, normalized, "registration_source = EXCLUDED.registration_source")
+	assert.NotContains(t, normalized, "status = EXCLUDED.status")
+	assert.NotContains(t, normalized, "spiffe_identity = EXCLUDED.spiffe_identity")
+	assert.NotContains(t, normalized, "metadata = EXCLUDED.metadata")
+	assert.NotContains(t, normalized, "created_by = EXCLUDED.created_by")
+	assert.NotContains(t, normalized, "agent_count = EXCLUDED.agent_count")
+	assert.NotContains(t, normalized, "checker_count = EXCLUDED.checker_count")
+	assert.NotContains(t, normalized, "first_registered = EXCLUDED.first_registered")
+}
 
 func TestBuildCNPGPollerStatusArgs(t *testing.T) {
 	now := time.Date(2025, time.June, 10, 12, 0, 0, 0, time.UTC)


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent poller status updates from overwriting registration metadata with defaults

- Modify UPSERT conflict clause to only update operational fields

- Preserve registration identity/provenance across heartbeat updates

- Add regression test to prevent metadata clobbering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Poller Status Update"] -->|"UPSERT with conflict"| B["CNPG Registry"]
  C["Service Registry Registration"] -->|"Update metadata"| B
  B -->|"Preserve: component_id, registration_source, spiffe_identity, metadata"| D["Registration Metadata"]
  B -->|"Update: last_seen, is_healthy, updated_at"| E["Operational State"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cnpg_registry.go</strong><dd><code>Restrict poller status UPSERT to operational fields only</code>&nbsp; </dd></summary>
<hr>

pkg/db/cnpg_registry.go

<ul><li>Remove registration metadata columns from UPSERT conflict update <br>clause<br> <li> Keep only operational fields: <code>first_seen</code> (with COALESCE), <code>last_seen</code>, <br><code>is_healthy</code>, <code>updated_at</code><br> <li> Prevent <code>component_id</code>, <code>registration_source</code>, <code>status</code>, <code>spiffe_identity</code>, <br><code>metadata</code>, <code>created_by</code>, <code>agent_count</code>, <code>checker_count</code>, <code>first_registered</code> <br>from being overwritten</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-e31b8b854d9ba774d2f3ed9899b1f5902462cd0e63990a2898dcaf9bc171d571">+2/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cnpg_registry_test.go</strong><dd><code>Add regression test for metadata preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/cnpg_registry_test.go

<ul><li>Add new test <code>TestUpsertPollerStatusSQL_PreservesRegistrationMetadata</code><br> <li> Verify UPSERT contains only operational field updates<br> <li> Assert registration metadata columns are absent from conflict clause<br> <li> Add <code>strings</code> import for SQL normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-e38716ee5b3614089e00e851d22d2c61e9934ebcc2b44b7aa4b79623251af869">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Proposal document for metadata preservation fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-poller-status-metadata-clobber/proposal.md

<ul><li>Document the issue: status updates overwriting registration metadata <br>with defaults<br> <li> Outline changes to CNPG UPSERT semantics<br> <li> Define write ownership boundaries between registration and status <br>paths<br> <li> List affected code files and expected impact</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-511a066de4507065281b37a979c77119b90e46e97e206f2e879f8af73d13c854">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>design.md</strong><dd><code>Design document with context and decision rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-poller-status-metadata-clobber/design.md

<ul><li>Explain context of shared <code>pollers</code> row between registration and status <br>writes<br> <li> Define goals: preserve metadata, keep updates cheap, maintain <br>ownership boundaries<br> <li> Document decision to treat status writes as operational-only<br> <li> Discuss alternatives considered and risk mitigations<br> <li> Note no data migration required</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-fd19193e9fe30b9b73e8c397a9a274eafa39efe8cef21fd07190038fc867112c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Service registry spec for metadata preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-poller-status-metadata-clobber/specs/service-registry/spec.md

<ul><li>Add requirement that status updates preserve registration metadata<br> <li> Define scenarios for explicitly registered pollers retaining metadata<br> <li> Specify that <code>first_seen</code> timestamps are not cleared by status updates<br> <li> Establish registration writes as authoritative for metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-e8ea81126ba5d49a821706cd6479d176ac1ee40a496dbb38938d830ea94d3e0a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Implementation and validation task checklist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-poller-status-metadata-clobber/tasks.md

<ul><li>Document implementation tasks with completion status<br> <li> Include SQL update, timestamp handling, regression tests, call site <br>audit<br> <li> List validation steps: spec validation and targeted Go tests</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2162/files#diff-6aa430ae5e044c6f55358d45cd7b2368b1168a735aa4f84739c6102fa7769720">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

