### PR TITLE
2145 clonedevicerecord shares empty non nil metadata map between original and clone

### DIFF
--- a/openspec/changes/fix-clone-device-record-metadata-aliasing/proposal.md
+++ b/openspec/changes/fix-clone-device-record-metadata-aliasing/proposal.md
@@ -1,0 +1,21 @@
+# Change: Fix `cloneDeviceRecord` metadata aliasing for empty maps
+
+## Why
+Issue #2145 reports that `pkg/registry/device_store.go:cloneDeviceRecord` fails to deep-copy `DeviceRecord.Metadata` when the source map is empty-but-non-nil. Because the record is shallow-copied (`dst := *src`), the clone and original end up sharing the same underlying map reference, defeating the defensive-copying contract used throughout the device registry.
+
+This can cause surprising cross-call contamination (a later clone “inherits” keys written to a previous clone), incorrect device state in the registry’s in-memory cache, and potential data races when callers concurrently read/write “independent” record copies.
+
+## What Changes
+- Update `cloneDeviceRecord` to deep-copy `Metadata` when `src.Metadata != nil` (including empty maps).
+- Update `cloneDeviceRecord` to deep-copy `DiscoverySources` and `Capabilities` when non-nil (including empty-but-non-nil slices) to avoid similar aliasing via shared backing arrays.
+- Add regression tests covering:
+  - Empty-but-non-nil `Metadata` map isolation (original vs clone and clone vs clone).
+  - Empty-but-non-nil slices with non-zero capacity (append to clone does not affect original or subsequent clones).
+
+## Impact
+- Affected specs: `device-registry-defensive-copying`
+- Affected code:
+  - `pkg/registry/device_store.go` (`cloneDeviceRecord`)
+  - `pkg/registry/*_test.go` (new/updated unit tests)
+- Risk: Low. Changes are limited to defensive copying; primary impact is small additional allocations during record cloning.
+

--- a/openspec/changes/fix-clone-device-record-metadata-aliasing/specs/device-registry-defensive-copying/spec.md
+++ b/openspec/changes/fix-clone-device-record-metadata-aliasing/specs/device-registry-defensive-copying/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: DeviceRecord clone isolation
+The device registry MUST return `DeviceRecord` values whose mutable fields do not alias internal stored state or other returned clones, including when those fields are empty-but-non-nil.
+
+#### Scenario: Empty metadata maps are deep-copied
+- **GIVEN** a stored `DeviceRecord` has `Metadata` set to an empty (but non-nil) map
+- **WHEN** a caller retrieves a copy via a registry getter that uses `cloneDeviceRecord`
+- **THEN** the returned `Metadata` MUST be a distinct map instance from the stored record
+- **AND** mutating the returned `Metadata` MUST NOT change the stored record’s `Metadata`
+
+#### Scenario: Empty slices are non-aliased
+- **GIVEN** a stored `DeviceRecord` has `DiscoverySources` and/or `Capabilities` set to empty-but-non-nil slices (including cases with non-zero capacity)
+- **WHEN** a caller retrieves a copy via a registry getter that uses `cloneDeviceRecord`
+- **THEN** appending to the returned slices MUST NOT affect the stored record’s slices
+- **AND** subsequent clones MUST NOT observe values appended to earlier clones
+
+#### Scenario: Clone mutation does not affect other clones
+- **GIVEN** two callers retrieve independent clones of the same stored `DeviceRecord`
+- **WHEN** one caller mutates its clone’s `Metadata` (e.g., sets a new key)
+- **THEN** the other caller’s clone MUST NOT reflect that mutation
+

--- a/openspec/changes/fix-clone-device-record-metadata-aliasing/tasks.md
+++ b/openspec/changes/fix-clone-device-record-metadata-aliasing/tasks.md
@@ -1,0 +1,13 @@
+## 1. Fix cloning behavior
+- [x] 1.1 Update `cloneDeviceRecord` to deep-copy `Metadata` for any non-nil map (even when empty)
+- [x] 1.2 Update `cloneDeviceRecord` to deep-copy `DiscoverySources` and `Capabilities` for any non-nil slice (even when empty)
+- [x] 1.3 Ensure pointer fields (`Hostname`, `MAC`, `IntegrationID`, `CollectorAgentID`) remain non-aliased as today
+
+## 2. Add regression tests
+- [x] 2.1 Add unit test: empty-but-non-nil `Metadata` is deep-copied (mutating clone does not affect original)
+- [x] 2.2 Add unit test: two clones from the same record do not share `Metadata` (mutating one does not affect the other)
+- [x] 2.3 Add unit test: empty-but-non-nil slices (including `make([]string, 0, N)`) do not alias (appending to clone does not affect original or later clones)
+
+## 3. Verification
+- [x] 3.1 Run `go test ./pkg/registry/...`
+- [x] 3.2 Run `go test -race ./pkg/registry/...` (or a targeted race repro test if needed)

--- a/pkg/registry/device_store.go
+++ b/pkg/registry/device_store.go
@@ -195,13 +195,13 @@ func cloneDeviceRecord(src *DeviceRecord) *DeviceRecord {
 		dst.CollectorAgentID = &collectorAgentID
 	}
 
-	if len(src.DiscoverySources) > 0 {
-		dst.DiscoverySources = append([]string(nil), src.DiscoverySources...)
+	if src.DiscoverySources != nil {
+		dst.DiscoverySources = append(make([]string, 0, len(src.DiscoverySources)), src.DiscoverySources...)
 	}
-	if len(src.Capabilities) > 0 {
-		dst.Capabilities = append([]string(nil), src.Capabilities...)
+	if src.Capabilities != nil {
+		dst.Capabilities = append(make([]string, 0, len(src.Capabilities)), src.Capabilities...)
 	}
-	if len(src.Metadata) > 0 {
+	if src.Metadata != nil {
 		meta := make(map[string]string, len(src.Metadata))
 		for k, v := range src.Metadata {
 			meta[k] = v


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
**Core Bug Fixes:**

- Fixed potential RWMutex deadlock in SNMP service `Check` method by removing recursive read locking

- Fixed host result aliasing in sweep snapshots by implementing deep-copy semantics for `PortResults`, `PortMap`, and `ICMPStatus`

- Fixed SNMP string type conversion error handling with explicit type validation for `ObjectDescription` and `OctetString`

**Major Enhancements:**

- Implemented parameterized SRQL query support across MCP server and all query tools to prevent SQL injection

- Added partition-scoped device identifier resolution in identity engine with cache key normalization

- Refactored OTEL insert operations with generic callback pattern and extracted SQL templates as constants

- Added batch execution helper function `sendBatchExecAll` for consistent error handling across database operations

- Implemented Apache AGE Cypher graph query execution support with security checks

- Added downsampling functionality for metric time-series queries with configurable aggregation

- Added visualization metadata generation for query results with column type and semantic hints

- Implemented mutual TLS (mTLS) client certificate authentication support in Rust database layer

- Refactored all Rust query modules to support parameterized queries with bind parameter extraction

**New Web-NG Foundation:**

- Established Phoenix LiveView-based web framework with authentication and routing

- Integrated Tailwind CSS with daisyUI theme system and custom dark/light mode support

- Added custom JavaScript hooks for interactive components (TimeseriesChart, topbar progress)

- Implemented Heroicons SVG icon integration via Tailwind CSS plugin

- Created Rust NIF module for SRQL query translation to Elixir integration

**Docker & Infrastructure:**

- Enhanced certificate generation with support for extra CNPG certificate IPs and workstation certificates

- Updated nginx entrypoint to use web-ng service on port 4000

**Testing:**

- Added comprehensive deep-copy validation tests for host result snapshots

- Added parameterized query binding tests for devices, logs, and events

- Added SNMP type conversion error handling tests

- Added batch operation error handling and execution tests

- Added static analysis test to prevent RWMutex deadlock patterns

- Added partition-scoped identifier resolution tests

- Added poller status upsert validation tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SNMP Service<br/>RWMutex Fix"] --> B["Bug Fixes"]
  C["Host Result<br/>Deep-Copy"] --> B
  D["String Type<br/>Conversion"] --> B
  
  E["Parameterized<br/>SRQL Queries"] --> F["Enhancements"]
  G["Partition-Scoped<br/>Identifiers"] --> F
  H["OTEL Generic<br/>Callback Pattern"] --> F
  I["Batch Helper<br/>Function"] --> F
  J["Apache AGE<br/>Cypher Support"] --> F
  K["Metric<br/>Downsampling"] --> F
  L["Query Viz<br/>Metadata"] --> F
  M["mTLS Client<br/>Certificates"] --> F
  
  N["Phoenix LiveView<br/>Framework"] --> O["Web-NG Foundation"]
  P["Tailwind CSS<br/>+ daisyUI"] --> O
  Q["Custom JS<br/>Hooks"] --> O
  R["Rust NIF<br/>Integration"] --> O
  
  S["Deep-Copy<br/>Tests"] --> T["Comprehensive Tests"]
  U["Parameterized<br/>Query Tests"] --> T
  V["SNMP Error<br/>Tests"] --> T
  W["Batch Operation<br/>Tests"] --> T
  X["Deadlock Prevention<br/>Tests"] --> T
  
  B --> Y["Complete PR"]
  F --> Y
  O --> Y
  T --> Y
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>41 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cnpg_observability.go</strong><dd><code>Refactor OTEL insert operations with generic callback pattern</code></dd></summary>
<hr>

pkg/db/cnpg_observability.go

<ul><li>Refactored OTEL insert operations to use a generic <code>insertOTELRows</code> <br>function with callback-based row handling<br> <li> Extracted SQL templates as module-level constants (<code>otelLogsInsertSQL</code>, <br><code>otelMetricsInsertSQL</code>, <code>otelTracesInsertSQL</code>)<br> <li> Created <code>otelRowInserter</code> interface and type-specific implementations <br>(<code>otelLogInserter</code>, <code>otelMetricInserter</code>, <code>otelTraceInserter</code>) to <br>encapsulate row data and queuing logic<br> <li> Added <code>unit</code> field to <code>otelMetricsInsertSQL</code> query</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-abaae95adb6fa6d0241553f6d1b39ecff3dd6159db72babbe39dfb3cd231cd3d">+188/-131</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity_engine.go</strong><dd><code>Add partition-scoped device identifier resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/identity_engine.go

<ul><li>Updated cache key format to include partition: <code>"<partition>:<type>:<value>"</code> instead of <code>"<type>:<value>"</code><br> <li> Added <code>strongIdentifierCacheKey</code> helper function to normalize partition <br>and build cache keys<br> <li> Refactored <code>batchLookupByStrongIdentifiers</code> to group updates by <br>partition and process each partition separately<br> <li> Added helper functions <code>groupUpdatesByPartition</code>, <br><code>collectStrongIdentifierSets</code>, and <code>batchLookupIdentifierType</code> for <br>partition-scoped lookups<br> <li> Updated <code>BatchGetDeviceIDsByIdentifier</code> calls to include partition <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-496f24b3784656e1d6bb97cafe5c528bbecea5a0b74b4be578d3b83e858038c7">+124/-54</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query_utils.go</strong><dd><code>Implement parameterized SRQL query support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/query_utils.go

<ul><li>Added <code>ParameterizedQueryExecutor</code> interface extending <code>QueryExecutor</code> <br>with <code>ExecuteSRQLQueryWithParams</code> method<br> <li> Created <code>srqlBindBuilder</code> type for parameter binding with <code>Bind</code> method <br>returning <code>$N</code> placeholders<br> <li> Modified query builders (<code>buildLogQuery</code>, <code>buildRecentLogsQuery</code>, <br><code>buildDevicesQuery</code>) to return tuples of <code>(string, []any)</code> with <br>parameterized queries<br> <li> Added <code>executeSRQL</code> helper to route queries to parameterized or plain <br>executor based on parameter presence<br> <li> Updated all query execution calls to use parameterized approach</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6a33491056954507b65b8252854786d3d9c65534c7c88700fcc2592f808b192b">+43/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>builder.go</strong><dd><code>Add parameter binding to generic filter builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/builder.go

<ul><li>Updated <code>FilterHandlerFunc</code> and <code>FilterBuilder.BuildFilters</code> signatures to <br>accept <code>*srqlBindBuilder</code> parameter<br> <li> Modified <code>GenericFilterBuilder.BuildFilters</code> to use parameter binding <br>instead of string concatenation<br> <li> Added sorted iteration over field mappings for deterministic filter <br>ordering<br> <li> Updated <code>BuildGenericFilterTool</code> to create <code>srqlBindBuilder</code> and pass to <br>filter handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ee3c16d7d8882a3a65d28bfedf7f0a5e59698b00ae482bc5565b3314503d5db2">+20/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Migrate MCP server to parameterized queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/server.go

<ul><li>Updated <code>executeGetDevice</code> to use parameterized query with <code>$1</code> <br>placeholder<br> <li> Modified <code>executeQueryEvents</code> to build parameterized queries with <br><code>srqlBindBuilder</code><br> <li> Added <code>executeSRQLQueryWithParams</code> method to route queries to <br>parameterized executor<br> <li> Updated <code>executeSRQLQuery</code> to delegate to <code>executeSRQLQueryWithParams</code> <br>with empty params</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bbb88ac338d81b0a37cd59fc53d68171d2de4780653253a2fd257f18fbf81bd0">+24/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sweep.go</strong><dd><code>Add HostResult deep-copy function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/models/sweep.go

<ul><li>Added <code>DeepCopyHostResult</code> function that creates a snapshot copy without <br>aliasing pointer/slice/map fields<br> <li> Function handles <code>PortResults</code> slice, <code>PortMap</code> map, and <code>ICMPStatus</code> <br>pointer with proper deep-copying<br> <li> Maintains referential integrity between <code>PortResults</code> and <code>PortMap</code> in the <br>copy</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-3cc7dd0e748c9f77be9e384fed2703ab77375716524b70860153b6a1abae27ca">+84/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools_sweeps.go</strong><dd><code>Parameterize sweep tool queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/tools_sweeps.go

<ul><li>Updated <code>registerGetRecentSweepsTool</code> to use parameterized query for <br><code>poller_id</code> filter<br> <li> Updated <code>registerGetSweepSummaryTool</code> to use parameterized query for <br><code>poller_id</code> filter<br> <li> Both tools now call <code>executeSRQLQueryWithParams</code> instead of <br><code>executeSRQLQuery</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c2ddcfeb6736358e171e60164cac1cb48b8af464bebe8445fd17fe580caaaa2f">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cnpg_identity_engine.go</strong><dd><code>Add partition filtering to identifier lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/cnpg_identity_engine.go

<ul><li>Updated <code>batchGetDeviceIDsByIdentifierSQL</code> to include partition filter <br>in WHERE clause<br> <li> Updated <code>BatchGetDeviceIDsByIdentifier</code> function signature to accept <br><code>partition</code> parameter<br> <li> Added partition normalization with default value fallback<br> <li> Updated query execution to pass partition as third parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-756702fbe82153fa86ae9b6bd6e5b109901d5fb8ee27cb9bc19f51277d3632f0">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools_events.go</strong><dd><code>Parameterize alert tool queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/tools_events.go

<ul><li>Updated <code>registerGetAlertsTool</code> to use parameterized query for <code>poller_id</code> <br>filter<br> <li> Changed from string concatenation to <code>$1</code> placeholder with parameter <br>binding<br> <li> Updated to call <code>executeSRQLQueryWithParams</code> instead of <code>executeSRQLQuery</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-3adaae4a85720d41db6c831160f8fd28273584047ac4a4540f2f9bcc5c6bcd90">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pgx_batch_helper.go</strong><dd><code>Add batch execution helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/pgx_batch_helper.go

<ul><li>Added <code>sendBatchExecAll</code> helper function for executing batch operations <br>with error handling<br> <li> Function handles empty batches, iterates through batch commands, and <br>ensures proper cleanup<br> <li> Returns formatted error messages with operation name and command index <br>on failure</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9a38f78952feb40cd7f517c2d9a6c4a76a8ffcfa3989ced955298ad0ee6786b8">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools_devices.go</strong><dd><code>Parameterize device tools queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/tools_devices.go

<ul><li>Updated device ID filter to use parameterized query with <code>$1</code> <br>placeholder<br> <li> Changed from string concatenation to parameter binding<br> <li> Updated to call <code>executeSRQLQueryWithParams</code> instead of <code>executeSRQLQuery</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9305d32d7f3683b79015dd7448623cf5393bf7f0631548313d810a3ed08d65dd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tools_logs.go</strong><dd><code>Parameterize log tool queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/tools_logs.go

<ul><li>Updated <code>registerLogTools</code> to use parameterized query for <code>poller_id</code> <br>filter<br> <li> Changed from string concatenation to <code>$1</code> placeholder with parameter <br>binding<br> <li> Updated to call <code>executeSRQLQueryWithParams</code> instead of <code>executeSRQLQuery</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8f85b80d8ce508452e002b324e459f01c581bbd97ad961c7e30a054505d8f29a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cnpg_unified_devices.go</strong><dd><code>Use batch helper for device deletion audit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/cnpg_unified_devices.go

<ul><li>Replaced manual batch result handling with <code>sendBatchExecAll</code> helper <br>function<br> <li> Simplified error handling for audit log batch execution</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ab3bf557cf9bb1b281a315a73abee38748de1654941c2471542e5e9bfc1716d8">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.go</strong><dd><code>Use batch helper for user storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/auth.go

<ul><li>Replaced manual batch result handling with <code>sendBatchExecAll</code> helper <br>function<br> <li> Simplified error handling for user batch storage</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-4d4e15c7e925bdd07a11ca5d2779a6f2acef74c2bebe286c4bbc9a7593cefdb7">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>viz.rs</strong><dd><code>Add visualization metadata generation for query results</code>&nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/viz.rs

<ul><li>New file implementing visualization metadata generation for query <br>results<br> <li> Defines <code>VizMeta</code>, <code>ColumnMeta</code>, <code>ColumnType</code>, <code>ColumnSemantic</code> structs for <br>describing result columns<br> <li> Implements <code>meta_for_plan()</code> function that returns visualization <br>suggestions and column metadata for different entity types<br> <li> Supports timeseries and table visualization kinds with semantic hints <br>for columns</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-70c860470ae125afe6d7e4a2f9cf9eb36f8967ae773c3a47804329bbf56a2d8b">+605/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>downsample.rs</strong><dd><code>Add downsampling support for metric time-series queries</code>&nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/downsample.rs

<ul><li>New file implementing downsampling functionality for metric queries<br> <li> Provides <code>to_sql_and_params()</code> and <code>execute()</code> functions to build and run <br>downsampled queries<br> <li> Supports time bucketing with configurable aggregation functions (avg, <br>min, max, sum, count)<br> <li> Implements series grouping and filtering for various metric entity <br>types</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-94f68b4684578afa112ab05ff903667b6cd902ad276e17c12af350078b300a6a">+521/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>devices.rs</strong><dd><code>Refactor devices query to support stats and bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/devices.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Added stats query support with <code>parse_stats_spec()</code> and <br><code>build_stats_query()</code> for count aggregations<br> <li> Implemented <code>collect_filter_params()</code> to extract bind parameters from <br>device filters<br> <li> Added validation for stats expressions and parameter binding</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-3202f22fff6863ed7848a129c49e2323322462b379d896d3fca2e59aa6f7b4c5">+195/-7</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.rs</strong><dd><code>Refactor services query to support stats and bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/services.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Added stats query support with <code>parse_stats_spec()</code> and <br><code>build_stats_query()</code> for count aggregations<br> <li> Implemented <code>collect_filter_params()</code> to extract bind parameters from <br>service filters<br> <li> Added parameter binding validation and reconciliation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ad5e7e1a352406ed473a765de4856625f1bede590e7e2c724163bcd1e7b313e9">+172/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser.rs</strong><dd><code>Add downsampling and graph cypher entity parsing support</code>&nbsp; </dd></summary>
<hr>

rust/srql/src/parser.rs

<ul><li>Added <code>GraphCypher</code> entity type for graph database queries<br> <li> Introduced <code>DownsampleSpec</code> and <code>DownsampleAgg</code> for downsampling <br>configuration<br> <li> Implemented parsing for <code>bucket</code>, <code>agg</code>, and <code>series</code> downsampling <br>parameters<br> <li> Enhanced stats parsing to support <code>as alias</code> syntax for result aliasing</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b2edf55d1721185349ecddb2f4eacc42e0dfcae19b6c2bc638602f187da67e66">+157/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph_cypher.rs</strong><dd><code>Add Apache AGE Cypher graph query execution support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/graph_cypher.rs

<ul><li>New file implementing Apache AGE Cypher query execution for graph <br>database<br> <li> Provides <code>execute()</code> and <code>to_sql_and_params()</code> functions for running <br>read-only Cypher queries<br> <li> Implements security checks to prevent write operations and SQL <br>injection<br> <li> Handles result transformation for nodes, edges, and generic row data</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-378b0ec80e1b1221c347160a0dac36c82d082fa06766d47d18cf069220166309">+208/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>interfaces.rs</strong><dd><code>Refactor interfaces query to support bind parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/interfaces.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> to extract bind parameters from <br>interface filters<br> <li> Added parameter binding validation and reconciliation with <br>limit/offset<br> <li> Updated stats query handling to return formatted SQL with parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-1ec833d4525fb2806523888b8c57b76ca8dd2ab70539368ccecc4d262769c8c5">+112/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>traces.rs</strong><dd><code>Refactor traces query to support bind parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/traces.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> and <code>collect_text_params()</code> for <br>trace filter parameters<br> <li> Added support for integer list filtering on status_code and span_kind <br>fields<br> <li> Added parameter binding validation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f390b0aef82baa9c3438719276dca70be826318d7446074a83b4527558528e19">+109/-4</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logs.rs</strong><dd><code>Refactor logs query to support bind parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/logs.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for log filter parameter <br>extraction<br> <li> Added support for severity_number integer filtering with list <br>operations<br> <li> Enhanced stats query handling with parameter conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f4d3b33667f2e79a6ebe4cfff931f93c728d9a81c305ac13586e623850a504db">+103/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cpu_metrics.rs</strong><dd><code>Refactor CPU metrics query to support bind parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/cpu_metrics.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for CPU metric filter parameter <br>extraction<br> <li> Added support for numeric filtering on core_id, usage_percent, and <br>frequency_hz<br> <li> Enhanced stats query handling with parameter conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-400c860c805cd3e1a5e7f7c42cece63cce3e62c1f3fd8b49a5803e26b40fe31e">+85/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pollers.rs</strong><dd><code>Refactor pollers query to support bind parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/pollers.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for poller filter parameter <br>extraction<br> <li> Added boolean filter support for <code>is_healthy</code> field<br> <li> Added parameter binding validation and reconciliation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e2192a3ba3041ed995e0abf9973489b7dff550949ff75da41d31bf514e765cc4">+81/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>otel_metrics.rs</strong><dd><code>Refactor OTEL metrics query to support bind parameters</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/otel_metrics.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for OTEL metric filter parameter <br>extraction<br> <li> Added boolean filter support for <code>is_slow</code> field<br> <li> Enhanced stats query handling with parameter conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8106bfa2099b8a6d945b338532f8b1108467e2f0592ddbd64d546fcbce3e3613">+85/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db.rs</strong><dd><code>Add mutual TLS (mTLS) client certificate authentication support</code></dd></summary>
<hr>

rust/srql/src/db.rs

<ul><li>Added support for client certificate and key authentication in TLS <br>connections<br> <li> Implemented <code>load_client_certs()</code> and <code>load_client_key()</code> functions for <br>certificate loading<br> <li> Enhanced <code>build_client_config()</code> to support mutual TLS (mTLS) <br>authentication<br> <li> Updated <code>PgConnectionManager::new()</code> to accept optional client cert and <br>key paths</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8d5a0c48024aa12a3e06de065ca71e940d2b5007fbc34ef87471b90d7937891c">+77/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timeseries_metrics.rs</strong><dd><code>Refactor timeseries metrics query to support bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/timeseries_metrics.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for timeseries metric filter <br>parameter extraction<br> <li> Added support for numeric filtering on if_index and value fields<br> <li> Added parameter binding validation and reconciliation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8450bff3aef4c1271bbf9b96809b4a5ac7b218e3f98c8b60387e35dbf4845bb0">+82/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>process_metrics.rs</strong><dd><code>Refactor process metrics query to support bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/process_metrics.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>collect_filter_params()</code> for process metric filter <br>parameter extraction<br> <li> Added support for numeric filtering on pid, cpu_usage, and <br>memory_usage fields<br> <li> Added parameter binding validation and reconciliation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c70bb600f5fba7199d80930fdc735cfc38371ef2d4ff3c821af55100e4cb0bac">+77/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trace_summaries.rs</strong><dd><code>Refactor trace summaries query to support bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/trace_summaries.rs

<ul><li>Refactored <code>to_debug_sql()</code> to <code>to_sql_and_params()</code> returning SQL and <br>bind parameters<br> <li> Implemented <code>bind_param_from_query()</code> to convert SQL bind values to <br><code>BindParam</code> type<br> <li> Updated placeholder rewriting for parameter binding</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ff98619eb5dc4d75205d1797477e9e2880f42081e8d0c61d6fd1d6e5926b72fa">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.rs</strong><dd><code>Add unit field to OTEL metric row model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/models.rs

<ul><li>Added <code>unit</code> field to <code>OtelMetricRow</code> struct for storing metric unit <br>information<br> <li> Updated <code>into_json()</code> method to include the new <code>unit</code> field in JSON <br>serialization</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-57c82b01f92e9bd40063d0b0178c12d452771ac133f2121fb0ac008b167da367">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>disk_metrics.rs</strong><dd><code>Refactor SQL generation to extract and return bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/disk_metrics.rs

<ul><li>Refactored <code>to_debug_sql</code> function to <code>to_sql_and_params</code> returning both <br>SQL string and bind parameters<br> <li> Added <code>collect_text_params</code> and <code>collect_filter_params</code> helper functions <br>to extract filter parameters<br> <li> Implemented bind parameter collection for time ranges, filters, and <br>limit/offset clauses<br> <li> Added validation to ensure bind count matches between diesel query and <br>collected parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b5a536baa37176f971e96c789991202b483314e2a85d4556489b4568a5675162">+72/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>memory_metrics.rs</strong><dd><code>Refactor SQL generation to extract and return bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/memory_metrics.rs

<ul><li>Refactored <code>to_debug_sql</code> function to <code>to_sql_and_params</code> returning both <br>SQL string and bind parameters<br> <li> Added <code>collect_text_params</code> and <code>collect_filter_params</code> helper functions <br>to extract filter parameters<br> <li> Implemented bind parameter collection for time ranges, filters, and <br>limit/offset clauses<br> <li> Added validation to ensure bind count matches between diesel query and <br>collected parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-a12a227c4b5c224359799853f5fd7bbf626ec14b1e7eae40e4c65b1db6699417">+73/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>device_updates.rs</strong><dd><code>Refactor SQL generation to extract and return bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/device_updates.rs

<ul><li>Refactored <code>to_debug_sql</code> function to <code>to_sql_and_params</code> returning both <br>SQL string and bind parameters<br> <li> Added <code>collect_text_params</code> with <code>allow_lists</code> parameter to control list <br>filter support per field<br> <li> Implemented <code>collect_filter_params</code> to handle device-specific filter <br>fields including boolean values<br> <li> Added validation to ensure bind count matches between diesel query and <br>collected parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-77b99f0ef409a6a3e4ecc65800ae841231a82b27a64e8dc1d4667db6698a539d">+78/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.rs</strong><dd><code>Refactor SQL generation to extract and return bind parameters</code></dd></summary>
<hr>

rust/srql/src/query/events.rs

<ul><li>Refactored <code>to_debug_sql</code> function to <code>to_sql_and_params</code> returning both <br>SQL string and bind parameters<br> <li> Added <code>collect_text_params</code> and <code>collect_filter_params</code> helper functions <br>to extract filter parameters<br> <li> Implemented bind parameter collection for time ranges, filters, and <br>limit/offset clauses<br> <li> Added validation to ensure bind count matches between diesel query and <br>collected parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ad603163a35223c63c68279e53a1a4c9219b9096042a168d8a87443abaa29a58">+71/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add Rust NIF for SRQL query translation to Elixir</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/native/srql_nif/src/lib.rs

<ul><li>Created new Rust NIF module for Elixir integration with SRQL query <br>translation<br> <li> Implemented <code>translate</code> function as a dirty CPU NIF that converts SRQL <br>queries to database queries<br> <li> Added error handling with atom-based responses for success and failure <br>cases<br> <li> Integrated with <code>srql::query::translate_request</code> for query processing</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-74a225cdf31e64db49fb42c0419c524068150b07528e8d722a75e3ec8034c297">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Export query types and add embedded SRQL support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/lib.rs

<ul><li>Exported public types <code>QueryDirection</code>, <code>QueryEngine</code>, <code>QueryRequest</code>, <br><code>QueryResponse</code>, <code>TranslateRequest</code>, and <code>TranslateResponse</code><br> <li> Added <code>EmbeddedSrql</code> struct to support embedded SRQL usage with <br>connection pooling<br> <li> Implemented <code>EmbeddedSrql::new</code> constructor for initializing with <br><code>AppConfig</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8c0401c0d0bb9761ed66ff5328703755132a87d625f77878f53037e2329644b8">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schema.rs</strong><dd><code>Add unit field to events table schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/schema.rs

<ul><li>Added <code>unit</code> field to the events table schema as nullable text column</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-2fe4906f42b52f96b7bc2d3431885b996b6701cfb88416905ae130b472d536ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate-certs.sh</strong><dd><code>Add support for extra CNPG certificate IPs and workstation cert</code></dd></summary>
<hr>

docker/compose/generate-certs.sh

<ul><li>Added logic to check if CNPG certificate is missing required SAN IPs <br>and regenerate if needed<br> <li> Implemented support for <code>CNPG_CERT_EXTRA_IPS</code> environment variable to <br>add additional IP addresses to CNPG certificate<br> <li> Added generation of new <code>workstation</code> certificate for developers <br>connecting from outside Docker network<br> <li> Refactored certificate existence check to handle conditional <br>regeneration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8298241543b4744a6ac7780c760ac5b5a0a87ba62de19c8612ebe1aba0996ebd">+28/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.js</strong><dd><code>Add Phoenix LiveSocket setup and custom hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/assets/js/app.js

<ul><li>Initialized Phoenix LiveSocket with custom hooks and colocated hooks<br> <li> Implemented <code>TimeseriesChart</code> hook for interactive chart tooltips and <br>hover line visualization<br> <li> Added topbar progress bar configuration for page loading feedback<br> <li> Configured development mode features for server log streaming and <br>editor integration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-16bc6f19f34cfdd66ac36b4ef2dd66d34e3470c4eb324ebc3e4bb8e58a91360c">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>router.ex</strong><dd><code>Add Phoenix router with authentication and LiveView routes</code></dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/router.ex

<ul><li>Defined browser and API pipelines with authentication and CSRF <br>protection<br> <li> Added routes for home page, API query execution, and device management <br>endpoints<br> <li> Configured LiveView sessions for authenticated users with multiple <br>dashboard pages<br> <li> Implemented authentication routes for user registration, login, and <br>logout</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-df516cd33165cd85914c1ccb3ff6511d3fe688d4a66498b99807958998c5d07c">+103/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>summary_snapshot_test.go</strong><dd><code>Add snapshot deep-copy verification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/summary_snapshot_test.go

<ul><li>Added test <code>TestGetSummary_HostResultsDoNotAliasInternalState</code> verifying <br>deep-copy semantics for host snapshots<br> <li> Added test <code>TestGetSummary_ConcurrentReadsDoNotPanic</code> ensuring <br>concurrent access to snapshots doesn't panic<br> <li> Tests validate that <code>ICMPStatus</code> and <code>PortMap</code>/<code>PortResults</code> are properly <br>deep-copied and not aliased</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-eb3740146940283b92c377e3c550ebe123ef3e010feaa2974a3029ef9260b08d">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parameterized_queries_test.go</strong><dd><code>Add parameterized query binding tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/parameterized_queries_test.go

<ul><li>Added test <code>TestDevicesGetDeviceBindsDeviceID</code> verifying device ID <br>parameter binding<br> <li> Added test <code>TestLogsGetRecentLogsBindsPollerID</code> verifying poller ID <br>parameter binding<br> <li> Added test <code>TestEventsGetEventsBindsMappedFilters</code> verifying multiple <br>filter parameter binding<br> <li> Added test <code>TestStructuredToolsRequireParameterizedExecutor</code> ensuring <br>non-parameterized executors are rejected<br> <li> Tests use <code>recordingParameterizedExecutor</code> mock to verify query and <br>parameter handling</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-330a1eb194c06c458ba999e3ce7346c4dc33dea154e15a8132dc6fc13bf3c296">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sweep_deepcopy_test.go</strong><dd><code>Add deep-copy validation tests for HostResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/models/sweep_deepcopy_test.go

<ul><li>Added comprehensive test <code>TestDeepCopyHostResult_NoAliasing</code> validating <br>deep-copy semantics<br> <li> Tests verify scalar fields match, pointer fields are copied, and <br>mutations don't affect source<br> <li> Validates <code>PortResults</code> slice, <code>PortMap</code> map, and <code>ICMPStatus</code> are properly <br>deep-copied</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-45bfc89e5b79e84e249bab30c33c776bd8465af54f17693e0bbc97c4eed0f003">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_deadlock_test.go</strong><dd><code>Add deadlock prevention static analysis test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/service_deadlock_test.go

<ul><li>Added static analysis test <code>TestCheckDoesNotRLockAndCallGetStatus</code> using <br>AST parsing<br> <li> Test embeds <code>service.go</code> source and verifies <code>Check</code> method doesn't hold <br><code>s.mu.RLock</code> while calling <code>GetStatus</code><br> <li> Prevents potential deadlock from recursive RWMutex read locking</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6a31b13924de8ba2b712fc5deb881056c50f7448bb61eb84efe82850eb08325e">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pgx_batch_helper_test.go</strong><dd><code>Add batch execution helper tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/pgx_batch_helper_test.go

<ul><li>Added test <code>TestSendBatchExecAll_EmptyBatchDoesNotSend</code> verifying empty <br>batches skip execution<br> <li> Added test <code>TestSendBatchExecAll_ExecErrorIncludesCommandIndexAndCloses</code> <br>verifying error reporting with command index<br> <li> Added test <code>TestSendBatchExecAll_CloseErrorReturnedWhenExecSucceeds</code> <br>verifying close errors are surfaced<br> <li> Tests use <code>fakeBatchResults</code> mock to simulate batch execution scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-67dd6237893aea0b294efd6b76f9aa138f4e8cd98424a3683f65ab9a7ce0372e">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client_conversion_test.go</strong><dd><code>Add SNMP type conversion tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/client_conversion_test.go

<ul><li>Added test <code>TestConvertVariable_OctetStringBytes</code> verifying <code>[]byte</code> <br>conversion to string<br> <li> Added test <code>TestConvertVariable_ObjectDescriptionBytes</code> verifying <code>[]byte</code> <br>conversion for object descriptions<br> <li> Added test <code>TestConvertVariable_StringTypesUnexpectedValueDoNotPanic</code> <br>verifying error handling for unexpected types<br> <li> Tests ensure conversions don't panic and return appropriate errors</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e382a2bd9f2612005f0a6239ae6a30272af91d68a70e25b7ac3c0ed8da3211cc">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pgx_batch_behavior_test.go</strong><dd><code>Add batch operation error handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/pgx_batch_behavior_test.go

<ul><li>Added test <code>TestInsertEvents_SurfacesBatchInsertErrors</code> verifying batch <br>insert error propagation<br> <li> Added test <code>TestStoreBatchUsers_SurfacesBatchInsertErrors</code> verifying <br>user batch error handling<br> <li> Tests use <code>fakePgxExecutor</code> and <code>fakeBatchResults</code> mocks to simulate batch <br>failures</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0c98da9a5d20f19ce43861711a001e0aebe953c4f004cb2bb38a245020f4e206">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identity_engine_partition_test.go</strong><dd><code>Add partition-scoped identifier resolution test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/identity_engine_partition_test.go

<ul><li>Added test <code>TestBatchLookupByStrongIdentifiers_PartitionScoped</code> <br>verifying partition-scoped identifier resolution<br> <li> Test validates that different partitions resolve to different device <br>IDs for same MAC address<br> <li> Uses mock to verify <code>BatchGetDeviceIDsByIdentifier</code> is called with <br>correct partition parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-77aee244beb622dec723a0a62d2d11785b5b76a9fe5df912ba559227d3f4ba70">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cnpg_registry_test.go</strong><dd><code>Add poller status upsert validation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/cnpg_registry_test.go

<ul><li>Added test <code>TestUpsertPollerStatusSQL_PreservesRegistrationMetadata</code> <br>verifying upsert query structure<br> <li> Test validates that registration metadata fields are not overwritten <br>on conflict<br> <li> Ensures only <code>last_seen</code>, <code>is_healthy</code>, and <code>updated_at</code> are updated</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e38716ee5b3614089e00e851d22d2c61e9934ebcc2b44b7aa4b79623251af869">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>client.go</strong><dd><code>Fix SNMP string type conversion error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/client.go

<ul><li>Removed <code>ObjectDescription</code> and <code>OctetString</code> from conversion map to <br>handle them separately<br> <li> Updated <code>convertObjectDescription</code> and <code>convertOctetString</code> to return <br><code>(interface{}, error)</code> and validate <code>[]byte</code> type<br> <li> Added explicit type checks with error handling for string conversion <br>types<br> <li> Removed unused conversion functions from map and added early-return <br>checks before map lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b5e92490b688495a040a2f6f5227dc83c46fc5e7ea59885f8285a3d6c868bd87">+37/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>memory_store.go</strong><dd><code>Use deep-copy for host result snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/memory_store.go

<ul><li>Updated <code>convertToSlice</code> to use <code>DeepCopyHostResult</code> instead of shallow <br>copy<br> <li> Updated <code>buildSummary</code> to use <code>DeepCopyHostResult</code> for host snapshots<br> <li> Fixed struct field alignment in <code>InMemoryStore</code> and initialization for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-54c761e2155455ac0e86e2cf1405610fe315d966ab17d4f008c3dd7227a05389">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base_processor.go</strong><dd><code>Use deep-copy for processor host snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sweeper/base_processor.go

<ul><li>Updated <code>collectShardSummaries</code> to use <code>DeepCopyHostResult</code> for host <br>snapshots<br> <li> Updated <code>processShardForSummary</code> to use <code>DeepCopyHostResult</code> when sending <br>hosts to channel<br> <li> Fixed trailing whitespace in <code>processTCPResult</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-40a89f977fa936cab19d62a659fb835665f646012674fbf3a8b09a8987917fbb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Fix potential RWMutex deadlock in Check method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/checker/snmp/service.go

<ul><li>Removed <code>s.mu.RLock()</code> and <code>defer s.mu.RUnlock()</code> from <code>Check</code> method<br> <li> Added comment explaining deadlock prevention: <code>GetStatus</code> performs its <br>own locking<br> <li> Prevents recursive RWMutex read locking that can deadlock with <br>write-preferring semantics</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c592649b582c62a85d1dd416ac7fb609e55531cb43c8199a15f4432ce8ae05d8">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mock_db.go</strong><dd><code>Update mock for partition-scoped identifier lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/mock_db.go

<ul><li>Updated <code>BatchGetDeviceIDsByIdentifier</code> mock signature to include <br><code>partition</code> parameter<br> <li> Updated mock recorder method to accept partition argument<br> <li> Added newline formatting for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-30e38f888d4849fc40d7ebb1559c2a84c43aa8cd13b3b89fd7ec6cf873b243c7">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>registry_test.go</strong><dd><code>Update registry tests for partition parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/registry_test.go

<ul><li>Updated all <code>BatchGetDeviceIDsByIdentifier</code> mock expectations to include <br>partition parameter<br> <li> Changes applied to <code>allowCanonicalizationQueries</code>, <br><code>TestProcessBatchDeviceUpdates_MergesSweepIntoCanonicalDevice</code>, and <br>other test functions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f010972d104404be52d2a8e6e784cb56e31194f90795a69571a12696bcbdc075">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>canon_simulation_test.go</strong><dd><code>Update DIRE simulation test for partition keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/registry/canon_simulation_test.go

<ul><li>Updated <code>setupDIREMockDB</code> to use <code>strongIdentifierCacheKey</code> for cache key <br>generation<br> <li> Updated mock <code>BatchGetDeviceIDsByIdentifier</code> to accept partition <br>parameter<br> <li> Updated <code>UpsertDeviceIdentifiers</code> mock to use <code>strongIdentifierCacheKey</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-73b73409b3941af4ac860561c87772763feca734fd8ab597f36e5e4047c6bf3c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>interfaces.go</strong><dd><code>Update Service interface for partition parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/db/interfaces.go

<ul><li>Updated <code>BatchGetDeviceIDsByIdentifier</code> interface signature to include <br><code>partition</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c230fe0c315251837357bfde4ae7f7b34080398d8e48af6bf78badb2124271f3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>server_test.go</strong><dd><code>Fix test file indentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/mcp/server_test.go

- Fixed indentation from spaces to tabs for Go style consistency


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0b91a426e8631fe9cc9109206e3e6d922ff1de7dfdee7b4c6518fbdd94e86c7a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint-nginx.sh</strong><dd><code>Update nginx entrypoint to use web-ng service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/compose/entrypoint-nginx.sh

<ul><li>Changed nginx upstream service from <code>web</code> on port 3000 to <code>web-ng</code> on port <br>4000<br> <li> Removed wait logic for <code>core</code> service on port 8090<br> <li> Simplified entrypoint to only wait for web-ng service</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0372d61e48b7bdb23bed91a7f72fc774fe36afca5ecafc97b170ed35be4e2e59">+4/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.css</strong><dd><code>Configure Tailwind CSS with daisyUI and custom themes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/assets/css/app.css

<ul><li>Configured Tailwind CSS with source scanning for CSS, JS, and template <br>files<br> <li> Integrated daisyUI plugin with custom dark and light theme <br>configurations<br> <li> Added custom Tailwind variants for LiveView loading states and dark <br>mode<br> <li> Configured transparent display for LiveView wrapper divs</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e2f1698b818ca68e34f2f330886b5dc3621fb6033b4414869c7e3d677aa4c4d3">+105/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>daisyui-theme.js</strong><dd><code>Add daisyUI theme plugin bundle for UI styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/assets/vendor/daisyui-theme.js

<ul><li>Added daisyUI theme plugin bundle with support for multiple color <br>themes<br> <li> Implemented theme configuration system with customizable color schemes <br>and design tokens<br> <li> Included MIT licensed daisyUI theme definitions for light and dark <br>modes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-1f651678246fddd353d5b865da740f0fd7f0a16d5e252a378d791ae43136c803">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>topbar.js</strong><dd><code>Add topbar progress bar library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/assets/vendor/topbar.js

<ul><li>Added topbar progress bar library for visual feedback during page <br>navigation<br> <li> Implemented canvas-based progress bar with gradient colors and shadow <br>effects<br> <li> Provided configuration options for bar thickness, colors, and <br>animation behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b33ec2270b5ebb791a0c96c3ff024f82d66d346be6d542374e5885273f7bc004">+138/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heroicons.js</strong><dd><code>Add Heroicons Tailwind CSS plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/assets/vendor/heroicons.js

<ul><li>Created Tailwind CSS plugin for Heroicons SVG icon integration<br> <li> Implemented dynamic icon loading from multiple icon sets (outline, <br>solid, mini, micro)<br> <li> Added CSS mask-based icon rendering with customizable sizing</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-435329705234b4577a06b84302017b73aaf264e7af376e6bfd5abbf71611d9bd">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.tool-versions</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-751af1a340658c7b8176fe32d7db9fadbe15d1d075daba1919a91df04155bc70">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+27/-119</a></td>

</tr>

<tr>
  <td><strong>Dockerfile.web-ng</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-92d43af1965575d56c3380ecc8a81024aac2ff36f039ec2d3839e9fc7852bc10">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nginx.conf.template</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-62ef305390094ce81632d493253e470ca46e7daa76da1079c131e41502975d07">+6/-138</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-593e5b1ccdb5f528a4b0f5d7dd56b10c4422aeb11cf7292bf4c21a93a7756340">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-5e5a5da59cb9f0b4f7a8fc3c492f1be70a9292fc0533fe4fc103a85f27f3c105">+0/-29</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-3fa8ff1eb6c2b79b5937f3b7e97d0eaa429475802e0e136d70e61f3ce8b996e1">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-68425fc01e3047a9fd103cfcb917fa84bdc3f2781539b29a5f0f983753d57627">+0/-148</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8bd336677c2048834707d9f86bcb964404304815695a2ebd7273203c57cb7c92">+0/-68</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6f0c5aff0b965fcdd9db0c5694e0687fa72e170a89c33bda18ec8f82f426ad33">+0/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-2860cadf010e37686782686da542b1669a8e860231acf8b00bbadbbde3f54719">+0/-34</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bc5b4da0f06380ea7f2f89c15b94cdbfc7c6637d3db0b6703950e2609f7933ff">+0/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bf83f1fb2e0bb30309a84bc3343bc28a06fef20726e1c8583b406a93697dfc87">+0/-68</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ad29ce951260d3acc52d2ff591319fda8dbf485bb420f3968f8a9dfd1e91c856">+0/-42</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-557ef0882398cb52535288f1dc8edd81197b0a34dc62ca68b69ecf1754d3c479">+0/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-888d2efd1371a95f95ba77bf4506d180c1fd65434603a56cf2e8a3ad495386ce">+0/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f3c3c8d9463a1c6eb3934bb6c516985accb7f58b402a0d5e414ff65c1c732bc3">+0/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6e956f86e942a3106c94ea3f1a1bd46210c035e9240be297a488b639449d3e90">+0/-85</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-7d7c4d6b4718fd5255ec47aa62dee71b5da2c83ff2160164603454379b618181">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-799ac314609701ea23f8321cd5e4464c24b9c4634ee8b863d104dc2955aa6eda">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bfc316cf42c3c49e04d2363e9ee566c1d78cd3d8830932590ddc8abe2e777a24">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b3d0f1681371e322ccc253767df5d32e59d23aaddfb979da0746932ef1f97139">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-5482ba561260689cb4331860e556a69f4e0c312d8b6a0636c4e354e80bfff88a">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-08fc870484787c82a4ca64544593d4fbeb34b7d2d09c0bd6f1ae1f1354ae1368">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-4aa7fc4af23187c7e80727f72cd233de9676cb832a0850271ea8c180dd50c140">+0/-29</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-cea28b6af37c67606e313f2233bd1ae7187f9a4e1289bef0823678c8346e6b7c">+0/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-dbf6e0bdd671feb4089a7d8897979220c1a3f7442d99cd6badf2c02cd80b4d03">+0/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-16748c17e91c4e6e2e591bec79735cf7c956cfd005e0aa7787d0893c04cf08d0">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-fcc4aa820ee62670cf4965e87b2e0206086d7bb9f83d4146f68a3d763ed66fd6">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-5a6bb224d3c0031de4edb02183b529c4e54b7d0c4f2972babcc848411436718f">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-1e72eebd22cd4f5b5250f5b168b102c3b6fcc5d1ef2418d71acba7a0e3efd340">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-eeff025d43ddd0d8d735cd97a9aa573b0d831f44190263c5cdcddce34d1a9b01">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-81a990985d497493238589e703ea366222940cc604a571ce21bfeca5bfc442e5">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f5daa5f8f49623f6cec383c2b7197ae8431b51bb217c391dd3f674a380bba00d">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-21ba4baae6c7dbf1e091af2f2cfde05086826dcd839802d6e26eaa407eab584c">+0/-35</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c00044e9668389895df2d518bf418b693b3a12ad3488e2926abbdd71b98644ba">+0/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-cb59e5a2e863f7206ac3be889b3cc23b7eef933fbc33909b0d4f19235eeacbd6">+208/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-381b711be98b0c138b5513beec105376f4b63e46d82bfd75e7d22e4b0eb3e6ff">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-52b58e4010c2df75f7534dc76212ed1c275e462f5f4be90fa0b947a5bfd407ce">+220/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8478335a646a61fa4a74ea2f9c784cd441632ec92dba1b3f8d5b5fed52c9db3d">+0/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e14559d7bc9392db00b7d08e31b875dd4fbe0eb15538a04ec4e9dbd8b342ad8c">+0/-61</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-da75158b3b75bf8129cbec0f47cd86dcee1b97f8cccb1b1864c628e11fb83beb">+0/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-7af7b9e5ec186b60f6082c416f1cf7fa777e26c7b67aa7a2fe5f582f3c558813">+0/-45</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-860d8d8d95eb220b8d6e5590df8982fec404e52dea8565587343d431998e54bb">+0/-60</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9031f16c5cff8b7150870d905750fef62ad51f9ec20faec52aa62a74efcb79a9">+0/-28</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ed59ef5f7b9f94cea669c81eccf7ae83d579c5ea60b4f139da3eb68a02e368ff">+0/-83</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-796f2e05e4b1942bcfd740f51f5f5a63cace288520ceee7a439936da6196521e">+0/-112</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-7306d84aa629841d30563d0ddbcc2178e690cdd564451cbf009ebdbfdcbf3e95">+0/-84</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-804cde784a8519f9f453950e7f5faf7eebe67a771a7c29a501f53acdd5ffac61">+0/-44</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-74ae971093987c8e2e0fae413c88feb5b5e95218869956d88808827005df0029">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9ef6c02134c8900f69fbd4326e8f1facbf6ac0cced8f09714c0776270840f24f">+0/-45</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-81ac6baf30e8d593daac5904fe8ee44954ea59b60cfebb932d6167039401ec70">+0/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b476498724d1ccfae69ca3db18d65fc2a18e629803fe277531948545ca36b944">+0/-46</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e7a2e1f30c6f53270296c7e92cf5828c71a4a21dc4ea2a6c1b4d74da304e87ac">+0/-24</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ca1b0821c2554f35858d70b8a41cd51bac6611ac04e7e16dfad75f38ed2ce930">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-69f23ca388bf44599fe256a2dedafc0e8af9fb346bb917efe6f2c95b84e971d7">+0/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0d3a5a254abeadabd0c30d04b56b43c8f4b43dcdb6c8f300d1f953fa602247d7">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-7120eaa6a5f458aa2e1649559057f77ecd7355c3eb9079a3cbe53fdfac97b93b">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-cd52b3fd553ef7792c277ff50c4e9a9e1f3499b62def55e845f1311f5da7eb0d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-a212262a53d3ee2d68753329b05835cd20f2aa7671ffa686b4a6083f1d330256">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0b26ad240d4dcd68f67721a1352e54bcf78ee404d2ee167feca6675008466f61">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-241d7df520e53d9bafd95027f32a00ffe31495c6bfaec479494a5904c4215d63">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9b1ddcbf90157cb6d07c63b0c435a434272e3279594c5510f2a3d297223fd672">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-2d6fc29f0ddfb9b6213d83339d0d93ef5196a7ec7fc0e6b07c587c5908894c95">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9024bbd8abac8c96b2d4e0437250ee344cf5f12560785561285afe82e21d4457">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-551f58cf66926ed96cb4df08f8de6bb718951933afbbcbb86831aa837b41d79f">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-2f311be222e7803de3df6b7b3361776eca39ecaa96c09f5699f260450154ec3d">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-113e7f6dcd42a481e54c270e3233214e97232f2c1788722655352a1e6d49590e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-3c4807d2b2ab7fb4b40fc23f5b929a2d0ffc4915da557ec96742b82b6d7b3fb8">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-fd19193e9fe30b9b73e8c397a9a274eafa39efe8cef21fd07190038fc867112c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-511a066de4507065281b37a979c77119b90e46e97e206f2e879f8af73d13c854">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-e8ea81126ba5d49a821706cd6479d176ac1ee40a496dbb38938d830ea94d3e0a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6aa430ae5e044c6f55358d45cd7b2368b1168a735aa4f84739c6102fa7769720">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bc74372977e86a0e3f64c1af49c0610fe4d80798113604c17298cba508433003">+0/-144</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-57a85c7ff6659407d8665b61c6d9d7b09c71a213d1aca1e5fd993c027c14cfc0">+0/-81</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-1ba2529c7b515076581e20414759e23c0d25c327e312d456620c98c2c0700f6a">+0/-43</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-4bcd11bed34206ce4102519db0e148b7b197fab33423d03712aa23475df761bc">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-9f15500fd74ac3845aec9f5a6a2b2024a019b2f9438ce92f47fe18a6d945ab09">+0/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-bd097cdff5fea1b8137a6f3fffb2dda7686b999f1e6e3889b4372481c1c37a66">+0/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-0534d758c6b8e27938b14175fe5a6ff9bf0ee3a352da208c3f651cab9a460736">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-5845d29d43f16fd852471b164a176e879de47eb15be4d4bcc32e27130a6095ec">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f7b9a49b7e16fb0ce430f87e5fe38160d9a072efe92259ca776fe6ee0449a7c9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8bad22e013f99a913f7db91e78970c89634e94cd39262d339a06e72734531ee4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-fa51756b168cdca03f99da7568ffe261ea59b0b33f5c7ac1de4781af378f55fc">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-b18156d1b4a0904f964884f6642aae45fd88d0ddcab58b0c699d236e34be3cee">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-a913209a981d4c6b3e8339293fcb062e02065c6485c215304d34a66dfca38997">+0/-39</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-8ea36913f5d5236389f519283c919ffd1c3d1124de5684b954873958051c8dbb">+0/-70</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-138a6873eaaab55e8974878fd16911bae1de7b8c708e006b996744428c2ecd5b">+0/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-6303af01f1a835c5774bb184afb2e37b9707b7b7c4283e3ee537b2b221ba614b">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-34df7c0ca139956ca9981cd0accef64a55838bf3057b72fc9dfcfa77ff19bd82">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-116bbee895b6dbf4fa6aaa32bd8fa799e2d2181a66071fb5e3129a46cc9154d7">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-c47d90ba805c8ea005726fc211e6179821ffa7e92b78054a338f6d5f6b81ab31">+0/-102</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-4a5a9adb68cec10a1c6b76d4788fe9b774c2f0034d1aa780814fb144fc458ad0">+0/-46</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-f34fa0a85f29520c314cde60d360176dff077bc0aae86fa99d96764c523ccac3">+0/-53</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-23212a3c01b653c3006efbbf6ca9782f767e74ce7aa85d7b71805dbb36d562ae">+0/-125</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-ad3bf3baec592ea2000de51abcd43628efd97c1524956d0580562e54b56515ad">+0/-129</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-239ceb7ed8d7185674ebc80a40aab82ea6955a159999df3ec7736870a416fac3">+0/-22</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-355450ac691dae6d2c3167233558588ea0e0ab969b5266044d4226b00e61ddab">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2163/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

