### PR TITLE
fix(db): only process .up.sql migration files

### DIFF
--- a/pkg/db/cnpg_migrate.go
+++ b/pkg/db/cnpg_migrate.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"sort"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -80,6 +81,10 @@ func RunCNPGMigrations(ctx context.Context, pool *pgxpool.Pool, log logger.Logge
 	filenames := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
+			continue
+		}
+		// Only process .up.sql files; .down.sql files are for rollbacks only
+		if !strings.HasSuffix(entry.Name(), ".up.sql") {
 			continue
 		}
 		filenames = append(filenames, entry.Name())


### PR DESCRIPTION
The migration runner was processing both .up.sql and .down.sql files from the migrations directory. Since .down.sql sorts before .up.sql alphabetically, down migrations were being applied first, causing the otel_trace_summaries materialized view to be dropped instead of created.

This fix filters the migration files to only include .up.sql files. Down migrations are intended for explicit rollback operations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?
