### PR TITLE
2147 rbac getrequiredroles bypasses wildcard when exact match lacks method roles

### DIFF
--- a/openspec/changes/fix-rbac-route-protection-wildcard-fallback/design.md
+++ b/openspec/changes/fix-rbac-route-protection-wildcard-fallback/design.md
@@ -1,0 +1,29 @@
+## Context
+`pkg/core/auth/rbac.go:getRequiredRoles` determines which RBAC roles are required for a given HTTP path + method using the `rbac.route_protection` config. The current implementation returns immediately on an exact path match, even when that exact match is a method-specific map that does not include the requested method. This causes wildcard protections (for example `/api/admin/*`) to be skipped.
+
+## Goals / Non-Goals
+- Goals:
+  - Prevent method-specific exact matches from bypassing wildcard protections when the method is not explicitly protected by the exact match.
+  - Preserve the ability for method-specific exact matches to override wildcard protections when the method is explicitly listed.
+  - Add tests that fail if this bypass reappears.
+- Non-Goals:
+  - Redesign the RBAC configuration schema.
+  - Change the middleware semantics where “no required roles” means “no role check”.
+  - Define or implement deterministic precedence between multiple overlapping wildcard patterns (unless required by follow-up work).
+
+## Decisions
+- Decision: Treat an exact path protection as applicable only if it yields at least one role for the requested method.
+  - Rationale: Method-specific maps are intended to scope protection to listed methods. Returning an empty role list should not disable more general protections that still apply.
+  - Result: `getRequiredRoles` will compute roles from the exact match and return them only when non-empty; otherwise it will continue evaluating wildcard patterns.
+
+## Risks / Trade-offs
+- Risk: Some deployments may have relied (unknowingly) on the bypass for access patterns.
+  - Mitigation: Treat this as a security bug fix; document the change and add tests demonstrating the intended behavior.
+
+## Migration Plan
+- No storage migration.
+- Code-only change in `pkg/core/auth`; roll out as a patch release after validation.
+
+## Open Questions
+- Should wildcard precedence be deterministic when multiple patterns match (for example, prefer the most-specific prefix match)?
+- Should method maps support an explicit “default/any method” key (for example `"*"`), and how should it interact with wildcards?

--- a/openspec/changes/fix-rbac-route-protection-wildcard-fallback/proposal.md
+++ b/openspec/changes/fix-rbac-route-protection-wildcard-fallback/proposal.md
@@ -1,0 +1,19 @@
+# Change: Fix RBAC route protection wildcard fallback for method-specific exact matches
+
+## Why
+GitHub issue #2147 (https://github.com/carverauto/serviceradar/issues/2147) reports a security bug in `pkg/core/auth/rbac.go:getRequiredRoles`: when an exact-path `route_protection` entry exists but does not define roles for the requested HTTP method, the code returns an empty role list and bypasses wildcard protections (for example `/api/admin/*`). This can unintentionally grant access to protected routes for authenticated users without the expected roles.
+
+## What Changes
+- Update RBAC route role resolution so exact path matches only take precedence when they yield required roles for the requested HTTP method; otherwise wildcard protections are still evaluated.
+- Add regression tests covering exact-match + method-map + wildcard combinations to prevent future bypasses.
+- Document the intended precedence rules for `route_protection` entries (exact vs wildcard; method-specific vs array).
+
+## Impact
+- Affected specs: `rbac-route-protection` (new)
+- Affected code: `pkg/core/auth/rbac.go`, `pkg/core/auth/*_test.go` (new/updated)
+- Compatibility: This is a security-hardening bug fix. Configurations that unintentionally relied on the bypass (exact match missing method allowing access) will become more restrictive.
+- Out of scope: Changing the `route_protection` schema, changing the meaning of “empty required roles” beyond the wildcard fallback behavior, or introducing deterministic precedence between multiple overlapping wildcard patterns.
+
+## Success Criteria
+- A request to a route matched by a wildcard protection does not become unprotected just because an exact path entry exists for the same route without roles for that method.
+- Unit tests reproduce the bypass case from issue #2147 and pass with the fix.

--- a/openspec/changes/fix-rbac-route-protection-wildcard-fallback/specs/rbac-route-protection/spec.md
+++ b/openspec/changes/fix-rbac-route-protection-wildcard-fallback/specs/rbac-route-protection/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Route protection falls back from exact method maps to wildcard patterns
+When `rbac.route_protection` contains both wildcard patterns (for example `/api/admin/*`) and an exact path entry for a concrete route, the core API MUST NOT bypass wildcard protections solely due to the presence of the exact path entry. If the exact path entry is a method-specific map and does not define roles for the requested HTTP method, the core API MUST continue evaluating wildcard patterns and apply any matching wildcard protection.
+
+#### Scenario: Exact match missing method falls back to wildcard protection
+- **GIVEN** `rbac.route_protection` includes `/api/admin/*: ["admin"]`
+- **AND** `rbac.route_protection` includes an exact entry for `/api/admin/users` with method-specific roles that only define `POST: ["superadmin"]`
+- **WHEN** a request is made to `GET /api/admin/users`
+- **THEN** the required roles include `admin` (from the wildcard protection)
+
+### Requirement: Method-specific exact matches override wildcard protection when defined
+When an exact path entry defines roles for the requested HTTP method, those roles MUST be used in preference to roles from wildcard protections.
+
+#### Scenario: Exact match method roles override wildcard roles
+- **GIVEN** `rbac.route_protection` includes `/api/admin/*: ["admin"]`
+- **AND** `rbac.route_protection` includes an exact entry for `/api/admin/users` with method-specific roles that define `POST: ["superadmin"]`
+- **WHEN** a request is made to `POST /api/admin/users`
+- **THEN** the required roles include `superadmin`
+- **AND** the required roles do not fall back to `admin` for that request
+
+### Requirement: RBAC includes regression tests for route protection resolution
+The core RBAC implementation MUST include unit tests that cover precedence and fallback behavior between exact path entries and wildcard patterns in `rbac.route_protection`.
+
+#### Scenario: Regression tests detect wildcard bypass
+- **GIVEN** a test configuration that includes a wildcard protection and an exact method map that does not define the requested method
+- **WHEN** the route protection resolution is exercised by tests
+- **THEN** tests fail if required roles are empty when a matching wildcard protection exists

--- a/openspec/changes/fix-rbac-route-protection-wildcard-fallback/tasks.md
+++ b/openspec/changes/fix-rbac-route-protection-wildcard-fallback/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Fix RBAC route protection wildcard fallback for method-specific exact matches
+
+## 1. Define expected behavior
+- [x] 1.1 Capture precedence rules for `route_protection` (exact match vs wildcard; array vs method map).
+- [x] 1.2 Identify affected configs (core.json, Helm config) and confirm they are compatible with the corrected behavior.
+
+## 2. Implement the fix
+- [x] 2.1 Update `getRequiredRoles` to fall back to wildcard matches when an exact match yields no roles for the requested method.
+- [x] 2.2 Ensure the fix preserves method-specific overrides when roles are defined for the method.
+
+## 3. Tests and validation
+- [x] 3.1 Add unit tests reproducing the bypass scenario from GitHub issue #2147.
+- [x] 3.2 Add unit tests proving method-specific exact matches still override wildcard roles for the same path/method.
+- [x] 3.3 Run `gofmt` and targeted `go test ./pkg/core/auth`.
+- [x] 3.4 Run `openspec validate fix-rbac-route-protection-wildcard-fallback --strict`.

--- a/pkg/core/auth/BUILD.bazel
+++ b/pkg/core/auth/BUILD.bazel
@@ -28,7 +28,10 @@ go_library(
 
 go_test(
     name = "auth_test",
-    srcs = ["auth_test.go"],
+    srcs = [
+        "auth_test.go",
+        "rbac_test.go",
+    ],
     embed = [":auth"],
     deps = [
         "//pkg/db",

--- a/pkg/core/auth/rbac.go
+++ b/pkg/core/auth/rbac.go
@@ -76,11 +76,17 @@ func getRequiredRoles(path, method string, routeProtection map[string]interface{
 
 	// Check for exact match first
 	if protection, exists := routeProtection[path]; exists {
-		return parseProtection(protection, method)
+		roles := parseProtection(protection, method)
+		if len(roles) > 0 {
+			return roles
+		}
 	}
 
 	// Check for wildcard matches
 	for pattern, protection := range routeProtection {
+		if !strings.HasSuffix(pattern, "/*") {
+			continue
+		}
 		if matchesPattern(path, pattern) {
 			return parseProtection(protection, method)
 		}
@@ -136,12 +142,12 @@ func HasPermission(user *models.User, permission string, config *models.RBACConf
 				if perm == "*" {
 					return true
 				}
-				
+
 				// Check exact match
 				if perm == permission {
 					return true
 				}
-				
+
 				// Check category wildcard (e.g., "config:*" matches "config:read")
 				if strings.HasSuffix(perm, ":*") {
 					category := strings.TrimSuffix(perm, ":*")
@@ -152,7 +158,7 @@ func HasPermission(user *models.User, permission string, config *models.RBACConf
 			}
 		}
 	}
-	
+
 	return false
 }
 

--- a/pkg/core/auth/rbac_test.go
+++ b/pkg/core/auth/rbac_test.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRequiredRoles_ExactMatchMethodMapFallsBackToWildcard(t *testing.T) {
+	routeProtection := map[string]interface{}{
+		"/api/admin/*": []string{"admin"},
+		"/api/admin/users": map[string]interface{}{
+			"POST": []string{"superadmin"},
+		},
+	}
+
+	roles := getRequiredRoles("/api/admin/users", "GET", routeProtection)
+	assert.Equal(t, []string{"admin"}, roles)
+}
+
+func TestGetRequiredRoles_ExactMatchMethodMapOverridesWildcard(t *testing.T) {
+	routeProtection := map[string]interface{}{
+		"/api/admin/*": []string{"admin"},
+		"/api/admin/users": map[string]interface{}{
+			"POST": []string{"superadmin"},
+		},
+	}
+
+	roles := getRequiredRoles("/api/admin/users", "POST", routeProtection)
+	assert.Equal(t, []string{"superadmin"}, roles)
+}


### PR DESCRIPTION
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?
