### PR TITLE
Bugs/agent gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -452,12 +452,6 @@ services:
       - RELEASE_NODE=serviceradar_agent_gateway@agent-gateway
       - RELEASE_DISTRIBUTION=sname
       - RELEASE_COOKIE=${RELEASE_COOKIE:-serviceradar_dev_cookie}
-      # Datasvc gRPC client configuration
-      - DATASVC_HOST=datasvc
-      - DATASVC_PORT=50057
-      - DATASVC_SSL=true
-      - DATASVC_CERT_DIR=/etc/serviceradar/certs
-      - DATASVC_CERT_NAME=gateway
     volumes:
       - cert-data:/etc/serviceradar/certs:ro
       - ./docker/compose/ssl_dist.gateway.conf:/etc/serviceradar/ssl_dist.conf:ro

--- a/docker/compose/agent.mtls.json
+++ b/docker/compose/agent.mtls.json
@@ -12,8 +12,8 @@
     "server_name": "agent-gateway.serviceradar",
     "role": "agent",
     "tls": {
-      "cert_file": "agent.pem",
-      "key_file": "agent-key.pem",
+      "cert_file": "tenants/default/components/agent-001-default-chain.pem",
+      "key_file": "tenants/default/components/agent-001-default-key.pem",
       "ca_file": "root.pem"
     }
   },

--- a/docker/compose/generate-certs.sh
+++ b/docker/compose/generate-certs.sh
@@ -28,7 +28,7 @@ ORG_UNIT="Docker"
 
 # Default tenant for development (creates a "default" tenant CA)
 DEFAULT_TENANT_SLUG="${DEFAULT_TENANT_SLUG:-default}"
-DEFAULT_PARTITION_ID="${DEFAULT_PARTITION_ID:-partition-1}"
+DEFAULT_PARTITION_ID="${DEFAULT_PARTITION_ID:-default}"
 
 # Create certificate directory
 mkdir -p "$CERT_DIR"

--- a/elixir/serviceradar_agent_gateway/config/runtime.exs
+++ b/elixir/serviceradar_agent_gateway/config/runtime.exs
@@ -161,13 +161,13 @@ config :serviceradar_core, :spiffe,
 # =============================================================================
 # serviceradar_core Dependencies
 # =============================================================================
-# Pollers should not start the core database or Oban by default.
-# Pollers participate in the cluster but do NOT run ClusterSupervisor/ClusterHealth
-# (those are managed by core-elx, the cluster coordinator)
+# Agent gateway does not start the core database or Oban.
+# Cluster coordination is handled by core-elx; the gateway only joins.
 
 config :serviceradar_core,
   repo_enabled: System.get_env("SERVICERADAR_CORE_REPO_ENABLED", "false") in ~w(true 1 yes),
   vault_enabled: false,
+  datasvc_enabled: false,
   cluster_enabled: System.get_env("CLUSTER_ENABLED", "true") in ~w(true 1 yes),
   cluster_coordinator: false
 

--- a/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_registry_proxy.ex
+++ b/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_registry_proxy.ex
@@ -1,0 +1,58 @@
+defmodule ServiceRadarAgentGateway.AgentRegistryProxy do
+  @moduledoc """
+  Owns AgentRegistry entries for Go agents connected through the gateway.
+
+  Horde registry entries are tied to the registering process PID. gRPC request
+  handlers are short-lived, so this proxy registers agents on a stable PID and
+  updates their metadata/heartbeats.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias ServiceRadar.AgentRegistry
+  alias ServiceRadar.Cluster.TenantRegistry
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec touch_agent(String.t(), String.t(), map()) :: :ok | {:error, term()}
+  def touch_agent(tenant_id, agent_id, metadata) do
+    GenServer.call(__MODULE__, {:touch_agent, tenant_id, agent_id, metadata})
+  end
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:touch_agent, tenant_id, agent_id, metadata}, _from, state) do
+    case TenantRegistry.update_value(tenant_id, {:agent, agent_id}, fn existing ->
+           existing
+           |> Map.merge(metadata)
+           |> Map.put(:last_heartbeat, DateTime.utc_now())
+         end) do
+      {_new, _old} ->
+        {:reply, :ok, state}
+
+      :error ->
+        case AgentRegistry.register_agent(tenant_id, agent_id, metadata) do
+          {:ok, _pid} ->
+            {:reply, :ok, state}
+
+          {:error, {:already_registered, _pid}} ->
+            {:reply, :ok, state}
+
+          {:error, reason} ->
+            Logger.warning(
+              "Failed to register agent #{agent_id} for tenant #{tenant_id}: #{inspect(reason)}"
+            )
+
+            {:reply, {:error, reason}, state}
+        end
+    end
+  end
+end

--- a/elixir/serviceradar_agent_gateway/mix.exs
+++ b/elixir/serviceradar_agent_gateway/mix.exs
@@ -18,7 +18,16 @@ defmodule ServiceRadarAgentGateway.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :ssl, :crypto, :public_key],
+      extra_applications: [
+        :logger,
+        :ssl,
+        :crypto,
+        :public_key,
+        :phoenix_pubsub,
+        :horde,
+        :grpc,
+        :ranch
+      ],
       mod: {ServiceRadarAgentGateway.Application, []}
     ]
   end
@@ -58,7 +67,6 @@ defmodule ServiceRadarAgentGateway.MixProject do
         include_executables_for: [:unix],
         applications: [
           runtime_tools: :permanent,
-          serviceradar_core: :permanent,
           serviceradar_agent_gateway: :permanent
         ],
         steps: [:assemble, :tar],

--- a/elixir/serviceradar_core/lib/serviceradar/application.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/application.ex
@@ -183,6 +183,8 @@ defmodule ServiceRadar.Application do
         ServiceRadar.AgentTracker,
         # Identity cache for device lookups (ETS-based with TTL)
         ServiceRadar.Identity.IdentityCache,
+        # Preload tenant slug mappings for edge resolution
+        ServiceRadar.Cluster.TenantRegistryLoader,
         # DataService client for KV operations (used to push config to Go/Rust services)
         datasvc_client_child()
       ]

--- a/elixir/serviceradar_core/lib/serviceradar/cluster/tenant_registry_loader.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/cluster/tenant_registry_loader.ex
@@ -1,0 +1,74 @@
+defmodule ServiceRadar.Cluster.TenantRegistryLoader do
+  @moduledoc """
+  Loads tenant slug mappings into the in-memory TenantRegistry table on startup.
+
+  This ensures edge components can resolve tenant slugs to IDs via the cluster
+  without requiring direct database access.
+  """
+
+  use GenServer
+
+  require Logger
+  require Ash.Query
+
+  alias ServiceRadar.Cluster.TenantRegistry
+  alias ServiceRadar.Identity.Tenant
+
+  @retry_delay_ms :timer.seconds(5)
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    if repo_enabled?() do
+      send(self(), :load_slugs)
+    else
+      Logger.debug("[TenantRegistryLoader] Repo disabled; skipping slug preload")
+    end
+
+    {:ok, %{loaded?: false}}
+  end
+
+  @impl true
+  def handle_info(:load_slugs, state) do
+    case load_slugs() do
+      :ok ->
+        {:noreply, %{state | loaded?: true}}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[TenantRegistryLoader] Failed to preload tenant slugs: #{inspect(reason)}; retrying"
+        )
+
+        Process.send_after(self(), :load_slugs, @retry_delay_ms)
+        {:noreply, state}
+    end
+  end
+
+  defp load_slugs do
+    query =
+      Tenant
+      |> Ash.Query.for_read(:read)
+      |> Ash.Query.select([:id, :slug])
+
+    case Ash.read(query, authorize?: false) do
+      {:ok, tenants} ->
+        Enum.each(tenants, fn tenant ->
+          TenantRegistry.register_slug(to_string(tenant.slug), tenant.id)
+        end)
+
+        Logger.info("[TenantRegistryLoader] Loaded #{length(tenants)} tenant slugs")
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp repo_enabled? do
+    Application.get_env(:serviceradar_core, :repo_enabled, true) &&
+      Process.whereis(ServiceRadar.Repo)
+  end
+end

--- a/elixir/serviceradar_core/lib/serviceradar/edge/agent_config_generator.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/edge/agent_config_generator.ex
@@ -153,12 +153,22 @@ defmodule ServiceRadar.Edge.AgentConfigGenerator do
   # Load service checks assigned to this agent from the database
   defp load_agent_checks(agent_id, tenant_id) do
     try do
+      actor = %{
+        id: "system",
+        email: "gateway@serviceradar",
+        role: :admin,
+        tenant_id: tenant_id
+      }
+
       # Query for enabled checks assigned to this agent
       checks =
         ServiceCheck
-        |> Ash.Query.for_read(:by_agent, %{agent_uid: agent_id})
+        |> Ash.Query.for_read(:by_agent, %{agent_uid: agent_id},
+          actor: actor,
+          tenant: tenant_id
+        )
         |> Ash.Query.filter(enabled == true)
-        |> Ash.read!(tenant: tenant_id)
+        |> Ash.read!()
 
       Logger.debug("Loaded #{length(checks)} checks for agent #{agent_id}")
       {:ok, checks}

--- a/elixir/serviceradar_core/lib/serviceradar/edge/agent_gateway_sync.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/edge/agent_gateway_sync.ex
@@ -1,0 +1,166 @@
+defmodule ServiceRadar.Edge.AgentGatewaySync do
+  @moduledoc """
+  RPC helpers for agent-gateway to interact with core-owned data.
+
+  These functions are intended to run on core-elx nodes with
+  database access and should be invoked via :rpc.call from the
+  agent-gateway release.
+  """
+
+  require Logger
+
+  alias ServiceRadar.Infrastructure.Agent
+
+  @spec get_config_if_changed(String.t(), String.t(), String.t()) ::
+          :not_modified | {:ok, map()} | {:error, term()}
+  def get_config_if_changed(agent_id, tenant_id, config_version) do
+    ServiceRadar.Edge.AgentConfigGenerator.get_config_if_changed(
+      agent_id,
+      tenant_id,
+      config_version
+    )
+  end
+
+  @spec upsert_agent(String.t(), String.t(), map()) :: :ok | {:error, term()}
+  def upsert_agent(agent_id, tenant_id, attrs) do
+    actor = system_actor(tenant_id)
+
+    case Agent.get_by_uid(agent_id, tenant: tenant_id, actor: actor, authorize?: false) do
+      {:ok, %Agent{} = agent} ->
+        update_agent(agent, tenant_id, attrs, actor)
+
+      {:error, reason} ->
+        if not_found_error?(reason) do
+          create_agent(agent_id, tenant_id, attrs, actor)
+        else
+          Logger.warning("Failed to lookup agent #{agent_id}: #{inspect(reason)}")
+          {:error, reason}
+        end
+    end
+  end
+
+  @spec heartbeat_agent(String.t(), String.t(), map()) :: :ok | {:error, term()}
+  def heartbeat_agent(agent_id, tenant_id, attrs) do
+    actor = system_actor(tenant_id)
+
+    case Agent.get_by_uid(agent_id, tenant: tenant_id, actor: actor, authorize?: false) do
+      {:ok, %Agent{} = agent} ->
+        heartbeat_agent_record(agent, tenant_id, attrs, actor)
+
+      {:error, reason} ->
+        if not_found_error?(reason) do
+          create_agent(agent_id, tenant_id, attrs, actor)
+        else
+          Logger.warning("Failed to lookup agent #{agent_id}: #{inspect(reason)}")
+          {:error, reason}
+        end
+    end
+  end
+
+  defp update_agent(agent, tenant_id, attrs, actor) do
+    update_attrs =
+      attrs
+      |> Map.take([
+        :name,
+        :capabilities,
+        :host,
+        :port,
+        :spiffe_identity,
+        :metadata,
+        :version,
+        :type_id
+      ])
+      |> compact_attrs()
+
+    result =
+      if map_size(update_attrs) > 0 do
+        agent
+        |> Ash.Changeset.for_update(:gateway_sync, update_attrs)
+        |> Ash.update(tenant: tenant_id, actor: actor, authorize?: false)
+      else
+        {:ok, agent}
+      end
+
+    case result do
+      {:ok, updated} -> heartbeat_agent_record(updated, tenant_id, attrs, actor)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp create_agent(agent_id, tenant_id, attrs, actor) do
+    create_attrs =
+      attrs
+      |> Map.put_new(:type_id, 4)
+      |> Map.put(:uid, agent_id)
+      |> Map.take([
+        :uid,
+        :name,
+        :type_id,
+        :type,
+        :uid_alt,
+        :vendor_name,
+        :version,
+        :policies,
+        :poller_id,
+        :device_uid,
+        :capabilities,
+        :host,
+        :port,
+        :spiffe_identity,
+        :metadata
+      ])
+      |> compact_attrs()
+
+    Agent
+    |> Ash.Changeset.for_create(:register_connected, create_attrs)
+    |> Ash.create(tenant: tenant_id, actor: actor, authorize?: false)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp heartbeat_agent_record(agent, tenant_id, attrs, actor) do
+    heartbeat_attrs =
+      attrs
+      |> Map.take([:capabilities, :is_healthy])
+      |> compact_attrs()
+
+    agent
+    |> Ash.Changeset.for_update(:heartbeat, heartbeat_attrs)
+    |> Ash.update(tenant: tenant_id, actor: actor, authorize?: false)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp compact_attrs(attrs) do
+    attrs
+    |> Enum.reject(fn
+      {_key, nil} -> true
+      {_key, ""} -> true
+      {_key, []} -> true
+      {_key, %{} = value} -> map_size(value) == 0
+      _ -> false
+    end)
+    |> Map.new()
+  end
+
+  defp not_found_error?(%Ash.Error.Query.NotFound{}), do: true
+
+  defp not_found_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &match?(%Ash.Error.Query.NotFound{}, &1))
+  end
+
+  defp not_found_error?(_error), do: false
+
+  defp system_actor(tenant_id) do
+    %{
+      id: "system",
+      email: "gateway@serviceradar",
+      role: :admin,
+      tenant_id: tenant_id
+    }
+  end
+end

--- a/elixir/serviceradar_core/lib/serviceradar/infrastructure/agent.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/infrastructure/agent.ex
@@ -261,6 +261,12 @@ defmodule ServiceRadar.Infrastructure.Agent do
       change set_attribute(:modified_time, &DateTime.utc_now/0)
     end
 
+    update :gateway_sync do
+      description "Sync agent metadata from the agent-gateway"
+      accept [:name, :capabilities, :host, :port, :spiffe_identity, :metadata, :version, :type_id]
+      change set_attribute(:modified_time, &DateTime.utc_now/0)
+    end
+
     update :heartbeat do
       description "Update last_seen_time and health status (for connected agents)"
       accept [:is_healthy, :capabilities]

--- a/web-ng/lib/serviceradar_web_ng_web/live/agent_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/agent_live/show.ex
@@ -698,14 +698,4 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
   defp srql_module do
     Application.get_env(:serviceradar_web_ng, :srql_module, ServiceRadarWebNG.SRQL)
   end
-
-  # Safely extract agent ID from either Infrastructure.Agent structs or maps
-  # Structs use :uid, maps may use :agent_id or :key
-  defp get_agent_id(%ServiceRadar.Infrastructure.Agent{uid: uid}), do: uid
-
-  defp get_agent_id(agent) when is_map(agent) do
-    Map.get(agent, :uid) || Map.get(agent, :agent_id) || Map.get(agent, :key)
-  end
-
-  defp get_agent_id(_), do: nil
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/agent_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/agent_live/show.ex
@@ -42,17 +42,18 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
 
   @impl true
   def handle_params(%{"uid" => uid}, _uri, socket) do
-    # First check Horde registry for live agent
-    all_agents = ServiceRadar.AgentRegistry.all_agents()
+    # Load database record first (source of truth for tenant_id)
+    db_agent =
+      case srql_module().query("in:agents uid:\"#{escape_value(uid)}\" limit:1") do
+        {:ok, %{"results" => [agent | _]}} when is_map(agent) ->
+          Map.put(agent, "_source", "database")
 
-    Logger.debug(
-      "[AgentShow] All agents in Horde: #{inspect(Enum.map(all_agents, &get_agent_id/1))}"
-    )
+        _ ->
+          nil
+      end
 
-    live_agent =
-      Enum.find(all_agents, fn agent ->
-        get_agent_id(agent) == uid
-      end)
+    tenant_id = agent_tenant_id(db_agent, socket.assigns.current_scope)
+    live_agent = lookup_registry_agent(tenant_id, uid)
 
     Logger.debug(
       "[AgentShow] Looking up agent uid=#{inspect(uid)}, live_agent=#{inspect(live_agent != nil)}"
@@ -66,10 +67,10 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
         nil
       end
 
-    # Convert Horde data to agent map format (string keys for consistency)
+    # Convert registry data to agent map format (string keys for consistency)
     horde_agent =
       if live_agent do
-        %{
+        base = %{
           "uid" => uid,
           "agent_id" => Map.get(live_agent, :agent_id, uid),
           "status" => to_string(Map.get(live_agent, :status, :connected)),
@@ -81,24 +82,18 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
           "last_heartbeat" => Map.get(live_agent, :last_heartbeat),
           "connected_at" => Map.get(live_agent, :connected_at),
           "spiffe_identity" => Map.get(live_agent, :spiffe_identity),
-          "pid" => inspect(Map.get(live_agent, :pid)),
-          "_source" => "horde"
+          "_source" => "registry"
         }
+
+        case Map.get(live_agent, :pid) do
+          pid when is_pid(pid) -> Map.put(base, "pid", inspect(pid))
+          _ -> base
+        end
       else
         nil
       end
 
-    # Fall back to SRQL database query
-    db_agent =
-      case srql_module().query("in:agents uid:\"#{escape_value(uid)}\" limit:1") do
-        {:ok, %{"results" => [agent | _]}} when is_map(agent) ->
-          Map.put(agent, "_source", "database")
-
-        _ ->
-          nil
-      end
-
-    # Prefer Horde data (live) over database (may be stale)
+    # Prefer registry data (live) over database (may be stale)
     # Merge if both exist to get the most complete picture
     {agent, error} =
       case {horde_agent, db_agent} do
@@ -128,6 +123,36 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
      |> assign(:live_agent, live_agent)
      |> assign(:poller_node_info, poller_node_info)
      |> assign(:srql, %{enabled: false, page_path: "/agents/#{uid}"})}
+  end
+
+  defp agent_tenant_id(db_agent, current_scope) do
+    cond do
+      is_map(db_agent) && Map.has_key?(db_agent, "tenant_id") ->
+        Map.get(db_agent, "tenant_id")
+
+      match?(%{active_tenant: %{id: _}}, current_scope) ->
+        current_scope.active_tenant.id
+
+      match?(%{user: %{tenant_id: _}}, current_scope) ->
+        current_scope.user.tenant_id
+
+      true ->
+        nil
+    end
+  end
+
+  defp lookup_registry_agent(nil, _uid), do: nil
+
+  defp lookup_registry_agent(tenant_id, uid) do
+    case ServiceRadar.AgentRegistry.lookup(tenant_id, uid) do
+      [{pid, metadata} | _] ->
+        metadata
+        |> Map.put(:pid, pid)
+        |> Map.put(:agent_id, uid)
+
+      [] ->
+        nil
+    end
   end
 
   defp format_node(nil), do: nil
@@ -207,7 +232,7 @@ defmodule ServiceRadarWebNGWeb.AgentLive.Show do
           >
             <span class="size-2.5 rounded-full bg-success animate-pulse"></span>
             <span class="text-sm text-success font-medium">Live Agent</span>
-            <span class="text-xs text-base-content/60">Connected to cluster via Horde registry</span>
+            <span class="text-xs text-base-content/60">Connected via gateway registry</span>
           </div>
           <div
             :if={!@live_agent && Map.get(@agent, "_source") == "database"}

--- a/web-ng/lib/serviceradar_web_ng_web/live/infrastructure_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/infrastructure_live/index.ex
@@ -229,6 +229,7 @@ defmodule ServiceRadarWebNGWeb.InfrastructureLive.Index do
   @impl true
   def handle_event("refresh", _params, socket) do
     cluster_info = load_cluster_info()
+
     refreshed_gateways_cache =
       merge_gateways_cache(socket.assigns.gateways_cache, load_initial_gateways_cache())
 


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored agent architecture to support push-based gateway communication instead of pull-based approach

- Added `GatewayClient` for agent-to-gateway gRPC communication with reconnection and backoff logic

- Implemented `PushLoop` for periodic agent status pushing with enrollment, config polling, and state management

- Extended protobuf definitions with new gateway communication messages (`GatewayStatusRequest`, `GatewayStatusResponse`, `GatewayStatusChunk`) and agent configuration messages (`AgentHelloRequest`, `AgentHelloResponse`, `AgentConfigRequest`, `AgentConfigResponse`)

- Added new `AgentGatewayService` gRPC service with `Hello`, `GetConfig`, `PushStatus`, and `StreamStatus` methods

- Implemented NATS account management service with JWT/NKey cryptographic operations for operator bootstrap, tenant account creation, and user credential generation

- Added `NATSAccountService` gRPC service with six RPC methods for NATS JWT signing operations

- Implemented NATS operator management with key generation and JWT signing capabilities

- Added comprehensive test suites for NATS account service (474 lines) and user credential generation (440 lines)

- Updated agent `Server` struct to remove listener-based architecture and add gateway configuration fields (`GatewayAddr`, `GatewaySecurity`, `PushInterval`, `TenantID`, `TenantSlug`)

- Added NATS credentials file support in event writer service

- Added CLI handlers for NATS bootstrap operations and account management

- Added Elixir production configuration files for both core and agent-gateway applications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Agent["Agent Server"]
  PushLoop["PushLoop<br/>Status Collection"]
  GatewayClient["GatewayClient<br/>gRPC Connection"]
  Gateway["Agent Gateway<br/>Service"]
  NATS["NATS Account<br/>Service"]
  
  Agent -- "coordinates checkers" --> PushLoop
  PushLoop -- "periodic push" --> GatewayClient
  GatewayClient -- "Hello/GetConfig/PushStatus" --> Gateway
  Gateway -- "JWT operations" --> NATS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>monitoring.pb.go</strong><dd><code>Add gateway communication and agent configuration proto messages</code></dd></summary>
<hr>

proto/monitoring.pb.go

<ul><li>Updated proto file path reference from <code>monitoring.proto</code> to <br><code>proto/monitoring.proto</code> in source comment<br> <li> Renamed all internal file descriptor variables from <br><code>file_monitoring_proto_*</code> to <code>file_proto_monitoring_proto_*</code> for <br>consistency<br> <li> Added <code>gateway_id</code> field to <code>StatusRequest</code>, <code>ResultsRequest</code>, <br><code>StatusResponse</code>, and <code>ResultsResponse</code> messages<br> <li> Added <code>gateway_id</code> field to <code>ResultsResponse</code> with getter method<br> <li> Added three new message types: <code>GatewayStatusRequest</code>, <br><code>GatewayStatusResponse</code>, and <code>GatewayStatusChunk</code> for agent-to-gateway <br>communication<br> <li> Added <code>GatewayServiceStatus</code> message type to represent individual <br>service status in gateway requests<br> <li> Added four new agent configuration message types: <code>AgentHelloRequest</code>, <br><code>AgentHelloResponse</code>, <code>AgentConfigRequest</code>, <code>AgentConfigResponse</code>, and <br><code>AgentCheckConfig</code><br> <li> Added new <code>AgentGatewayService</code> gRPC service with methods: <code>Hello</code>, <br><code>GetConfig</code>, <code>PushStatus</code>, and <code>StreamStatus</code><br> <li> Updated message type count from 13 to 24 and service count from 2 to 3</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-4f7e955b42854cc9cf3fb063b95e58a04f36271e6a0c1cb42ea6d7953dd96cc4">+1312/-225</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_account_grpc.pb.go</strong><dd><code>Add NATS account service gRPC definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/nats_account_grpc.pb.go

<ul><li>New file containing gRPC service definitions for NATS account <br>management<br> <li> Implements <code>NATSAccountService</code> with six RPC methods: <code>BootstrapOperator</code>, <br><code>GetOperatorInfo</code>, <code>CreateTenantAccount</code>, <code>GenerateUserCredentials</code>, <br><code>SignAccountJWT</code>, and <code>PushAccountJWT</code><br> <li> Provides both client and server implementations with proper error <br>handling and interceptor support<br> <li> Includes comprehensive documentation for each method describing NATS <br>JWT signing operations</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-af98ae5f073d25a2ea0a044c996542fc65d215f6a70f14a9fba0447d87b34e11">+376/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Refactor agent server for push-based gateway architecture</code></dd></summary>
<hr>

pkg/agent/types.go

<ul><li>Removed <code>proto.UnimplementedAgentServiceServer</code> embedding from <code>Server</code> <br>struct (no longer needed for push-mode architecture)<br> <li> Removed <code>listenAddr</code> field from <code>Server</code> struct<br> <li> Removed <code>ListenAddr</code> field from <code>ServerConfig</code> struct<br> <li> Added gateway configuration fields: <code>GatewayAddr</code>, <code>GatewaySecurity</code>, and <br><code>PushInterval</code> for push-based architecture<br> <li> Added multi-tenant configuration fields: <code>TenantID</code> and <code>TenantSlug</code> for <br>tenant routing<br> <li> Updated <code>Security</code> field tag from <code>hot:"rebuild"</code> to <code>omitempty</code> for <br>consistency<br> <li> Updated comments to clarify push-mode operation where <code>Server</code> <br>coordinates checkers and <code>PushLoop</code> handles gateway communication</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e3a3767c816cdb568a387a32243f7348046f1f3445549cc06368870c914496cd">+13/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_bootstrap.go</strong><dd><code>CLI handlers for NATS bootstrap and account management</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cli/nats_bootstrap.go

<ul><li>Implements CLI handlers for NATS bootstrap operations including <br><code>nats-bootstrap</code>, <code>admin nats generate-bootstrap-token</code>, and <code>admin nats </code><br><code>status</code> subcommands<br> <li> Provides local and remote bootstrap modes with support for operator <br>initialization, system account generation, and platform account setup<br> <li> Generates NATS server configuration files, JWT resolver directories, <br>and credential files with proper file permissions<br> <li> Includes verification mode to validate existing NATS bootstrap <br>configuration and tenant listing functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-2176d03ba6ab4ccc1b0587a4727171546eecf6123e4df815ead583aaab062457">+961/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_account_service.go</strong><dd><code>gRPC service implementation for NATS account operations</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/datasvc/nats_account_service.go

<ul><li>Implements <code>NATSAccountServer</code> gRPC service for NATS JWT/NKey <br>cryptographic operations with stateless design<br> <li> Provides operator bootstrap, tenant account creation, user credential <br>generation, and JWT signing capabilities<br> <li> Manages resolver connections for pushing account JWTs to NATS system <br>via <code>$SYS</code> subject<br> <li> Includes mTLS-based authorization, file-based JWT resolver support, <br>and proper connection lifecycle management</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3e814328b5d5bddca9cd4b0ca021a975cf416afdc059e454452580a4ce751320">+888/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push_loop.go</strong><dd><code>Agent push loop implementation for gateway communication</code>&nbsp; </dd></summary>
<hr>

pkg/agent/push_loop.go

<ul><li>New file implementing <code>PushLoop</code> for periodic agent status pushing to <br>gateway<br> <li> Manages agent enrollment, config polling, and status collection from <br>services and checkers<br> <li> Includes thread-safe state management with mutex protection for <br>interval and enrollment status<br> <li> Implements check type mapping, address building, and source IP <br>detection logic</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5f0d59be34ef26b449d7f5fd2b198a29b277936b9708a699f7487415ed6c2785">+869/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>operator.go</strong><dd><code>NATS operator management and JWT signing implementation</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/nats/accounts/operator.go

<ul><li>New file providing NATS operator key management and JWT signing <br>capabilities<br> <li> Implements <code>Operator</code> struct for managing operator keys and signing <br>account claims<br> <li> Includes bootstrap functionality for creating new operators or <br>importing existing ones<br> <li> Provides utility functions for generating operator, account, and user <br>keys with base64 encoding support</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-14ae6d6482381ca8bbbd5dc42b4a5caa04269601624c8e7dc1941567f8e874d8">+476/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateway_client.go</strong><dd><code>Gateway client for agent-gateway gRPC communication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/agent/gateway_client.go

<ul><li>New file implementing <code>GatewayClient</code> for agent-gateway communication<br> <li> Manages gRPC connection lifecycle with reconnection and backoff logic<br> <li> Implements status pushing, streaming, and enrollment (Hello) RPC calls<br> <li> Includes security provider integration and connection state management</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-54aa63b6f05aabb0db096685e5be714c0c6d5c5a892310f048ff2ff8a542191f">+473/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>NATS credentials file support in event writer service</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/consumers/db-event-writer/service.go

<ul><li>Added support for NATS credentials file configuration in connection <br>setup<br> <li> Trims whitespace from <code>NATSCredsFile</code> path before applying to connection <br>options<br> <li> Enables authenticated NATS connections using credentials files</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-9f9f48b11e7670c7ae374abc41327adf4617972b214f1c168e9da53d3cd7b609">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>prod.exs</strong><dd><code>Add Elixir production configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/config/prod.exs

<ul><li>New production configuration file for Elixir application<br> <li> Sets logger level to <code>info</code> for production environment<br> <li> Includes note that production configuration is typically set via <br><code>runtime.exs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-4fe837307f8710c783ecb9ae7595bb7bb9ec37d8522248bd081fa256803c3e92">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prod.exs</strong><dd><code>Production configuration for Elixir application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_agent_gateway/config/prod.exs

<ul><li>Adds production configuration file for Elixir application with logger <br>level set to info</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5fdc859dfda96a02326392f61218325913f22f9f0c75a1276ee940d5db9fc62b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Code generation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nats_account.pb.go</strong><dd><code>Generated protobuf code for NATS account service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/nats_account.pb.go

<ul><li>Generated protobuf Go code for NATS account management service with 15 <br>message types and 1 enum<br> <li> Defines data structures for operator bootstrap, tenant account <br>creation, user credential generation, and JWT signing<br> <li> Includes message types for account limits, subject mappings, <br>permissions, and resolver operations<br> <li> Implements gRPC service interface for NATSAccountService with 6 RPC <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-49eb93c28e2d86d8dcf4ee78fd24bed498cf3fcfaa8e49849a36e70980420087">+1266/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kv.pb.go</strong><dd><code>Proto file path normalization in generated code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/kv.pb.go

<ul><li>Updated proto file path references from <code>proto/kv.proto</code> to <code>kv.proto</code> in <br>source comments and descriptor variables<br> <li> Changed all <code>file_proto_kv_proto_*</code> variable names to <code>file_kv_proto_*</code> <br>throughout the generated code<br> <li> Updated raw descriptor string to reflect the shorter proto path<br> <li> Maintained all functionality while standardizing file path references</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-0b9bbdd1cf0f65de86dd5ee0c824e5d35326bb4b8edcf1c97b61864493f4477f">+83/-83</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nats_account_service_test.go</strong><dd><code>NATS account service test suite with comprehensive coverage</code></dd></summary>
<hr>

pkg/datasvc/nats_account_service_test.go

<ul><li>New comprehensive test suite for <code>NATSAccountServer</code> with 474 lines of <br>test coverage<br> <li> Tests account creation, user credential generation, JWT signing with <br>various configurations<br> <li> Includes tests for authorization context, limits, subject mappings, <br>and error handling<br> <li> Validates proto conversion functions for account limits, credential <br>types, and user permissions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3d1ee22d8514e26752c45da92cfacb867a80d29cb8bfc3682b5784d123bcfc52">+474/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user_manager_test.go</strong><dd><code>User credential generation test suite with type-specific validation</code></dd></summary>
<hr>

pkg/nats/accounts/user_manager_test.go

<ul><li>New test suite with 440 lines covering user credential generation <br>functionality<br> <li> Tests credential generation for collector, service, and admin user <br>types<br> <li> Validates custom permissions, expiration handling, and JWT claims <br>verification<br> <li> Includes tests for invalid seeds, wrong key types, and unique key <br>generation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-000364a4950aac254d71c594f4c09b87abd8a8993f855d7a71cb248847cb82ce">+440/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>.bazelignore</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-a5641cd37d6ad98b32cdfce1980836cc68312277bc6a7052f55da02ada5bc6cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.bazelrc</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+171/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MODULE.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Makefile</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README-Docker.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-9fd61d24482efe68c22d8d41e2a1dcc440f39195aa56e7a050f2abe598179efd">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-884fa9353a5226345e44fbabea3300efc7a87dfbcde0b6a42521ca51823f1b68">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-0e80ea46aeb61a873324685edb96eae864c7a2004fbb7ee404b4ec951190ba10">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mix_release.bzl</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-86ec281f99363b6b6eb1f49e21d83b7eeca93a35b552b9f305fffc6855e38ccd">+120/-49</a></td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5b1bc8fe77422534739bdd3a38dc20d2634a86c171265c34e1b5d0c5a61b6bab">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-61358711e980ccf505246fd3915f97cbd3a380e9b66f6fa5aad46749968c5ca3">+170/-74</a></td>

</tr>

<tr>
  <td><strong>monitoring.proto</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-b56f709f4a0a3db694f2124353908318631f23e20b7846bc4b8ee869e2e0632a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-bce0f4ca6548712f224b73816825d28e831acbbff7dbed3c98671ed50f65d028">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-2c4395fee16396339c3eea518ad9bec739174c67c9cedf62e6848c17136dd33e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-05038f3867985e757de9027609950e682bad6d1992dac6acd7c28962a3c65dc4">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>grpc_server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e4564a93f6cf84ff91cd3d8141fc9272ec9b4ec19defd107afa42be01fcfed5b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>message_processor.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-9fcbc5358a9009e60a8cd22d21e5a9ea652787c727732d0b869e0865495114c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-97f7335def0ad5d644b594a1076ae2d7080b11259cbb8de22c7946cc8e4b39f8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer-with-otel.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-68375f1f7847e1fbdf75664f6be65b1ad94ae6ce86ed73fc5964d65054668acb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-4d308af9802a93a0f656e8c02a3b5fcd8991407bb18360f087470db74e1f9524">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-c62c0139ebdb337369f4067567cd2c52b8e7decb3ddfabc77f9f67b2f6e5789c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5e7731adfb877918cd65d9d5531621312496450fd550fea2682efca4ca8fe816">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-af9f49f931e282dca53d1f0521b036d222fe671f77e61a876a84cf4c6d7cca4d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats_output.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-a82e2e4d413539bf0b414b5629665b19648447523994cba639c4d1238aa5a0c1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-c64b9ace832b8ea57a2be62f84166e03bb1904882635d444ec76a880cdf14cc0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-abbaec651da3d6af96b482e0f77bb909b65dbe0cabd78b5803769cc9dab0a1b0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats_output.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-6b585ea3564a481174e04da1270e2e13edd4e2b980d02a2652d6d21e6d82a498">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3891f667deb20fd26e296d3e2742c57378d3764fe1743118e612465ae360391f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-c89b88ba4d2bf0a054d0ba69a672a92c30140b8d19503d67b980a218ffe3106d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-33b655d8730ae3e9c844ee280787d11f1b0d5343119188273f89558805f814ba">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.elx.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-9562070d7ad4a3e9b2d06567008cf35de1d96448d914b3b45bf6c36d97cdd914">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.spiffe.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-603fd9e7d40841d174f26b95d0cb0c9537430bf3f7a5da3ccbba4ea3d8ac66c9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+319/-269</a></td>

</tr>

<tr>
  <td><strong>Dockerfile.agent-gateway</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-332bc81a932ae08efa711a71b60fe0954d99bf17ebdab00a3baaa177a44de8b0">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.core-elx</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5ec7a971285669999af442a0c7f141c34f7fd9180257307f5c4ed12f789a2182">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.poller-elx</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-966cdcf55b7defa4f9fd83a15c55a0e1106430e6e20926c1181187e95ed8d87e">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.web-ng</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-92d43af1965575d56c3380ecc8a81024aac2ff36f039ec2d3839e9fc7852bc10">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent-minimal.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-1f09fad94636c90373af8e270f6ba0332ae4f4d1df50a4909729280a3a9691e6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5d33fe703515d03076d31261ecf946e9c6fc668cf5bf65099d49b670739e455e">+5/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-008f2216f159a9bd5db9cc90baaf6f1e64487df7af05b56ab3b9d6c4946aa95f">+7/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.gitkeep</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-d72c41aab2d6f2c230a4340dfefe7917cdd12bed942c825aa0d4c9875a637bac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3f2719d3dbfe042e8383739e3c78e74e5f851a44e5e46bea8e79c4b79fdcc34f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3a45619e57f1e6e9a31486ec7fffb33ef246e271f82bac272ee0a946b88da70a">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db-event-writer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-7a33f95f7545499abf0ed9fc91b58499ab209639e4885019579c959583fc7496">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-83d6800b184a5233c66c69766286b0a60fece1bc64addb112d9f8dc019437f05">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-824f8797b418d4b9f5ea41e4a3741a0ed64b881f343072464489a76b7ea01008">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-8298241543b4744a6ac7780c760ac5b5a0a87ba62de19c8612ebe1aba0996ebd">+216/-10</a></td>

</tr>

<tr>
  <td><strong>nats.docker.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-06f2012494f428fe1bfb304972061c2094e0d99da88ba9af6914f7776872e6eb">+16/-160</a></td>

</tr>

<tr>
  <td><strong>netflow-consumer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-f15920e8498a24f71ce3eec4f48fe8fefbb1765a90362998af779a660fcef9e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-d4af38790e3657b7589cd37a7539d5308b032f11caba7aa740ddc86bf99f4415">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_hba.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-7bd5f7292054916c7e5997f4c84ac9ec07d4c945621a48936c2aed0575fb96eb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_ident.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e7b8ce062e32c61fdc3bcc9e525c1f1df1c8008fbc02b11409e58c67baa17cc5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.core.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-08d49d8621b581d1a9aa5c456f61e8c5774e021083c982cbb514019f915a1701">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.gateway.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-4a43a8290d45ac68592000e7ef51afe78b4213090155bd42aafb46e66130f7ae">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.poller.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-3373e5d02bd9a19c75819948cf829086dc9c02f41f30c78759beb7038c428d3e">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.web.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-cef5be462ddb059fdfdeb9fd7c5cd70e656c4cd8b6ae1fe3fe312557b3da80ac">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trapd.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-1ab1a0e03e63bc02e0ef31992a7187a377927272ed2060150b40d44cc0ea3357">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e060a3164cdc2746e0d9ad000fcf43c4bcdb05f4a41c586d7220e2ff2a7df01d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-0e4db31c224a8f72ae8e870a849e38a59d74a2c7f7b04347b0b3eb07e20c5a80">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>push_targets.bzl</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-4af33fe62caba04b6d479589c16cfb85babc39bae5c92595d4d4e31660738513">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>architecture.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-90abd06467420fd89391fd1a4d75ceb1f6a9381de4d13a95fffe606abff38d37">+58/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ash-api.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-1cb48a12148688dc640f42675d0b3c2458ecc40175f4ae7eef4b07bdc2ede3a3">+305/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ash-authentication.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e3d22dc8d6917661b980dd9c7e08bdc07fad4d225b10c60885b091a9cdd20425">+244/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ash-authorization.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-72abeea2439e2281b6f998db2d11a73fe3ab393898125c466f0b16e7a49d3088">+283/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ash-domains.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-bc78325c5ea4c6839212536a43336a231175450738af14f4173be663acf2fe49">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ash-migration-guide.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e730373f07f6656d00327de02b4aa64e13809aadb3bf5478a4c60041ee431ad8">+339/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-setup.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-8604269dffb3ce4133e48cab374ca8e97745d0efbdef67cad792aeb5945fe5ec">+39/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>edge-agents.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-df8f4b6b6cd8fb926f9204b2bab85ec4f393286d1b25d8a62d2debd357dd651d">+253/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>edge-onboarding.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-f32fbefcc4dd23b0f2146015630a411099012e8bf56ea7b9d52ae8b2a83ac3e3">+316/-273</a></td>

</tr>

<tr>
  <td><strong>security-architecture.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-49e33c2fc609030af8a64af34016a22e9e86c0f3781acec5a9e6d0f7ccf5dc09">+238/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>spiffe-identity.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-6a3f0bdce99eb15d1075805cb5101594398f81ad92aa4eea9b27bb7545098db1">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting-guide.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-343b87dd0b430b3f99b16d32200c353bb6e3d7bbb185da3c1b3effc3a03e7f2a">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-00c928e77e8bf2f741a35e42e304acd2f2d4b8546532a5125a717924f2bde5dc">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-aa8f6a4e89041a3423f2299efab4bb1b5d13358d445b3c6e35cc46f527dbaa7b">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-abaac0167f05b505cf4bc5c5d375ae769001d8cc20120919941748c79681bbae">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dev.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-378e53cb66373073730a5d7ceba4973777eb84ae419c8a38472e3f69c3056fe9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-842568fafa717a8064203543d674517fd28ad7dd2a4d3f0f157d274cfda4f18b">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-00c8b58b49024f5d6f37ba40ac310a571e5a1b47fc16819423dc42f3035bc175">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_client.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-82bf77f47ac3b0001b036f0f22944d07bf894f1ee07b912e0ecab959eb8d5c53">+472/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agent_gateway_server.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-369a368073dc8ec1140bcea699005a1ce97a90cd59629df0bd18c71c7ffaae9f">+912/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agent_registry_proxy.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-ec1db726cca7e8b741173f1060f570b58d4ed32f3238a1979e8ba600c2af9c96">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>application.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-fc8dfd7489f127775b1f0baf09cea0cdf77b825dd5f92540e126a43cb246f5b2">+313/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5ba6871060dcff48aabea128b381e2d121bbb32256be1066c31dba447dc10813">+363/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>endpoint.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-ba09da2cb13f93e8b0f8d1dad1a214444239ef82ccd052a1e580f1fd1173d3d4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>status_processor.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-2d04050dff3ba2cc8153559e33a892f5f421982bf6dcbda7172857b3bf398a02">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>task_executor.ex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5779481787c6634825d987f45daa3d38f8010f4476f108dd14befcd275a2becf">+435/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mix.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-0230a6c5cfe38c579eedeae533c0ae08389c513592b55ab18f9ecca34edbdef7">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env.sh.eex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-e9df1de6119d13ee07c13d3368d94d8d5bf5e4bfb8eafa88296d92ca8cfba3d8">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-poller.service</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-09a1230ce7d28b7c4ecc829f950ab86e06e519a57de9f8f072c47430db58de9a">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vm.args.eex</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-94b4c9aef90071b4b2f63e05a89e3f4b1aa385ca4dfc299c606179dce3fdc6df">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registration_test.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-9a5e2ee4c17c6db1518f26ff99f0dfc6465038eaa839794c7415002662f7fb31">+235/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_helper.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-438a6880b1ce83b9bc82deacc98898368920b156c596305b0cdf6b8ff0ed7b06">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.formatter.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-791d4757cee68d168d8ab62d3eca6562470207fa6b3ccbf124e35c3fbd9de875">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-f1e707ff2843703a98d4752b3a3730c080c75772dbb5dbff1221f66af0678bc7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5dc9fa4d00db77d9f3e08a76ec06c2e2d703a7976ac2531af5edd9e3d1175b56">+269/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-42b3888cc53d9dcf4ebc45ec7fffb2c672b129bffe763b6c76de58e4678a13a8">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dev.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-a18ef01363a8ee26ebf4b56399d88607b4cf7934c597d6d3085041195b06ab5b">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.exs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-5d045e2af9f15590a9745058e25a00380ad7a2cc363d0a9934715bd11ea8eef3">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2223/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

