### PR TITLE
2144 user controlled cert dir enables arbitrary file read in mtls onboarding

### DIFF
--- a/docs/docs/edge-onboarding.md
+++ b/docs/docs/edge-onboarding.md
@@ -75,6 +75,11 @@ load balancers change:
 > Keep the metadata focused on connectivity. Arbitrary keys are persisted but
 > ignored by the bootstrap scripts.
 
+For mTLS packages, Core reads the CA certificate/key from a Core-side base directory
+(`edge_onboarding.mtls_cert_base_dir`, default `/etc/serviceradar/certs`). If you
+provide `ca_cert_path` / `ca_key_path` in `metadata_json`, they MUST resolve to
+paths within that directory; attempts to reference other paths are rejected.
+
 ---
 
 ## 3. Poller Onboarding (Current)

--- a/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/design.md
+++ b/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/design.md
@@ -1,0 +1,33 @@
+# Design: Fix edge onboarding mTLS cert_dir path traversal
+
+## Context
+The Core edge onboarding service can issue packages in mTLS mode. During package creation, Core reads a CA certificate and private key from disk in order to mint a client certificate for the edge component.
+
+Today, the CA file paths are derived from user-controlled metadata fields (`cert_dir`, `ca_cert_path`, `ca_key_path`). Although Core checks that `ca_*_path` are within `cert_dir`, `cert_dir` itself is not constrained to a trusted base directory.
+
+## Goals
+- Prevent authenticated users from causing Core to read arbitrary files from the filesystem during mTLS package issuance.
+- Keep operator flexibility to place CA material in a non-default directory via Core configuration.
+- Provide clear client errors when requests attempt to escape the allowed directory.
+
+## Non-Goals
+- Redesign the edge onboarding metadata schema beyond what is required to close the vulnerability.
+- Change how SPIFFE/SPIRE packages are generated.
+
+## Decisions
+- Decision: Introduce a Core-configured “mTLS CA base directory” (default `/etc/serviceradar/certs`) and enforce that any CA file reads are confined to it.
+- Decision: Validate paths using `filepath.Rel` (and optionally `filepath.EvalSymlinks` if needed) rather than prefix checks on raw strings.
+- Decision: Treat escape attempts as invalid requests (HTTP 400) and ensure Core does not attempt to read the referenced paths.
+
+## Risks / Trade-offs
+- Tightening validation may break workflows that relied on passing arbitrary filesystem paths via `metadata_json`. This is an acceptable trade-off for closing a security issue; operators can migrate by configuring the base directory appropriately.
+- Symlink traversal is not addressed by `filepath.Abs` alone; if the Core host’s CA directory contains attacker-controlled symlinks, additional hardening (EvalSymlinks / `openat`-style checks) may be required.
+
+## Migration Plan
+1. Ship the Core config option with default `/etc/serviceradar/certs`.
+2. Reject package creation requests that specify `cert_dir` outside the configured base directory.
+3. Update docs and examples to avoid implying that `cert_dir` can point anywhere on the Core host.
+
+## Open Questions
+- Should Core ignore user-provided `ca_cert_path` / `ca_key_path` entirely (always using `root.pem` / `root-key.pem`), or keep allowing overrides as long as they remain under the allowed base directory?
+- Should we tighten validation for `metadata_json.cert_dir` (used as a template variable) to prevent surprising edge-side file locations, even though it no longer influences Core-side CA reads?

--- a/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/proposal.md
+++ b/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/proposal.md
@@ -1,0 +1,26 @@
+# Change: Fix edge onboarding mTLS cert_dir path traversal
+
+## Why
+- Core’s edge onboarding mTLS flow reads CA files from paths derived from user-controlled `metadata_json` fields (`ca_cert_path`, `ca_key_path`), and previously coupled those reads to a user-controlled `cert_dir`.
+- An authenticated user can set CA paths to arbitrary files (for example `/etc/shadow`), causing unintended filesystem reads on the Core host during package issuance.
+- This enables unintended filesystem reads on the Core host during package issuance (`pkg/core/edge_onboarding.go:buildMTLSBundle`), which is a security vulnerability (GH issue #2144).
+
+## What Changes
+- Constrain mTLS CA certificate/key reads to an operator-configured base directory (default: `/etc/serviceradar/certs`) rather than a user-controlled directory.
+- Validate `ca_cert_path` and `ca_key_path` using path-safe checks (for example `filepath.Rel` against the configured base directory) and reject attempts to escape the allowed directory.
+- Return actionable client errors for invalid paths during package creation (HTTP 400 / invalid request), without attempting to read the referenced files.
+- Add regression tests demonstrating the traversal attempt and verifying the request is rejected.
+- Document the supported configuration and clarify which metadata keys are accepted for mTLS onboarding.
+
+## Impact
+- Affected specs: `edge-onboarding`
+- Affected code (expected):
+  - `pkg/core/edge_onboarding.go` (mTLS bundle generation + validation)
+  - `pkg/core/api/edge_onboarding.go` (request validation / error mapping, if needed)
+  - `pkg/models/config.go` (edge onboarding config additions)
+  - `docs/docs/edge-onboarding.md` (operator documentation)
+- Breaking/behavioral notes:
+  - Requests that previously set `metadata_json.ca_*_path` outside the configured allowed base directory will now be rejected.
+
+## Status
+- Security fix: prevents authenticated arbitrary file read during mTLS package issuance (GH-2144).

--- a/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/specs/edge-onboarding/spec.md
+++ b/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/specs/edge-onboarding/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: mTLS CA file access is confined to an operator-configured directory
+When issuing an edge onboarding package in mTLS mode, Core SHALL only read the CA certificate and private key from an operator-configured base directory (default: `/etc/serviceradar/certs`) and SHALL reject requests that attempt to reference paths outside that directory.
+
+#### Scenario: Reject user-controlled CA path escape attempt
+- **GIVEN** edge onboarding is enabled
+- **WHEN** an admin issues an mTLS edge package with `metadata_json` that sets `ca_cert_path` (or `ca_key_path`) to a path outside the configured base directory
+- **THEN** Core SHALL reject the request as invalid
+- **AND** Core SHALL NOT attempt to read the referenced CA cert/key paths
+
+#### Scenario: Allow default CA directory
+- **GIVEN** edge onboarding is enabled
+- **WHEN** an admin issues an mTLS edge package without overriding CA certificate/key paths
+- **THEN** Core SHALL read CA material from the configured base directory and mint the mTLS bundle

--- a/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/tasks.md
+++ b/openspec/changes/fix-edge-onboarding-mtls-cert-dir-validation/tasks.md
@@ -1,0 +1,12 @@
+## 1. Core validation + config
+- [x] 1.1 Add an operator-configurable base directory for mTLS CA material (default `/etc/serviceradar/certs`) under `EdgeOnboardingConfig`.
+- [x] 1.2 Update `edgeOnboardingService.buildMTLSBundle` to read CA material from the configured base directory (not user-controlled `cert_dir`).
+- [x] 1.3 Update CA cert/key path validation to use path-safe checks (for example `filepath.Rel`) and return `ErrPathOutsideAllowedDir` on escape attempts.
+- [x] 1.4 Ensure invalid-path failures are returned as `models.ErrEdgeOnboardingInvalidRequest` (HTTP 400) without reading the target files.
+
+## 2. Tests
+- [x] 2.1 Add regression tests for the GH-2144 traversal attempt (`cert_dir=/etc`, `ca_cert_path=/etc/shadow`) and assert rejection.
+- [x] 2.2 Add tests for allowed behavior (default cert dir; optional subdirectory inside the configured base dir).
+
+## 3. Documentation
+- [x] 3.1 Update `docs/docs/edge-onboarding.md` to document the allowed CA base directory behavior and the accepted metadata keys for mTLS onboarding.

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -253,6 +253,7 @@ type EdgeOnboardingConfig struct {
 	JoinTokenTTL           Duration                     `json:"join_token_ttl,omitempty"`
 	DownloadTokenTTL       Duration                     `json:"download_token_ttl,omitempty"`
 	PollerIDPrefix         string                       `json:"poller_id_prefix,omitempty"`
+	MTLSCertBaseDir        string                       `json:"mtls_cert_base_dir,omitempty"`
 }
 
 // SRQLConfig configures the external SRQL microservice integration.


### PR DESCRIPTION
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?
