### PR TITLE
Fix/agent gateway genserver

### DIFF
--- a/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_gateway_server.ex
+++ b/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_gateway_server.ex
@@ -586,6 +586,8 @@ defmodule ServiceRadarAgentGateway.AgentGatewayServer do
     end
   end
 
+  defp normalize_partition(_partition), do: "default"
+
   defp normalize_message(msg, source) do
     max_bytes =
       case source do
@@ -606,12 +608,17 @@ defmodule ServiceRadarAgentGateway.AgentGatewayServer do
     end
   end
 
-  defp normalize_partition(_partition), do: "default"
-
   # Record metrics for the push operation
   defp record_push_metrics(agent_id, service_count) do
-    # TODO: Integrate with telemetry/metrics system
-    Logger.debug("Recorded push metrics: agent=#{agent_id} services=#{service_count}")
+    :telemetry.execute(
+      [:serviceradar, :agent_gateway, :push, :complete],
+      %{service_count: service_count},
+      %{
+        agent_id: agent_id,
+        gateway_id: Config.gateway_id(),
+        domain: Config.domain()
+      }
+    )
   end
 
   defp normalize_capabilities(capabilities) do

--- a/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/application.ex
+++ b/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/application.ex
@@ -30,9 +30,11 @@ defmodule ServiceRadarAgentGateway.Application do
   - `GATEWAY_ID` - Unique identifier for this gateway
   - `GATEWAY_DOMAIN` - The domain this gateway handles
   - `GATEWAY_GRPC_PORT` - gRPC port for receiving agent pushes (default: 50052)
-  - `GATEWAY_TENANT_ID` - Tenant UUID for multi-tenant deployments
-  - `GATEWAY_TENANT_SLUG` - Tenant slug for multi-tenant deployments
+  - `GATEWAY_CAPABILITIES` - Comma-separated list of capabilities (icmp, tcp, http, etc.)
   - `CLUSTER_HOSTS` - Comma-separated list of cluster nodes to join
+
+  Note: Tenant context is derived per-request from mTLS certificates.
+  The gateway is platform infrastructure serving all tenants.
 
   ## Architecture
 
@@ -76,8 +78,6 @@ defmodule ServiceRadarAgentGateway.Application do
 
     gateway_id = System.get_env("GATEWAY_ID", generate_gateway_id())
     domain = System.get_env("GATEWAY_DOMAIN", "default")
-    tenant_id = System.get_env("GATEWAY_TENANT_ID")
-    tenant_slug = System.get_env("GATEWAY_TENANT_SLUG")
 
     # Gateway gRPC server configuration
     grpc_port = get_grpc_port()
@@ -85,15 +85,9 @@ defmodule ServiceRadarAgentGateway.Application do
 
     capabilities = parse_capabilities(System.get_env("GATEWAY_CAPABILITIES", ""))
 
-    if tenant_slug do
-      Logger.info(
-        "Starting ServiceRadar Agent Gateway: #{gateway_id} in partition: #{partition_id} for tenant: #{tenant_slug}"
-      )
-    else
-      Logger.info(
-        "Starting ServiceRadar Agent Gateway: #{gateway_id} in partition: #{partition_id}"
-      )
-    end
+    Logger.info(
+      "Starting ServiceRadar Agent Gateway: #{gateway_id} in partition: #{partition_id}"
+    )
 
     Logger.info("Agent Gateway gRPC server listening on port #{grpc_port}")
 
@@ -116,9 +110,7 @@ defmodule ServiceRadarAgentGateway.Application do
        partition_id: partition_id,
        gateway_id: gateway_id,
        domain: domain,
-       capabilities: capabilities,
-       tenant_id: tenant_id,
-       tenant_slug: tenant_slug},
+       capabilities: capabilities},
 
       # Registration worker - registers this gateway in the distributed registry.
       # Gateways are platform-level; tenant context is derived per-request via mTLS.
@@ -126,8 +118,7 @@ defmodule ServiceRadarAgentGateway.Application do
        partition_id: partition_id,
        gateway_id: gateway_id,
        domain: domain,
-       entity_type: :gateway,
-       tenant_id: tenant_id},
+       entity_type: :gateway},
       # Register gateway for platform-wide visibility (Infrastructure UI).
       {ServiceRadar.GatewayRegistrationWorker,
        gateway_id: gateway_id,

--- a/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/config.ex
+++ b/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/config.ex
@@ -4,37 +4,14 @@ defmodule ServiceRadarAgentGateway.Config do
 
   Stores runtime configuration that can be queried by other gateway components.
 
-  ## Tenant Isolation
+  ## Platform Infrastructure
 
-  For multi-tenant deployments, each tenant's gateways run with:
-  - A unique tenant_id that scopes all operations
-  - A tenant-derived EPMD cookie (prevents cross-tenant ERTS clustering)
-  - Tenant-prefixed NATS channels
+  The agent gateway is platform infrastructure that serves multiple tenants.
+  Tenant isolation is handled per-request via mTLS certificates - each connecting
+  agent's certificate contains its tenant identity.
 
-  The tenant_id is resolved in priority order:
-  1. `GATEWAY_TENANT_ID` environment variable
-  2. `SERVICERADAR_PLATFORM_TENANT_ID` environment variable
-  3. **Cluster RPC discovery** - queries core-elx for platform tenant info
-
-  If no tenant_id is configured via environment, the gateway
-  will automatically discover it from the core service via cluster RPC.
-  This allows the gateway to self-configure without manual environment setup.
-
-  The tenant_slug is resolved in priority order:
-  1. `GATEWAY_TENANT_SLUG` environment variable
-  2. `SERVICERADAR_PLATFORM_TENANT_SLUG` environment variable
-  3. Extracted from the mTLS certificate CN (if using tenant-scoped certs)
-  4. Defaults to the platform tenant slug
-
-  ## Certificate CN Format
-
-  When using per-tenant certificates, the CN has format:
-  `<gateway_id>.<partition_id>.<tenant_slug>.serviceradar`
-
-  The tenant_slug is extracted and used for:
-  - Horde registry namespacing
-  - NATS channel prefixing
-  - Audit logging
+  This Config module stores the gateway's own identity (partition, gateway_id, domain)
+  but NOT tenant information. Tenant context flows through each gRPC request.
   """
 
   use GenServer
@@ -45,11 +22,7 @@ defmodule ServiceRadarAgentGateway.Config do
           partition_id: String.t(),
           gateway_id: String.t(),
           domain: String.t(),
-          capabilities: [atom()],
-          tenant_id: String.t() | nil,
-          tenant_slug: String.t() | nil,
-          nats_prefix: String.t() | nil,
-          status: :initializing | :ready
+          capabilities: [atom()]
         }
 
   # Client API
@@ -84,120 +57,11 @@ defmodule ServiceRadarAgentGateway.Config do
   end
 
   @doc """
-  Returns the tenant ID for this gateway.
-
-  All operations are scoped to this tenant. Defaults to the
-  default tenant UUID if not explicitly configured.
-  """
-  @spec tenant_id() :: String.t()
-  def tenant_id do
-    GenServer.call(__MODULE__, :tenant_id)
-  end
-
-  @doc """
-  Returns the tenant slug for this gateway.
-
-  The slug is used for NATS channel prefixing and Horde registry keys.
-  Defaults to "default" if not explicitly configured.
-  """
-  @spec tenant_slug() :: String.t()
-  def tenant_slug do
-    GenServer.call(__MODULE__, :tenant_slug)
-  end
-
-  @doc """
-  Returns the NATS channel prefix for this gateway.
-
-  Returns the tenant slug, which prefixes all NATS channels for tenant isolation.
-  """
-  @spec nats_prefix() :: String.t()
-  def nats_prefix do
-    GenServer.call(__MODULE__, :nats_prefix)
-  end
-
-  @doc """
   Get a specific config value by key.
   """
   @spec get(atom()) :: any()
   def get(key) when is_atom(key) do
     GenServer.call(__MODULE__, {:get, key})
-  end
-
-  @doc """
-  Returns the current status of the config GenServer.
-
-  - `:initializing` - Tenant discovery is in progress
-  - `:ready` - Configuration is complete and available
-  """
-  @spec status() :: :initializing | :ready
-  def status do
-    GenServer.call(__MODULE__, :status)
-  end
-
-  @doc """
-  Blocks until the config GenServer is ready or timeout is reached.
-
-  Returns `:ok` if ready, `{:error, :timeout}` if timeout reached.
-  Useful for components that depend on tenant configuration.
-  """
-  @spec await_ready(timeout()) :: :ok | {:error, :timeout}
-  def await_ready(timeout \\ 30_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout
-    do_await_ready(deadline)
-  end
-
-  defp do_await_ready(deadline) do
-    case status() do
-      :ready ->
-        :ok
-
-      :initializing ->
-        remaining = deadline - System.monotonic_time(:millisecond)
-
-        if remaining > 0 do
-          Process.sleep(100)
-          do_await_ready(deadline)
-        else
-          {:error, :timeout}
-        end
-    end
-  end
-
-  @doc """
-  Returns a NATS channel name with the tenant prefix applied.
-
-  ## Examples
-
-      iex> Config.nats_channel("gateways.heartbeat")
-      "tenant-acme.gateways.heartbeat"  # multi-tenant
-
-      iex> Config.nats_channel("gateways.heartbeat")
-      "gateways.heartbeat"  # single-tenant
-  """
-  @spec nats_channel(String.t()) :: String.t()
-  def nats_channel(base_channel) do
-    case nats_prefix() do
-      "" -> base_channel
-      prefix -> "#{prefix}.#{base_channel}"
-    end
-  end
-
-  @doc """
-  Builds a Horde registry key with tenant scope.
-
-  Includes tenant_slug in the key tuple to prevent cross-tenant process collisions.
-
-  ## Examples
-
-      iex> Config.registry_key(:device, "partition-1", "10.0.0.1")
-      {"tenant-acme", "partition-1", "10.0.0.1"}
-
-      iex> Config.registry_key(:device, "partition-1", "10.0.0.1")
-      {"default", "partition-1", "10.0.0.1"}  # default tenant
-  """
-  @spec registry_key(atom(), String.t(), String.t()) :: tuple()
-  def registry_key(_type, partition_id, identifier) do
-    {tenant_slug(), partition_id, identifier}
   end
 
   # Server callbacks
@@ -209,174 +73,16 @@ defmodule ServiceRadarAgentGateway.Config do
     domain = Keyword.fetch!(opts, :domain)
     capabilities = Keyword.get(opts, :capabilities, [])
 
-    # Get tenant info from environment, certificate, or cluster RPC
-    # System is always multi-tenant - default tenant is used if none specified
-    {tenant_id, tenant_slug} = resolve_tenant_info(opts)
-    tenant_id = normalize_tenant_id(tenant_id)
-    tenant_slug = normalize_tenant_slug(tenant_slug)
-
-    initial_state = %{
+    config = %{
       partition_id: partition_id,
       gateway_id: gateway_id,
       domain: domain,
-      capabilities: capabilities,
-      tenant_id: tenant_id,
-      tenant_slug: tenant_slug,
-      nats_prefix: nil,
-      status: :initializing
+      capabilities: capabilities
     }
 
-    if is_nil(tenant_id) do
-      # No tenant_id from env/cert - discover via cluster RPC asynchronously
-      # This prevents blocking the supervisor during startup
-      Logger.info("No tenant_id configured; will discover from cluster...")
-      {:ok, initial_state, {:continue, :discover_tenant}}
-    else
-      validate_tenant_id!(tenant_id)
-      tenant_slug = tenant_slug || platform_tenant_slug()
+    Logger.info("Gateway configured: #{gateway_id} in partition #{partition_id}, domain #{domain}")
 
-      config =
-        initial_state
-        |> Map.put(:tenant_slug, tenant_slug)
-        |> Map.put(:nats_prefix, tenant_slug)
-        |> Map.put(:status, :ready)
-
-      Logger.info("Gateway configured for tenant: #{tenant_slug} (ID: #{tenant_id})")
-      {:ok, config}
-    end
-  end
-
-  @impl true
-  def handle_continue(:discover_tenant, state) do
-    case do_discover_tenant() do
-      {:ok, tenant_id, tenant_slug} ->
-        config =
-          state
-          |> Map.put(:tenant_id, tenant_id)
-          |> Map.put(:tenant_slug, tenant_slug)
-          |> Map.put(:nats_prefix, tenant_slug)
-          |> Map.put(:status, :ready)
-
-        Logger.info("Gateway configured for tenant: #{tenant_slug} (ID: #{tenant_id})")
-        {:noreply, config}
-
-      {:error, reason} ->
-        Logger.error("Failed to discover tenant from cluster: #{inspect(reason)}")
-        {:stop, {:discovery_failed, reason}, state}
-    end
-  end
-
-  defp do_discover_tenant do
-    try do
-      {tenant_id, tenant_slug} = discover_tenant_from_cluster()
-      {:ok, tenant_id, tenant_slug}
-    rescue
-      e ->
-        {:error, {e, __STACKTRACE__}}
-    catch
-      kind, reason ->
-        {:error, {kind, reason}}
-    end
-  end
-
-  defp normalize_tenant_id(nil), do: nil
-
-  defp normalize_tenant_id(value) do
-    value
-    |> to_string()
-    |> String.trim()
-    |> case do
-      "" -> nil
-      id -> id
-    end
-  end
-
-  defp normalize_tenant_slug(nil), do: nil
-
-  defp normalize_tenant_slug(value) do
-    value
-    |> to_string()
-    |> String.trim()
-    |> String.downcase()
-    |> case do
-      "" ->
-        nil
-
-      slug ->
-        if Regex.match?(~r/^[a-z0-9-]{1,63}$/, slug) do
-          slug
-        else
-          raise "invalid tenant_slug format for agent gateway"
-        end
-    end
-  end
-
-  defp validate_tenant_id!(tenant_id) do
-    if not Regex.match?(~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, tenant_id) do
-      raise "invalid tenant_id format for agent gateway"
-    end
-
-    if tenant_id == "00000000-0000-0000-0000-000000000000" do
-      raise "invalid tenant_id for agent gateway: platform tenant must not be the zero UUID"
-    end
-  end
-
-  # Discover tenant info from core via cluster RPC with retries
-  @discovery_max_attempts 30
-  @discovery_retry_interval_ms 2_000
-
-  defp discover_tenant_from_cluster do
-    discover_tenant_from_cluster(1)
-  end
-
-  defp discover_tenant_from_cluster(attempt) when attempt > @discovery_max_attempts do
-    raise "failed to discover platform tenant from cluster after #{@discovery_max_attempts} attempts"
-  end
-
-  defp discover_tenant_from_cluster(attempt) do
-    case find_core_node() do
-      nil ->
-        Logger.debug("No core node found (attempt #{attempt}/#{@discovery_max_attempts}), retrying...")
-        Process.sleep(@discovery_retry_interval_ms)
-        discover_tenant_from_cluster(attempt + 1)
-
-      core_node ->
-        case rpc_get_platform_tenant(core_node) do
-          {:ok, %{tenant_id: tenant_id, tenant_slug: tenant_slug}} ->
-            validate_tenant_id!(tenant_id)
-            Logger.info("Discovered platform tenant from #{core_node}: #{tenant_slug} (#{tenant_id})")
-            {tenant_id, tenant_slug}
-
-          {:error, :not_ready} ->
-            Logger.debug("Core node #{core_node} not ready (attempt #{attempt}/#{@discovery_max_attempts}), retrying...")
-            Process.sleep(@discovery_retry_interval_ms)
-            discover_tenant_from_cluster(attempt + 1)
-
-          {:error, reason} ->
-            Logger.warning("RPC to #{core_node} failed: #{inspect(reason)} (attempt #{attempt}/#{@discovery_max_attempts})")
-            Process.sleep(@discovery_retry_interval_ms)
-            discover_tenant_from_cluster(attempt + 1)
-        end
-    end
-  end
-
-  defp find_core_node do
-    # Look for a core-elx node in the cluster
-    Node.list()
-    |> Enum.find(fn node ->
-      node_str = Atom.to_string(node)
-      String.contains?(node_str, "serviceradar_core")
-    end)
-  end
-
-  defp rpc_get_platform_tenant(node) do
-    case :rpc.call(node, ServiceRadar.Edge.AgentGatewaySync, :get_platform_tenant_info, [], 5_000) do
-      {:badrpc, reason} ->
-        {:error, reason}
-
-      result ->
-        result
-    end
+    {:ok, config}
   end
 
   @impl true
@@ -400,129 +106,7 @@ defmodule ServiceRadarAgentGateway.Config do
     {:reply, config.capabilities, config}
   end
 
-  def handle_call(:tenant_id, _from, config) do
-    {:reply, config.tenant_id, config}
-  end
-
-  def handle_call(:tenant_slug, _from, config) do
-    {:reply, config.tenant_slug, config}
-  end
-
-  def handle_call(:nats_prefix, _from, config) do
-    {:reply, config.nats_prefix, config}
-  end
-
-  def handle_call(:status, _from, config) do
-    {:reply, config.status, config}
-  end
-
   def handle_call({:get, key}, _from, config) do
     {:reply, Map.get(config, key), config}
-  end
-
-  # Resolve tenant info from environment or certificate
-  defp resolve_tenant_info(opts) do
-    # Priority 1: Explicit tenant_id/tenant_slug from opts
-    tenant_id = Keyword.get(opts, :tenant_id)
-    tenant_slug = Keyword.get(opts, :tenant_slug)
-
-    if tenant_id || tenant_slug do
-      {tenant_id, tenant_slug}
-    else
-      # Priority 2: Environment variables
-      env_tenant_id =
-        System.get_env("GATEWAY_TENANT_ID") ||
-          System.get_env("SERVICERADAR_PLATFORM_TENANT_ID") ||
-          System.get_env("PLATFORM_TENANT_ID")
-
-      env_tenant_slug =
-        System.get_env("GATEWAY_TENANT_SLUG") ||
-          System.get_env("SERVICERADAR_PLATFORM_TENANT_SLUG") ||
-          System.get_env("PLATFORM_TENANT_SLUG")
-
-      if env_tenant_id || env_tenant_slug do
-        {env_tenant_id, env_tenant_slug}
-      else
-        # Priority 3: Extract from certificate CN (if available)
-        extract_tenant_from_cert()
-      end
-    end
-  end
-
-  # Extract tenant from certificate CN
-  # CN format: <gateway_id>.<partition_id>.<tenant_slug>.serviceradar
-  defp extract_tenant_from_cert do
-    cert_dir = System.get_env("CERT_DIR", "/etc/serviceradar/certs")
-    cert_file = Path.join(cert_dir, "svid.pem")
-
-    case File.read(cert_file) do
-      {:ok, pem} ->
-        case extract_cn_from_pem(pem) do
-          {:ok, cn} ->
-            case parse_tenant_from_cn(cn) do
-              {:ok, %{tenant_slug: slug}} -> {nil, slug}
-              _ -> {nil, nil}
-            end
-
-          _ ->
-            {nil, nil}
-        end
-
-      _ ->
-        {nil, nil}
-    end
-  end
-
-  defp extract_cn_from_pem(pem) do
-    case :public_key.pem_decode(pem) do
-      [{:Certificate, der, _} | _] ->
-        case :public_key.pkix_decode_cert(der, :otp) do
-          {:OTPCertificate, tbs_cert, _, _} ->
-            extract_cn_from_tbs(tbs_cert)
-
-          _ ->
-            {:error, :invalid_cert}
-        end
-
-      _ ->
-        {:error, :no_cert}
-    end
-  end
-
-  defp extract_cn_from_tbs(tbs_cert) do
-    subject = elem(tbs_cert, 6)
-
-    case subject do
-      {:rdnSequence, rdns} ->
-        cn =
-          rdns
-          |> List.flatten()
-          |> Enum.find_value(fn
-            {:AttributeTypeAndValue, {2, 5, 4, 3}, {:utf8String, cn}} -> cn
-            {:AttributeTypeAndValue, {2, 5, 4, 3}, {:printableString, cn}} -> List.to_string(cn)
-            _ -> nil
-          end)
-
-        if cn, do: {:ok, cn}, else: {:error, :no_cn}
-
-      _ ->
-        {:error, :invalid_subject}
-    end
-  end
-
-  # Parse tenant from CN
-  # Format: <component_id>.<partition_id>.<tenant_slug>.serviceradar
-  defp parse_tenant_from_cn(cn) do
-    case String.split(cn, ".") do
-      [_component_id, _partition_id, tenant_slug, "serviceradar"] ->
-        {:ok, %{tenant_slug: tenant_slug}}
-
-      _ ->
-        {:error, :invalid_cn_format}
-    end
-  end
-
-  defp platform_tenant_slug do
-    Application.get_env(:serviceradar_core, :platform_tenant_slug, "platform")
   end
 end

--- a/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/config.ex
+++ b/elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/config.ex
@@ -1,59 +1,75 @@
 defmodule ServiceRadarAgentGateway.Config do
   @moduledoc """
-  Configuration store for the agent gateway.
+  Gateway identity configuration using persistent_term.
 
-  Stores runtime configuration that can be queried by other gateway components.
+  Stores the gateway's static identity (gateway_id, domain, capabilities) in
+  persistent_term for fast access from gRPC handlers without GenServer overhead.
 
   ## Platform Infrastructure
 
-  The agent gateway is platform infrastructure that serves multiple tenants.
-  Tenant isolation is handled per-request via mTLS certificates - each connecting
-  agent's certificate contains its tenant identity.
+  The agent gateway is platform infrastructure that serves all tenants and
+  all partitions. This module stores only the gateway's own identity.
+  Tenant and partition context flows through each gRPC request via mTLS.
 
-  This Config module stores the gateway's own identity (partition, gateway_id, domain)
-  but NOT tenant information. Tenant context flows through each gRPC request.
+  ## Usage
+
+  Call `setup/1` once at application startup, then use reader functions:
+
+      # At startup (in Application.start)
+      Config.setup(gateway_id: "gw-1", domain: "prod")
+
+      # In gRPC handlers
+      Config.gateway_id()  # => "gw-1"
+      Config.domain()      # => "prod"
   """
 
-  use GenServer
+  @pt_key __MODULE__
 
-  require Logger
+  @doc """
+  Initialize gateway config. Call once at application startup.
+  """
+  @spec setup(keyword()) :: :ok
+  def setup(opts) do
+    config = %{
+      gateway_id: Keyword.fetch!(opts, :gateway_id),
+      domain: Keyword.fetch!(opts, :domain),
+      capabilities: Keyword.get(opts, :capabilities, [])
+    }
 
-  @type config :: %{
-          partition_id: String.t(),
-          gateway_id: String.t(),
-          domain: String.t(),
-          capabilities: [atom()]
-        }
-
-  # Client API
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    :persistent_term.put(@pt_key, config)
+    :ok
   end
 
-  @spec get() :: config()
+  @doc """
+  Returns the full config map.
+  """
+  @spec get() :: map()
   def get do
-    GenServer.call(__MODULE__, :get)
+    :persistent_term.get(@pt_key)
   end
 
-  @spec partition_id() :: String.t()
-  def partition_id do
-    GenServer.call(__MODULE__, :partition_id)
-  end
-
+  @doc """
+  Returns the gateway's unique identifier.
+  """
   @spec gateway_id() :: String.t()
   def gateway_id do
-    GenServer.call(__MODULE__, :gateway_id)
+    get().gateway_id
   end
 
+  @doc """
+  Returns the domain this gateway serves.
+  """
   @spec domain() :: String.t()
   def domain do
-    GenServer.call(__MODULE__, :domain)
+    get().domain
   end
 
+  @doc """
+  Returns the gateway's capabilities.
+  """
   @spec capabilities() :: [atom()]
   def capabilities do
-    GenServer.call(__MODULE__, :capabilities)
+    get().capabilities
   end
 
   @doc """
@@ -61,52 +77,6 @@ defmodule ServiceRadarAgentGateway.Config do
   """
   @spec get(atom()) :: any()
   def get(key) when is_atom(key) do
-    GenServer.call(__MODULE__, {:get, key})
-  end
-
-  # Server callbacks
-
-  @impl true
-  def init(opts) do
-    partition_id = Keyword.fetch!(opts, :partition_id)
-    gateway_id = Keyword.fetch!(opts, :gateway_id)
-    domain = Keyword.fetch!(opts, :domain)
-    capabilities = Keyword.get(opts, :capabilities, [])
-
-    config = %{
-      partition_id: partition_id,
-      gateway_id: gateway_id,
-      domain: domain,
-      capabilities: capabilities
-    }
-
-    Logger.info("Gateway configured: #{gateway_id} in partition #{partition_id}, domain #{domain}")
-
-    {:ok, config}
-  end
-
-  @impl true
-  def handle_call(:get, _from, config) do
-    {:reply, config, config}
-  end
-
-  def handle_call(:partition_id, _from, config) do
-    {:reply, config.partition_id, config}
-  end
-
-  def handle_call(:gateway_id, _from, config) do
-    {:reply, config.gateway_id, config}
-  end
-
-  def handle_call(:domain, _from, config) do
-    {:reply, config.domain, config}
-  end
-
-  def handle_call(:capabilities, _from, config) do
-    {:reply, config.capabilities, config}
-  end
-
-  def handle_call({:get, key}, _from, config) do
-    {:reply, Map.get(config, key), config}
+    Map.get(get(), key)
   end
 end

--- a/elixir/serviceradar_core/lib/serviceradar/edge/onboarding_packages.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/edge/onboarding_packages.ex
@@ -452,6 +452,11 @@ defmodule ServiceRadar.Edge.OnboardingPackages do
         Map.get(attrs, :tenant_id) ||
         Map.get(attrs, "tenant_id")
 
+    if is_nil(tenant_value) do
+      raise ArgumentError,
+            "Tenant could not be resolved - missing tenant identifier in options or attributes"
+    end
+
     TenantSchemas.schema_for_tenant(tenant_value)
   end
 

--- a/elixir/serviceradar_core/lib/serviceradar/identity/alias_events.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/identity/alias_events.ex
@@ -514,8 +514,13 @@ defmodule ServiceRadar.Identity.AliasEvents do
     updates
     |> Enum.group_by(& &1.device_id)
     |> Enum.map(fn {_device_id, grouped} ->
-      # Keep the update with the latest timestamp
-      Enum.max_by(grouped, & &1.timestamp, DateTime)
+      # Keep the update with the latest timestamp, handling nil timestamps
+      Enum.max_by(grouped, & &1.timestamp, fn
+        nil, nil -> :eq
+        nil, _ -> :lt
+        _, nil -> :gt
+        a, b -> DateTime.compare(a, b)
+      end)
     end)
   end
 

--- a/web-ng/lib/serviceradar_web_ng_web/controllers/api/collector_controller.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/controllers/api/collector_controller.ex
@@ -534,7 +534,8 @@ defmodule ServiceRadarWebNG.Api.CollectorController do
     return_error(conn, :internal_server_error, "NATS credentials not provisioned")
   end
 
-  defp handle_bundle_error(conn, reason) when reason in [:tls_key_not_found, :tls_cert_not_found] do
+  defp handle_bundle_error(conn, reason)
+       when reason in [:tls_key_not_found, :tls_cert_not_found] do
     return_error(conn, :internal_server_error, "TLS certificates not provisioned")
   end
 

--- a/web-ng/lib/serviceradar_web_ng_web/controllers/api/edge_controller.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/controllers/api/edge_controller.ex
@@ -50,6 +50,7 @@ defmodule ServiceRadarWebNG.Api.EdgeController do
   """
   def index(conn, params) do
     filters = build_filters(params)
+
     with {:ok, tenant} <- require_tenant(conn) do
       packages = OnboardingPackages.list(filters, tenant: tenant)
       json(conn, Enum.map(packages, &package_to_json/1))
@@ -254,7 +255,14 @@ defmodule ServiceRadarWebNG.Api.EdgeController do
   end
 
   defp handle_bundle_error(conn, reason)
-       when reason in [:invalid_token, :expired, :not_found, :already_delivered, :revoked, :deleted] do
+       when reason in [
+              :invalid_token,
+              :expired,
+              :not_found,
+              :already_delivered,
+              :revoked,
+              :deleted
+            ] do
     handle_download_error(conn, reason)
   end
 
@@ -301,7 +309,9 @@ defmodule ServiceRadarWebNG.Api.EdgeController do
          {:ok, %{package: package, join_token: join_token, bundle_pem: bundle_pem}} <-
            deliver_package(id, download_token, tenant_schema, source_ip, nil),
          {:ok, tarball} <-
-           wrap_bundle_error(BundleGenerator.create_tarball(package, bundle_pem || "", join_token)) do
+           wrap_bundle_error(
+             BundleGenerator.create_tarball(package, bundle_pem || "", join_token)
+           ) do
       filename = BundleGenerator.bundle_filename(package)
       {:ok, tarball, filename}
     else

--- a/web-ng/lib/serviceradar_web_ng_web/controllers/auth_controller.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/controllers/auth_controller.ex
@@ -42,6 +42,7 @@ defmodule ServiceRadarWebNGWeb.AuthController do
   def success(conn, _activity, %_{} = user, _token) do
     return_to = get_session(conn, :user_return_to) || ~p"/analytics"
     tenant_id = user.tenant_id
+
     tenant_schema =
       case Map.fetch(user.__metadata__, :tenant) do
         {:ok, tenant} when is_binary(tenant) -> tenant

--- a/web-ng/lib/serviceradar_web_ng_web/plugs/api_auth.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/plugs/api_auth.ex
@@ -81,6 +81,7 @@ defmodule ServiceRadarWebNGWeb.Plugs.ApiAuth do
 
   defp validate_bearer_token(conn, token) do
     tenant = token_tenant(token)
+
     if is_nil(tenant) do
       {:error, :unauthorized}
     else
@@ -313,6 +314,7 @@ defmodule ServiceRadarWebNGWeb.Plugs.ApiAuth do
   end
 
   defp tenant_schema_from_id(nil), do: nil
+
   defp tenant_schema_from_id(tenant_id) when is_binary(tenant_id),
     do: TenantSchemas.schema_for_id(tenant_id)
 

--- a/web-ng/lib/serviceradar_web_ng_web/router.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/router.ex
@@ -346,6 +346,7 @@ defmodule ServiceRadarWebNGWeb.Router do
   end
 
   defp maybe_set_tenant(conn, nil), do: conn
+
   defp maybe_set_tenant(conn, tenant_id) do
     case ServiceRadarWebNGWeb.TenantResolver.schema_for_tenant_id(tenant_id) do
       tenant_schema when is_binary(tenant_schema) ->

--- a/web-ng/lib/serviceradar_web_ng_web/user_auth.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/user_auth.ex
@@ -55,6 +55,7 @@ defmodule ServiceRadarWebNGWeb.UserAuth do
   # Verify an Ash JWT token and load the user
   defp verify_token(token) do
     tenant = token_tenant(token)
+
     if is_nil(tenant) do
       {:error, :invalid_token}
     else
@@ -251,6 +252,7 @@ defmodule ServiceRadarWebNGWeb.UserAuth do
   end
 
   defp tenant_schema_from_id(nil), do: nil
+
   defp tenant_schema_from_id(tenant_id) when is_binary(tenant_id),
     do: TenantResolver.schema_for_tenant_id(tenant_id)
 

--- a/web-ng/test/serviceradar_web_ng_web/controllers/api/edge_controller_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/controllers/api/edge_controller_test.exs
@@ -29,7 +29,8 @@ defmodule ServiceRadarWebNG.Api.EdgeControllerTest do
     end
 
     test "filters by status", %{conn: conn} do
-      {:ok, _} = OnboardingPackages.create(%{label: "test-filter-status"}, tenant: tenant_id(conn))
+      {:ok, _} =
+        OnboardingPackages.create(%{label: "test-filter-status"}, tenant: tenant_id(conn))
 
       conn = get(conn, ~p"/api/admin/edge-packages?status=issued")
       result = json_response(conn, 200)
@@ -308,6 +309,7 @@ defmodule ServiceRadarWebNG.Api.EdgeControllerTest do
 
     test "returns 404 for non-existent package", %{conn: conn} do
       fake_id = Ecto.UUID.generate()
+
       {:ok, created} =
         OnboardingPackages.create(%{label: "test-nonexistent-bundle"}, tenant: tenant_id(conn))
 
@@ -327,22 +329,29 @@ defmodule ServiceRadarWebNG.Api.EdgeControllerTest do
       # Second attempt
       conn =
         build_conn()
-        |> get(~p"/api/edge-packages/#{created.package.id}/bundle?token=#{created.download_token}")
+        |> get(
+          ~p"/api/edge-packages/#{created.package.id}/bundle?token=#{created.download_token}"
+        )
 
       assert json_response(conn, 409)["error"] == "package already_delivered"
     end
 
     test "bundle contains expected files", %{conn: conn} do
       {:ok, created} =
-        OnboardingPackages.create(%{
-          label: "test-bundle-contents",
-          component_type: :checker,
-          checker_kind: "sysmon"
-        }, tenant: tenant_id(conn))
+        OnboardingPackages.create(
+          %{
+            label: "test-bundle-contents",
+            component_type: :checker,
+            checker_kind: "sysmon"
+          },
+          tenant: tenant_id(conn)
+        )
 
       conn =
         build_conn()
-        |> get(~p"/api/edge-packages/#{created.package.id}/bundle?token=#{created.download_token}")
+        |> get(
+          ~p"/api/edge-packages/#{created.package.id}/bundle?token=#{created.download_token}"
+        )
 
       body = response(conn, 200)
       {:ok, files} = :erl_tar.extract({:binary, body}, [:compressed, :memory])


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- **Major architectural shift from poller to gateway model**: Refactored agent from gRPC server to push-mode architecture with gateway client integration, replacing `PollerService` with `AgentGatewayService`

- **Agent Gateway gRPC Server implementation**: New Elixir gRPC server for receiving status pushes from Go agents with mTLS authentication, multi-tenant security isolation, and agent enrollment/configuration management

- **Multi-tenant infrastructure**: Implemented comprehensive tenant management with NATS account provisioning, encrypted seed storage, and per-tenant Horde registries for process isolation

- **NATS credentials file support**: Added credentials file configuration across multiple components (trapd, zen consumer, flowgger, OTEL) for secure NATS connections

- **Device and agent runtime management**: New GenServer-based device actor for runtime state management and agent resource with state machine lifecycle (connecting, connected, degraded, disconnected, unavailable)

- **Certificate generation and SPIFFE integration**: X.509 certificate generation for tenant CAs and edge components with SPIFFE/SPIRE integration for distributed cluster security

- **Comprehensive database schema**: Initial tenant schema migration with 1416 lines defining all tenant database tables including gateways, agents, devices, service checks, and monitoring infrastructure

- **Service health monitoring**: Service heartbeat GenServer for periodic health status tracking of core, web, and gateway services

- **Edge onboarding packages**: Ash-based context module for managing edge component onboarding with token generation, delivery, and component certificate signing

- **Statistics aggregation**: Device statistics aggregator GenServer for periodic snapshots with device counts, availability, and capability breakdowns

- **Terminology updates**: Renamed `poller_id` to `gateway_id` across multiple checkers (sysmon, rperf-client, trapd) and updated CLI subcommands (`update-poller` → `update-gateway`)

- **DataService KV client**: New gRPC client for datasvc KV operations with automatic reconnection and exponential backoff strategy

- **Removed legacy poller infrastructure**: Deleted poller-specific files, configurations, and Docker/Kubernetes deployment templates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Agent["Go Agent<br/>Push Mode"]
  GW["Agent Gateway<br/>gRPC Server"]
  Tenant["Tenant Registry<br/>Horde Process Isolation"]
  NATS["NATS Account<br/>Multi-Tenant"]
  Device["Device Actor<br/>Runtime State"]
  Core["Core Cluster<br/>RPC Integration"]
  
  Agent -- "mTLS Push Status" --> GW
  GW -- "Extract Tenant" --> Tenant
  GW -- "Forward Data" --> Core
  Tenant -- "Manage Processes" --> Device
  Tenant -- "Account Provisioning" --> NATS
  Device -- "Heartbeat/Events" --> Core
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>31 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Agent refactored to push mode with gateway integration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/agent/main.go

<ul><li>Refactored agent from gRPC server model to push-mode architecture with <br>gateway client integration<br> <li> Replaced complex config bootstrap with simplified file-based loading <br>and embedded defaults fallback<br> <li> Added signal handling for graceful shutdown with timeout protection<br> <li> Introduced <code>loadConfig()</code> and <code>runPushMode()</code> functions for cleaner <br>separation of concerns</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-61358711e980ccf505246fd3915f97cbd3a380e9b66f6fa5aad46749968c5ca3">+174/-74</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>NATS account service initialization and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/data-services/main.go

<ul><li>Added NATS account service initialization with operator key management<br> <li> Implemented resolver path configuration with environment variable <br>overrides<br> <li> Added system account credentials file setup for JWT resolver <br>operations<br> <li> Registered <code>NATSAccountService</code> gRPC server if configured</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-5e7731adfb877918cd65d9d5531621312496450fd550fea2682efca4ca8fe816">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>CLI subcommands updated for gateway and NATS operations</code>&nbsp; &nbsp; </dd></summary>
<hr>

cmd/cli/main.go

<ul><li>Renamed <code>update-poller</code> subcommand to <code>update-gateway</code><br> <li> Added <code>nats-bootstrap</code> subcommand for NATS operations<br> <li> Added <code>admin</code> subcommand dispatcher with <code>nats</code> admin resource routing</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>SNMP checker service renamed from poller to gateway</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/checkers/snmp/main.go

<ul><li>Renamed <code>SNMPPollerService</code> to <code>SNMPGatewayService</code><br> <li> Renamed <code>Poller</code> struct to <code>Gateway</code> struct</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-f25402eade63525184cb5e7437accff93c7b9338eebe81add6dc5f2a9eb12550">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.go</strong><dd><code>Core app gRPC service renamed to AgentGatewayService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/core/app/app.go

<ul><li>Renamed gRPC service registration from <code>PollerService</code> to <br><code>AgentGatewayService</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4ad8a289575edf3b163088617b7a40ae1305c29ced0c7d59b3751c57d6938072">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Zen consumer NATS credentials file configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/consumers/zen/src/config.rs

<ul><li>Added optional <code>nats_creds_file</code> configuration field<br> <li> Added validation to ensure <code>nats_creds_file</code> is not empty when provided<br> <li> Added <code>nats_creds_path()</code> method to resolve credentials file path with <br>support for relative paths</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-05038f3867985e757de9027609950e682bad6d1992dac6acd7c28962a3c65dc4">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>Sysmon checker updated to use gateway_id terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/checkers/sysmon/src/server.rs

<ul><li>Renamed <code>poller_id</code> field to <code>gateway_id</code> in status and results logging<br> <li> Updated response structures to use <code>gateway_id</code> instead of <code>poller_id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2c4395fee16396339c3eea518ad9bec739174c67c9cedf62e6848c17136dd33e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>OTEL NATS credentials file configuration support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/otel/src/config.rs

<ul><li>Added optional <code>creds_file</code> field to <code>NATSConfigTOML</code> struct<br> <li> Added parsing logic to handle empty credentials file values<br> <li> Updated <code>NATSConfig</code> struct to include <code>creds_file</code> as <code>Option<PathBuf></code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-abbaec651da3d6af96b482e0f77bb909b65dbe0cabd78b5803769cc9dab0a1b0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Trapd NATS credentials and gateway_id updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/trapd/src/main.rs

<ul><li>Added credentials file support for NATS connections in both secure and <br>non-secure modes<br> <li> Updated connection logic to use <code>credentials_file()</code> when <br><code>nats_creds_path</code> is available<br> <li> Renamed <code>poller_id</code> to <code>gateway_id</code> in status and results responses</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-33b655d8730ae3e9c844ee280787d11f1b0d5343119188273f89558805f814ba">+23/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_output.rs</strong><dd><code>Flowgger NATS output credentials file support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/flowgger/src/flowgger/output/nats_output.rs

<ul><li>Added <code>creds_file</code> field to <code>NATSConfig</code> struct<br> <li> Implemented credentials file parsing with empty value handling<br> <li> Applied credentials file to NATS connection options</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-a82e2e4d413539bf0b414b5629665b19648447523994cba639c4d1238aa5a0c1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Trapd NATS credentials file configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/trapd/src/config.rs

<ul><li>Added optional <code>nats_creds_file</code> configuration field<br> <li> Added validation to ensure credentials file is not empty<br> <li> Added <code>nats_creds_path()</code> method to resolve file paths relative to <br>security cert directory</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c89b88ba4d2bf0a054d0ba69a672a92c30140b8d19503d67b980a218ffe3106d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_output.rs</strong><dd><code>OTEL NATS output credentials file support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/otel/src/nats_output.rs

<ul><li>Added <code>creds_file</code> field to <code>NATSConfig</code> struct with default <code>None</code><br> <li> Implemented credentials file application to NATS connection options<br> <li> Added debug logging for credentials file usage</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-6b585ea3564a481174e04da1270e2e13edd4e2b980d02a2652d6d21e6d82a498">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>grpc_server.rs</strong><dd><code>Zen consumer gRPC server gateway_id terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/consumers/zen/src/grpc_server.rs

<ul><li>Renamed <code>poller_id</code> to <code>gateway_id</code> in status and results response <br>structures</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e4564a93f6cf84ff91cd3d8141fc9272ec9b4ec19defd107afa42be01fcfed5b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats.rs</strong><dd><code>Zen consumer NATS credentials file integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/consumers/zen/src/nats.rs

<ul><li>Added credentials file support to NATS connection initialization<br> <li> Applied <code>nats_creds_path()</code> to connection options when available</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-97f7335def0ad5d644b594a1076ae2d7080b11259cbb8de22c7946cc8e4b39f8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.rs</strong><dd><code>RPerf checker gateway_id field addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/checkers/rperf-client/src/server.rs

- Added `gateway_id` field to status and results response structures


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-bce0f4ca6548712f224b73816825d28e831acbbff7dbed3c98671ed50f65d028">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>setup.rs</strong><dd><code>OTEL setup debug logging for credentials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/otel/src/setup.rs

- Added debug logging for NATS credentials file configuration


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-3891f667deb20fd26e296d3e2742c57378d3764fe1743118e612465ae360391f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>onboarding_packages.ex</strong><dd><code>Edge onboarding packages context module implementation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/edge/onboarding_packages.ex

<ul><li>Implemented comprehensive Ash-based context module for edge onboarding <br>package management<br> <li> Provides CRUD operations with token generation, delivery, revocation, <br>and soft-delete<br> <li> Added component certificate generation signed by tenant CA<br> <li> Includes authorization and state machine integration for package <br>lifecycle</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e4fe8e19bc324416302bb4c962f57133b3f62eb82053766844d881c522a473e5">+617/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_heartbeat.ex</strong><dd><code>Service heartbeat GenServer for health monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/infrastructure/service_heartbeat.ex

<ul><li>Implemented GenServer for Elixir service self-reporting via periodic <br>heartbeats<br> <li> Provides health status tracking for core, web, and gateway services<br> <li> Includes state change reporting for degraded and recovered states<br> <li> Integrates with HealthTracker for unified infrastructure monitoring</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2f74eb0839cbc5e48dc55edd899a75d724bab3295cbf4de69780926adae9a90c">+320/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_gateway_server.ex</strong><dd><code>Agent Gateway gRPC Server with mTLS Multi-Tenant Security</code></dd></summary>
<hr>

elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_gateway_server.ex

<ul><li>Implements gRPC server for receiving status pushes from Go agents with <br>mTLS authentication<br> <li> Handles agent enrollment (<code>hello</code>), configuration requests (<code>get_config</code>), <br>and status updates (<code>push_status</code>, <code>stream_status</code>)<br> <li> Extracts tenant identity from mTLS certificates and enforces <br>multi-tenant security isolation<br> <li> Validates service statuses, manages agent heartbeats, and forwards <br>data to core cluster via RPC</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-369a368073dc8ec1140bcea699005a1ce97a90cd59629df0bd18c71c7ffaae9f">+1013/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent.ex</strong><dd><code>Agent Resource with State Machine and Capability Management</code></dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/infrastructure/agent.ex

<ul><li>Defines <code>Agent</code> resource for managing Go agents using Ash framework with <br>state machine<br> <li> Implements agent lifecycle states (connecting, connected, degraded, <br>disconnected, unavailable)<br> <li> Provides capability definitions (ICMP, TCP, HTTP, gRPC, DNS, Process, <br>SNMP) and OCSF type mappings<br> <li> Includes JSON API routes for agent registration, connection <br>management, and heartbeat operations</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c56f92b6ce744cab3f2dc00dde92e2017cffdd12ad4618f7fa720252f2a6843a">+665/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tenant_registry.ex</strong><dd><code>Multi-Tenant Registry with Horde-Based Process Isolation</code>&nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/cluster/tenant_registry.ex

<ul><li>Manages per-tenant Horde registries and DynamicSupervisors for <br>multi-tenant process isolation<br> <li> Provides registry lifecycle management (creation, lookup, termination) <br>with slug-based alias mapping<br> <li> Implements process registration, discovery, and child process <br>management within tenant boundaries<br> <li> Includes convenience functions for agent and gateway registration and <br>heartbeat tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-91248b3b128a2e3d9bea6ffdb5e0f295e4a1745e82f87687c640ad01416fb85d">+634/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generator.ex</strong><dd><code>X.509 Certificate Generation for Tenant CAs and Components</code></dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/edge/tenant_ca/generator.ex

<ul><li>Generates X.509 certificates for tenant intermediate CAs and edge <br>components using Erlang's <code>:public_key</code> module<br> <li> Creates tenant CA certificates (10-year validity) and component <br>certificates (1-year validity) with SPIFFE URIs<br> <li> Computes SPKI SHA-256 hashes for certificate verification and extracts <br>tenant information from certificate CNs<br> <li> Supports RSA 2048-bit keys with proper extensions (BasicConstraints, <br>KeyUsage, SubjectAltName)</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-b48e4a9e1189da61e2a60e16f56fce81298d76b7cdab745107140fed3f6e48b4">+541/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>alias_events.ex</strong><dd><code>Device Alias Lifecycle Event Tracking and Detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/identity/alias_events.ex

<ul><li>Tracks device alias lifecycle events (service IDs, IPs, collectors) <br>with change detection<br> <li> Provides <code>AliasRecord</code> struct for parsing alias metadata from device <br>records<br> <li> Builds lifecycle events for alias changes and processes alias updates <br>with state transitions<br> <li> Supports sighting counting and confirmation thresholds for alias <br>validation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-bc3743067ea774f59bc5665770f7110a2d6e90f6e1156a7717a1c287f8979d28">+649/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hash_password.ex</strong><dd><code>Bcrypt Password Hashing Change for Ash Resources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/identity/changes/hash_password.ex

<ul><li>Implements Ash change for bcrypt password hashing in create and update <br>actions<br> <li> Hashes password argument and stores result in <code>hashed_password</code> <br>attribute<br> <li> Handles nil and empty password cases gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-7a83d2af7ffcff928ba3f58d175bfe63eaaae87a1994ba899e42080427739534">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>account_client.ex</strong><dd><code>NATS Account Client for Multi-Tenant Isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/nats/account_client.ex

<ul><li>New gRPC client module for NATS account management and tenant <br>isolation<br> <li> Implements account creation, user credential generation, JWT signing, <br>and operator bootstrap<br> <li> Provides channel management with fallback to fresh connections when <br>DataService.Client unavailable<br> <li> Includes helper functions for building protobuf request structures <br>(limits, permissions, mappings)</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2e18ac777ac600b12982ba9e9d5327e23ebd84c139a2add7976f8bf61283e554">+567/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spiffe.ex</strong><dd><code>SPIFFE/SPIRE Integration for Cluster Security</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/spiffe.ex

<ul><li>New SPIFFE/SPIRE integration module for distributed cluster security<br> <li> Provides SSL/TLS options for ERTS distribution with SPIFFE certificate <br>verification<br> <li> Implements SPIFFE ID parsing, validation, and certificate expiry <br>monitoring<br> <li> Supports both filesystem and workload API modes for certificate <br>loading</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0cb8d921c19f671b66f91c0978e351e71d927c5f4694924984c9f1ed34d7ee78">+564/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stats_aggregator.ex</strong><dd><code>Device Statistics Aggregator with Periodic Snapshots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/core/stats_aggregator.ex

<ul><li>New GenServer for periodic device statistics aggregation and caching<br> <li> Computes snapshots with device counts, availability, activity, and <br>capability breakdowns<br> <li> Implements canonical record filtering and deduplication logic<br> <li> Includes telemetry recording and alert handler integration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-1f4ac8290be7d27cac0ed660e51a9b3b23a219a6bb43b3735f3c5a9768321031">+628/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tenant.ex</strong><dd><code>Tenant Resource with NATS Account Provisioning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/identity/tenant.ex

<ul><li>New Ash resource representing tenants (organizations) in multi-tenant <br>system<br> <li> Defines tenant statuses (active, suspended, pending, deleted) and <br>billing plans<br> <li> Implements NATS account provisioning with encrypted seed storage via <br>AshCloak<br> <li> Includes custom actions for CA generation, registration, and NATS <br>account management</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9d0658a5118ece5eac7a6326788fdf59407a52f87c4b9c9ac69e6900bc04dc2a">+604/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>device.ex</strong><dd><code>Device Actor for Runtime State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/actors/device.ex

<ul><li>New GenServer representing device runtime state with in-memory caching<br> <li> Manages device identity, health status, configuration, and event <br>buffering<br> <li> Implements lazy initialization, Horde registry integration, and <br>hibernation<br> <li> Provides health state machine, event aggregation, and periodic <br>persistence</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-eba1d95a852e4a736813c7b486da651704f20718e24f931c966ff3f37c421eea">+613/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>client.ex</strong><dd><code>DataService KV Client with Reconnection Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/data_service/client.ex

<ul><li>New gRPC client for datasvc KV service with automatic reconnection<br> <li> Implements put, get, delete, list_keys, and put_many operations<br> <li> Includes exponential backoff reconnection strategy and connection <br>pooling<br> <li> Supports mTLS with configurable certificates and environment variable <br>overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-503e195ad79e05e12d7ad03a675f6e35ffdfc201b8571b0d30a220fe036e03a1">+511/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reserved_tenant_slug.ex</strong><dd><code>Reserved Tenant Slug Validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/identity/validations/reserved_tenant_slug.ex

<ul><li>New Ash validation ensuring reserved tenant slugs are only used for <br>platform tenant<br> <li> Validates slug constraints during tenant creation and updates<br> <li> Extracts slug from changeset with fallback to existing data</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-3495f8e60db2c1472c538ed33b6d2be79730d7938ad034d273281040ee1558cb">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>API documentation updated for gateway terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/core/main.go

<ul><li>Updated API description from "service pollers" to "service gateways"</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4ab3fd1d4debc53dd2499d94a0f60c648fdae4235dd1e3678095a975f5bb434a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Config sync tool documentation updated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/tools/config-sync/main.go

<ul><li>Updated role flag documentation to reference "gateway" instead of <br>"poller"</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-bc6eeb1b05bcb9179525e32fac1de9926b5823ec3504be546ab10c5c9740f544">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>message_processor.rs</strong><dd><code>Zen message processor test configuration update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/consumers/zen/src/message_processor.rs

- Added `nats_creds_file: None` field to test configuration struct


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9fcbc5358a9009e60a8cd22d21e5a9ea652787c727732d0b869e0865495114c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>20260107043446_initial_schema.exs</strong><dd><code>Initial tenant schema migration with full database structure</code></dd></summary>
<hr>

elixir/serviceradar_core/priv/repo/tenant_migrations/20260107043446_initial_schema.exs

<ul><li>Created comprehensive initial schema migration with 1416 lines <br>defining all tenant database tables<br> <li> Includes tables for gateways, agents, devices, service checks, polling <br>schedules, NATS infrastructure, and monitoring<br> <li> Implements encryption for sensitive fields using AshCloak<br> <li> Defines relationships, indexes, and constraints for multi-tenant <br>architecture</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0d217dc9822fab0d3390e8ec21040f98e67106e5c9126e043a9b701efcbfb576">+1416/-0</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitkeep</strong><dd><code>Credentials Directory Placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/compose/creds/.gitkeep

- New empty placeholder file for credentials directory


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d72c41aab2d6f2c230a4340dfefe7917cdd12bed942c825aa0d4c9875a637bac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>.bazelignore</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-a5641cd37d6ad98b32cdfce1980836cc68312277bc6a7052f55da02ada5bc6cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.bazelrc</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env-sample</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c4368a972a7fa60d9c4e333cebf68cdb9a67acb810451125c02e3b7eb2594e3d">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+177/-11</a></td>

</tr>

<tr>
  <td><strong>INSTALL.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MODULE.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Makefile</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+55/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README-Docker.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9fd61d24482efe68c22d8d41e2a1dcc440f39195aa56e7a050f2abe598179efd">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ROADMAP.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-884fa9353a5226345e44fbabea3300efc7a87dfbcde0b6a42521ca51823f1b68">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0e80ea46aeb61a873324685edb96eae864c7a2004fbb7ee404b4ec951190ba10">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mix_release.bzl</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-86ec281f99363b6b6eb1f49e21d83b7eeca93a35b552b9f305fffc6855e38ccd">+124/-49</a></td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-143f8d1549d52f28906f19ce28e5568a5be474470ff103c2c1e63c3e6b08d670">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-bfd308915d0cf522e7fc76600dee687617dc69165ab22502a1d219850c0c0860">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-5b1bc8fe77422534739bdd3a38dc20d2634a86c171265c34e1b5d0c5a61b6bab">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-251e7a923f45f8f903e510d10f183366bda06d281c8ecc3669e1858256e2186d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monitoring.proto</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-b56f709f4a0a3db694f2124353908318631f23e20b7846bc4b8ee869e2e0632a">+3/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2e9751b437fa61442aac074c7a4a912d0ac50ac3ea156ac8aedd8478d21c6bdb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monitoring.proto</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9faf6025eb0d3d38383f5b7ad2b733abeb38454d5e4de3e83994e94b12d87a50">+2/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer-with-otel.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-68375f1f7847e1fbdf75664f6be65b1ad94ae6ce86ed73fc5964d65054668acb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4d308af9802a93a0f656e8c02a3b5fcd8991407bb18360f087470db74e1f9524">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2423ef78d36e905ae993b69ff59f5df6b2e1b9492fb0fa8c6d0aad7c76d2d229">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-ef778d85ac6f9652c25cb0d631f0fe8dfb3edac4dde5d719a4fc2926fb5c3216">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c62c0139ebdb337369f4067567cd2c52b8e7decb3ddfabc77f9f67b2f6e5789c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0b0725713b87dca1de57200214a4fe04633f0d856c39aa8032280227bf8e8141">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-f425b4378f84e0ba0c6f532facff17ff5d55b4dc6033d8bf35130a159cd2ba32">+9/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-af9f49f931e282dca53d1f0521b036d222fe671f77e61a876a84cf4c6d7cca4d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c64b9ace832b8ea57a2be62f84166e03bb1904882635d444ec76a880cdf14cc0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e1f7c698e0e3a4e6afa971c1140e71cbf22593fbb19c81cb26b02c15c5dc46ec">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9edc2486fff55fc399e0ac96dba5137948a7ea7285f5ef7846835355684b7ab5">+0/-111</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4b8ec845da50cd58d011e69f9d1c30530ee1968df26616b8768bb1fc03433bbe">+0/-138</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4f5d2ea4260d490a0d6f28adde0b35eca8af77d22f3ee366a783946c53687619">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-bcac20d6b3cb81f0059e766839ba1ee59a885009249501b0ba1182ebb1daea25">+0/-77</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-78dc6bc53f1c760c66f43ff5f486bfe78a65bee8b2e0d4862293ec0892da2b29">+0/-123</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.elx.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9562070d7ad4a3e9b2d06567008cf35de1d96448d914b3b45bf6c36d97cdd914">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.spiffe.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-603fd9e7d40841d174f26b95d0cb0c9537430bf3f7a5da3ccbba4ea3d8ac66c9">+8/-157</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+318/-269</a></td>

</tr>

<tr>
  <td><strong>Dockerfile.agent-gateway</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-332bc81a932ae08efa711a71b60fe0954d99bf17ebdab00a3baaa177a44de8b0">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.core-elx</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-5ec7a971285669999af442a0c7f141c34f7fd9180257307f5c4ed12f789a2182">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.poller</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d3ba129830fb366bfe23b00db4ef6218b10fc981d3c04842b1b3b3b367a8982f">+0/-70</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.sync</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0227933b9961fd553af1d229e89d71a0271fdc475081bbcef49b587941af1eda">+0/-95</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.tools</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0258db71e4070e342198965f1d046f3097640850b037df8a2287a7e239630add">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.web-ng</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-92d43af1965575d56c3380ecc8a81024aac2ff36f039ec2d3839e9fc7852bc10">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent-minimal.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-1f09fad94636c90373af8e270f6ba0332ae4f4d1df50a4909729280a3a9691e6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-5d33fe703515d03076d31261ecf946e9c6fc668cf5bf65099d49b670739e455e">+5/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-008f2216f159a9bd5db9cc90baaf6f1e64487df7af05b56ab3b9d6c4946aa95f">+7/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bootstrap-nested-spire.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-ab4746a08fb1e0b307a1e47660cd22182e283a087cba87dcbff0fdfe750f44f1">+0/-80</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-3f2719d3dbfe042e8383739e3c78e74e5f851a44e5e46bea8e79c4b79fdcc34f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-3a45619e57f1e6e9a31486ec7fffb33ef246e271f82bac272ee0a946b88da70a">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db-event-writer.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9fc51271f7ef5bb460160013e24e44e829b730656891d26fc49d5fe72fbb3147">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db-event-writer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-7a33f95f7545499abf0ed9fc91b58499ab209639e4885019579c959583fc7496">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FRICTION_POINTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-b0653c58880f810ba832c0500733d63de309db98b43009fe73a1862494cf41bd">+0/-355</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-31849f033cfc932acee35f549c069abb1f36101c352e553dd6bff8713b29f98c">+0/-207</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SETUP_GUIDE.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-b4914f8640a78038e45f51235a624535672680dc902de5f107fc051f4f281913">+0/-307</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.edge-e2e.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-575d19ea771bdf8102cb9729db43a1bfd6afc2527160e54105beeac2e314f362">+0/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manage-packages.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-3c2ff6febbddb956c71557894adaf7d0a39a1f20dda120fe126364946bc47280">+0/-211</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup-edge-e2e.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2714e2c7e111f69ea9e9f5ddd7f6a70fa5ea96e3a53b851cb13b8b8b7cd12917">+0/-198</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>edge-poller-restart.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-96a8fe52c38fd0d7c14895127df34a27be311cac89c53d28ee178661b629bd22">+0/-178</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>downstream-agent.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-747de0375ced42af978ca7dac239862bdabb7f6bd0bd634f134b485517a7b4ee">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-686f1a954c542f2ec9bf14c3170648b65190ad242c7f3a95a0f872ae41b8b1c6">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-025f5b5ab79526cf549ca1fdb90dd659ba76b438f05a7f77d916d18728c4b572">+0/-51</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>upstream-agent.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e8a869ddf4affa31536a8d4e4e6f09c40072a7026da2c609d93c6ecf04138902">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-83d6800b184a5233c66c69766286b0a60fece1bc64addb112d9f8dc019437f05">+13/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-poller.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e202d27e3331088745eb55cdd2b3e40ac3f5df109d9ff5c76c0faed60772807a">+0/-274</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-sync.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9d5620b8e6833309dbafb8ee6b6b75c3b942d163c3fe7f1a9827958b2d640265">+0/-96</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fix-cert-permissions.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-17ea40a11edcaa7c85bb4215fda46b5a32505246fef0ab5f3ed47b28470c5ec8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-824f8797b418d4b9f5ea41e4a3741a0ed64b881f343072464489a76b7ea01008">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-8298241543b4744a6ac7780c760ac5b5a0a87ba62de19c8612ebe1aba0996ebd">+214/-12</a></td>

</tr>

<tr>
  <td><strong>nats.docker.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-06f2012494f428fe1bfb304972061c2094e0d99da88ba9af6914f7776872e6eb">+16/-160</a></td>

</tr>

<tr>
  <td><strong>netflow-consumer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-f15920e8498a24f71ce3eec4f48fe8fefbb1765a90362998af779a660fcef9e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d4af38790e3657b7589cd37a7539d5308b032f11caba7aa740ddc86bf99f4415">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_hba.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-7bd5f7292054916c7e5997f4c84ac9ec07d4c945621a48936c2aed0575fb96eb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_ident.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e7b8ce062e32c61fdc3bcc9e525c1f1df1c8008fbc02b11409e58c67baa17cc5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poller-stack.compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-f3b5c991c2c1f7646db0ca4ed9bcb5df0f313ce6a05d8f3c890f80c873f776f5">+0/-121</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d64ebb69ec31e831efd187c47a5bfff2573960306b177f6464e91cb44a3c709d">+0/-128</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-ef5d74bb3607431245c2bf06169d7fee89cae817e114035075b59a671229ab46">+0/-135</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.spiffe.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4e04bd23a0216287d5c0bb3831e0f95e7922ed03e8386a10ae7f4873e4fdb538">+0/-55</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>refresh-upstream-credentials.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d3b3a8fcdea1b49c9e1c0ecc12d61fb6d416313520e8ad52edbee9094dbdc271">+0/-248</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>seed-poller-kv.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c12070f475dbe7dc83e747fa6ec9d2ebdbdd97921a54f372abc89a102b783ad7">+0/-83</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup-edge-poller.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d7aec89d87f4cc98f4d6935e49a8f6ce571bc6dda254d894e93b60922f3a775f">+0/-204</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0cb49b4e37a7692f026133d5de971d449f42a1068226e848da5adf9af0ff4a2e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bootstrap-compose-spire.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-ca219a124d4c95ee7995764d7e0c322b4bfe59e357b7bcb42bc5d7c8b9b0af0d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.core.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-08d49d8621b581d1a9aa5c456f61e8c5774e021083c982cbb514019f915a1701">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.gateway.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4a43a8290d45ac68592000e7ef51afe78b4213090155bd42aafb46e66130f7ae">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ssl_dist.web.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-cef5be462ddb059fdfdeb9fd7c5cd70e656c4cd8b6ae1fe3fe312557b3da80ac">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sync.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4237fcee4f33a230abf28e12e8d4823499d163759cd1ff124fec1c62faa8b8b4">+0/-71</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sync.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-c652c07f7127be5b2932d92e6ef4c7448c544d1f3095cb96a03294fa58fd3c4c">+0/-75</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sysmon-osx.checker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-044334b566d907c77656b7f951092709da2a111dc968da9a76315b1c71200cf4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tools-profile.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-f47597e2f5d4d085d8bf109109608f8ec0b7db8e90545e869b9ae409b607a4ac">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trapd.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-1ab1a0e03e63bc02e0ef31992a7187a377927272ed2060150b40d44cc0ea3357">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-config.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-9ae50be83a13010a038389c74407ba1bde8cabcea0944e238c4b3374133f78bf">+1/-190</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>zen.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-e060a3164cdc2746e0d9ad000fcf43c4bcdb05f4a41c586d7220e2ff2a7df01d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-0e4db31c224a8f72ae8e870a849e38a59d74a2c7f7b04347b0b3eb07e20c5a80">+80/-84</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>push_targets.bzl</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-4af33fe62caba04b6d479589c16cfb85babc39bae5c92595d4d4e31660738513">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758a">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CNCF_DAY0.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-49a3c958df12738f89e0f701e36d8aee08dc3e8bf275a0421159cff0c2e5a9ce">+31/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CNCF_security_self_assessment.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-d64ffa4a0d2f25cc11d0731c714caa8b406a11b20bf63396fdb3144471e58105">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2230/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

