### PR TITLE
Fix/analytics page

### DIFF
--- a/elixir/serviceradar_core/lib/serviceradar/inventory/sync_ingestor.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/inventory/sync_ingestor.ex
@@ -34,6 +34,8 @@ defmodule ServiceRadar.Inventory.SyncIngestor do
       case Device.get_by_uid(device_id, tenant: tenant_schema, actor: actor, authorize?: false) do
         {:ok, device} ->
           device
+          |> Ash.Changeset.new()
+          |> Ash.Changeset.change_attribute(:last_seen_time, timestamp)
           |> Ash.Changeset.for_update(:update, update_attrs)
           |> Ash.update(tenant: tenant_schema, actor: actor, authorize?: false)
           |> case do
@@ -100,8 +102,6 @@ defmodule ServiceRadar.Inventory.SyncIngestor do
       mac: update.mac,
       hostname: update.hostname,
       name: update.hostname || update.ip,
-      last_seen_time: timestamp,
-      modified_time: timestamp,
       is_available: update.is_available,
       metadata: metadata
     }

--- a/pkg/core/gateways.go
+++ b/pkg/core/gateways.go
@@ -68,6 +68,12 @@ func (s *Server) MonitorGateways(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.handleMonitorTick(ctx)
+		case <-cleanupTicker.C:
+			if err := s.cleanupUnknownGateways(ctx); err != nil {
+				s.logger.Error().
+					Err(err).
+					Msg("Daily cleanup of unknown gateways failed")
+			}
 		}
 	}
 }

--- a/pkg/nats/accounts/BUILD.bazel
+++ b/pkg/nats/accounts/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = [
         "account_manager_test.go",
         "operator_test.go",
+        "test_keys_test.go",
         "user_manager_test.go",
     ],
     embed = [":accounts"],

--- a/pkg/nats/accounts/test_keys_test.go
+++ b/pkg/nats/accounts/test_keys_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Carver Automation Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accounts
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/nats-io/nkeys"
+)
+
+const testOperatorSeed = "SOAAFY5ZRTNXZC3KR3DIGXIF2CNEXXT3XPHRW2SMVS7WDDSZEOMAU3HDNY"
+const testAccountSeed = "SAAHPPNBNGJS55UFJ25VHHOKBBXFTZRFMOKVOIMD6E23SUDADM2YUDRNRE"
+
+var (
+	testOperatorOnce sync.Once
+	testOperator     *Operator
+	testOperatorErr  error
+)
+
+// newTestOperator returns a cached operator to avoid repeated key generation in tests.
+func newTestOperator(t *testing.T) *Operator {
+	t.Helper()
+
+	testOperatorOnce.Do(func() {
+		testOperator, testOperatorErr = NewOperator(&OperatorConfig{
+			Name:         "test-operator",
+			OperatorSeed: testOperatorSeed,
+		})
+	})
+
+	if testOperatorErr != nil {
+		t.Fatalf("NewOperator() error = %v", testOperatorErr)
+	}
+
+	return testOperator
+}
+
+func testOperatorPublicKey(t *testing.T) string {
+	t.Helper()
+
+	return publicKeyFromSeed(t, testOperatorSeed)
+}
+
+func testAccountPublicKey(t *testing.T) string {
+	t.Helper()
+
+	return publicKeyFromSeed(t, testAccountSeed)
+}
+
+func publicKeyFromSeed(t *testing.T, seed string) string {
+	t.Helper()
+
+	kp, err := nkeys.FromSeed([]byte(seed))
+	if err != nil {
+		t.Fatalf("nkeys.FromSeed() error = %v", err)
+	}
+
+	pubKey, err := kp.PublicKey()
+	if err != nil {
+		t.Fatalf("kp.PublicKey() error = %v", err)
+	}
+
+	return pubKey
+}

--- a/pkg/nats/accounts/test_keys_test.go
+++ b/pkg/nats/accounts/test_keys_test.go
@@ -26,6 +26,7 @@ import (
 const testOperatorSeed = "SOAAFY5ZRTNXZC3KR3DIGXIF2CNEXXT3XPHRW2SMVS7WDDSZEOMAU3HDNY"
 const testAccountSeed = "SAAHPPNBNGJS55UFJ25VHHOKBBXFTZRFMOKVOIMD6E23SUDADM2YUDRNRE"
 
+//nolint:gochecknoglobals // test-only globals for sync.Once caching pattern
 var (
 	testOperatorOnce sync.Once
 	testOperator     *Operator

--- a/web-ng/lib/serviceradar_web_ng/srql/ash_adapter.ex
+++ b/web-ng/lib/serviceradar_web_ng/srql/ash_adapter.ex
@@ -545,8 +545,10 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
   defp maybe_apply_offset(query, offset, true), do: apply_offset(query, offset)
 
   defp apply_offset(query, nil), do: query
+
   defp apply_offset(query, offset) when is_integer(offset) and offset > 0,
     do: Ash.Query.offset(query, offset)
+
   defp apply_offset(query, _), do: query
 
   # Execute the query against the Ash domain

--- a/web-ng/lib/serviceradar_web_ng/srql/ash_adapter.ex
+++ b/web-ng/lib/serviceradar_web_ng/srql/ash_adapter.ex
@@ -244,17 +244,22 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
   """
   def query(entity, params, scope \\ nil) do
     with {:ok, resource} <- get_resource(entity),
-         {:ok, domain} <- get_domain(entity),
-         {:ok, query} <- build_query(resource, entity, params) do
+         {:ok, domain} <- get_domain(entity) do
       # Check if this is a stats query (aggregation)
       case Map.get(params, :stats) do
         stats when is_list(stats) and stats != [] ->
-          execute_stats_query(query, stats, scope, entity, params)
+          with {:ok, query} <- build_query(resource, entity, params, apply_pagination?: false) do
+            execute_stats_query(query, stats, scope, entity, params)
+          end
 
         _ ->
-          case execute_query(domain, query, scope) do
-            {:ok, results} -> {:ok, format_response(results, entity, params)}
-            {:error, reason} -> {:error, reason}
+          with {:ok, offset} <- decode_cursor(Map.get(params, :cursor)),
+               {:ok, query} <-
+                 build_query(resource, entity, Map.put(params, :offset, offset)) do
+            case execute_query(domain, query, scope) do
+              {:ok, results} -> {:ok, format_response(results, entity, params, offset)}
+              {:error, reason} -> {:error, reason}
+            end
           end
       end
     else
@@ -266,13 +271,7 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
 
   # Execute a stats/aggregation query
   defp execute_stats_query(query, stats, scope, entity, params) do
-    # Extract tenant and actor from scope for explicit passing
-    {tenant, actor} = extract_tenant_and_actor(scope)
-
-    opts =
-      []
-      |> maybe_add_opt(:tenant, tenant)
-      |> maybe_add_opt(:actor, actor)
+    opts = if scope, do: [scope: scope], else: []
 
     # Build result map from stats
     result =
@@ -289,25 +288,6 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
 
     {:ok, format_stats_response(result, entity, params)}
   end
-
-  # Extract tenant and actor from scope
-  defp extract_tenant_and_actor(nil), do: {nil, nil}
-
-  defp extract_tenant_and_actor(%{active_tenant: tenant, user: user}) do
-    # Convert tenant to schema string using TenantSchemas
-    tenant_schema =
-      case tenant do
-        %{id: id} -> ServiceRadar.Cluster.TenantSchemas.schema_for_tenant(id)
-        _ -> nil
-      end
-
-    {tenant_schema, user}
-  end
-
-  defp extract_tenant_and_actor(_), do: {nil, nil}
-
-  defp maybe_add_opt(opts, _key, nil), do: opts
-  defp maybe_add_opt(opts, key, value), do: [{key, value} | opts]
 
   defp execute_single_stat(query, %{type: :count, alias: _alias}, opts) do
     case Ash.count(query, opts) do
@@ -399,14 +379,18 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
   end
 
   # Build an Ash query from SRQL parameters
-  defp build_query(resource, entity, params) do
-    query = Ash.Query.new(resource)
+  defp build_query(resource, entity, params, opts \\ []) do
+    apply_pagination? = Keyword.get(opts, :apply_pagination?, true)
+    limit = Map.get(params, :limit)
+    offset = Map.get(params, :offset)
 
     query =
-      query
+      resource
+      |> Ash.Query.for_read(:read, %{})
       |> apply_filters(entity, Map.get(params, :filters, []))
       |> apply_sort(entity, Map.get(params, :sort))
-      |> apply_limit(Map.get(params, :limit))
+      |> maybe_apply_offset(offset, apply_pagination?)
+      |> maybe_apply_limit(limit, apply_pagination?)
 
     {:ok, query}
   rescue
@@ -536,12 +520,23 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
     end
   end
 
+  defp maybe_apply_limit(query, _limit, false), do: query
+  defp maybe_apply_limit(query, limit, true), do: apply_limit(query, limit)
+
   defp apply_limit(query, nil), do: Ash.Query.limit(query, 100)
 
   defp apply_limit(query, limit) when is_integer(limit) and limit > 0,
     do: Ash.Query.limit(query, limit)
 
   defp apply_limit(query, _), do: Ash.Query.limit(query, 100)
+
+  defp maybe_apply_offset(query, _offset, false), do: query
+  defp maybe_apply_offset(query, offset, true), do: apply_offset(query, offset)
+
+  defp apply_offset(query, nil), do: query
+  defp apply_offset(query, offset) when is_integer(offset) and offset > 0,
+    do: Ash.Query.offset(query, offset)
+  defp apply_offset(query, _), do: query
 
   # Execute the query against the Ash domain
   # Uses scope: option which automatically extracts actor/tenant via Ash.Scope.ToOpts
@@ -551,17 +546,13 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
   end
 
   # Format the response to match SRQL response format
-  defp format_response(results, entity, params) when is_list(results) do
+  defp format_response(results, entity, params, offset) do
     limit = Map.get(params, :limit, 100)
+    {rows, _page} = normalize_page_results(results)
 
     %{
-      "results" => Enum.map(results, &format_result(&1, entity)),
-      "pagination" => %{
-        # Keyset pagination is not implemented yet.
-        "next_cursor" => nil,
-        "prev_cursor" => nil,
-        "limit" => limit
-      },
+      "results" => Enum.map(rows, &format_result(&1, entity)),
+      "pagination" => build_pagination(offset, limit, rows),
       "viz" => nil,
       "error" => nil
     }
@@ -612,4 +603,54 @@ defmodule ServiceRadarWebNG.SRQL.AshAdapter do
   # Skip unloaded associations
   defp format_value(value) when is_struct(value), do: nil
   defp format_value(value), do: value
+
+  defp normalize_page_results(%Ash.Page.Keyset{} = page), do: {page.results, page}
+  defp normalize_page_results(%Ash.Page.Offset{} = page), do: {page.results, page}
+  defp normalize_page_results(results) when is_list(results), do: {results, nil}
+  defp normalize_page_results(_), do: {[], nil}
+
+  defp build_pagination(offset, limit, results) do
+    %{
+      "next_cursor" => next_cursor(offset, limit, results),
+      "prev_cursor" => prev_cursor(offset, limit),
+      "limit" => limit
+    }
+  end
+
+  defp next_cursor(offset, limit, results)
+       when is_integer(offset) and is_integer(limit) and limit > 0 do
+    if length(results) >= limit do
+      encode_cursor(offset + limit)
+    else
+      nil
+    end
+  end
+
+  defp next_cursor(_, _, _), do: nil
+
+  defp prev_cursor(offset, limit)
+       when is_integer(offset) and is_integer(limit) and limit > 0 and offset > 0 do
+    encode_cursor(max(offset - limit, 0))
+  end
+
+  defp prev_cursor(_, _), do: nil
+
+  defp decode_cursor(nil), do: {:ok, 0}
+
+  defp decode_cursor(cursor) when is_binary(cursor) do
+    with {:ok, payload} <- Base.url_decode64(cursor, padding: false),
+         {:ok, %{"offset" => offset}} <- Jason.decode(payload),
+         true <- is_integer(offset) do
+      {:ok, max(offset, 0)}
+    else
+      _ -> {:error, "invalid cursor"}
+    end
+  end
+
+  defp decode_cursor(_), do: {:error, "invalid cursor"}
+
+  defp encode_cursor(offset) when is_integer(offset) do
+    payload = Jason.encode!(%{offset: max(offset, 0)})
+    Base.url_encode64(payload, padding: false)
+  end
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
@@ -406,6 +406,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
 
   defp extract_count_value(value) when is_integer(value), do: value
   defp extract_count_value(value) when is_float(value), do: trunc(value)
+  defp extract_count_value(%Decimal{} = value), do: Decimal.to_integer(value)
 
   defp extract_count_value(value) when is_binary(value) do
     case Integer.parse(String.trim(value)) do
@@ -428,6 +429,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
 
   defp parse_count_value(value) when is_integer(value), do: value
   defp parse_count_value(value) when is_float(value), do: trunc(value)
+  defp parse_count_value(%Decimal{} = value), do: Decimal.to_integer(value)
 
   defp parse_count_value(value) when is_binary(value) do
     case Integer.parse(String.trim(value)) do


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Refactoring


___

### **Description**
- **Major architectural refactoring from poller-based to gateway-based system**: Comprehensive terminology and implementation changes throughout the codebase replacing `poller` with `gateway`

- **Multi-tenant gateway push architecture**: Refactored sync service to support push-first communication model with gateway clients replacing pull-based gRPC methods

- **Gateway monitoring and status management**: New comprehensive implementation for gateway health checks, offline/recovery detection, alert handling, and streaming status report support

- **NATS bootstrap and account management**: Added CLI implementation for NATS bootstrap functionality with operator, system account, and platform account generation for multi-tenant routing

- **Protobuf definitions update**: Refactored protobuf messages from poller to gateway architecture with new agent-gateway communication types and service definitions

- **Edge onboarding enhancements**: Updated edge onboarding to support gateway terminology and added `EdgeOnboardingComponentTypeSync` component type support

- **Removed legacy poller infrastructure**: Deleted poller-specific packages, CLI commands, and related implementations in favor of gateway-based approach


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy Poller<br/>Architecture"] -->|"Refactor to"| B["Gateway-Based<br/>Architecture"]
  B -->|"Implements"| C["Push-First<br/>Communication"]
  B -->|"Adds"| D["Multi-Tenant<br/>Support"]
  B -->|"Includes"| E["Gateway Monitoring<br/>& Status Mgmt"]
  C -->|"Replaces"| F["Pull-Based<br/>gRPC Methods"]
  D -->|"Uses"| G["NATS Account<br/>Management"]
  E -->|"Provides"| H["Health Checks &<br/>Alert Handling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>monitoring.pb.go</strong><dd><code>Refactor protobuf definitions from poller to gateway architecture</code></dd></summary>
<hr>

proto/monitoring.pb.go

<ul><li>Renamed <code>PollerId</code> field to <code>GatewayId</code> across multiple message types <br>(<code>StatusRequest</code>, <code>ResultsRequest</code>, <code>StatusResponse</code>, <code>ResultsResponse</code>)<br> <li> Removed deprecated <code>PollerStatusRequest</code>, <code>PollerStatusResponse</code>, and <br><code>ServiceStatus</code> message types<br> <li> Replaced <code>PollerStatusChunk</code> with new <code>GatewayStatusRequest</code>, <br><code>GatewayStatusResponse</code>, and <code>GatewayStatusChunk</code> types<br> <li> Added new <code>GatewayServiceStatus</code> message type with tenant-related fields <br>(<code>TenantId</code>, <code>TenantSlug</code>)<br> <li> Added new agent-gateway communication messages: <code>AgentHelloRequest</code>, <br><code>AgentHelloResponse</code>, <code>AgentConfigRequest</code>, <code>AgentConfigResponse</code>, <br><code>AgentCheckConfig</code><br> <li> Updated service definitions from <code>PollerService</code> to <code>AgentGatewayService</code> <br>with new RPC methods</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4f7e955b42854cc9cf3fb063b95e58a04f36271e6a0c1cb42ea6d7953dd96cc4">+1039/-404</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_bootstrap.go</strong><dd><code>Add comprehensive NATS bootstrap CLI implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cli/nats_bootstrap.go

<ul><li>New file implementing NATS bootstrap functionality for ServiceRadar <br>CLI<br> <li> Provides handlers for <code>nats-bootstrap</code> and <code>admin nats</code> subcommands with <br>support for token-based and local bootstrap modes<br> <li> Implements NATS operator, system account, and platform account <br>generation and configuration<br> <li> Includes verification mode to validate existing NATS bootstrap <br>configurations<br> <li> Supports multi-tenant routing with tenant ID and slug fields</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2176d03ba6ab4ccc1b0587a4727171546eecf6123e4df815ead583aaab062457">+961/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Multi-tenant gateway push architecture with dynamic config</code></dd></summary>
<hr>

pkg/sync/service.go

<ul><li>Refactored sync service to support multi-tenant architecture with <br>gateway push-first communication model<br> <li> Removed KV client and gRPC client dependencies; added gateway client <br>for push-based results and status reporting<br> <li> Implemented per-source discovery scheduling with interval tracking and <br>per-tenant configuration management<br> <li> Added gateway enrollment, config polling, and heartbeat loops for <br>dynamic configuration updates<br> <li> Deprecated pull-based <code>GetResults</code> and <code>StreamResults</code> gRPC methods in <br>favor of push-based gateway communication</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-b4ea5a5b3d811fa94c6a84c71c0ddb920ce177a376d13cb776f05dd6017c4c7e">+1258/-316</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gateways.go</strong><dd><code>Gateway monitoring and status management implementation</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/core/gateways.go

<ul><li>New comprehensive gateway monitoring and status management <br>implementation with 1541 lines of core functionality<br> <li> Implements gateway health checks, offline/recovery detection, and <br>alert handling with event publishing to NATS<br> <li> Adds streaming status report support for large datasets with chunk <br>reassembly and service message processing<br> <li> Includes device registration, service registry integration, and <br>auto-registration of gateways/agents/checkers</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-260332914ad2238e720f4637a71b0f9f01e899102bc6b37f7827782e56b0b5c0">+1541/-0</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Update API documentation terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/core/main.go

<ul><li>Updated API description from "service pollers" to "service gateways" <br>to reflect architectural terminology change</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4ab3fd1d4debc53dd2499d94a0f60c648fdae4235dd1e3678095a975f5bb434a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>prod.exs</strong><dd><code>Add Elixir production configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_agent_gateway/config/prod.exs

<ul><li>New production configuration file for Elixir agent-gateway module<br> <li> Sets logger level to <code>info</code> for production environment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-5fdc859dfda96a02326392f61218325913f22f9f0c75a1276ee940d5db9fc62b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prod.exs</strong><dd><code>Elixir production configuration setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/config/prod.exs

<ul><li>Added new production configuration file for Elixir application<br> <li> Sets logger level to <code>info</code> for production environment</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4fe837307f8710c783ecb9ae7595bb7bb9ec37d8522248bd081fa256803c3e92">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.gitkeep</strong><dd><code>Docker Compose credentials directory placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/compose/creds/.gitkeep

<ul><li>Creates new empty placeholder file for credentials directory in Docker <br>Compose setup</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d72c41aab2d6f2c230a4340dfefe7917cdd12bed942c825aa0d4c9875a637bac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nats_account.pb.go</strong><dd><code>NATS account management protobuf definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/nats_account.pb.go

<ul><li>Generated protobuf code for NATS account management service with 15 <br>message types and 1 enum<br> <li> Defines account creation, user credential generation, JWT signing, and <br>operator bootstrap operations<br> <li> Includes resource limits, subject mappings, and permission management <br>for tenant isolation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-49eb93c28e2d86d8dcf4ee78fd24bed498cf3fcfaa8e49849a36e70980420087">+1266/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nats_account_grpc.pb.go</strong><dd><code>NATS account service gRPC definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

proto/nats_account_grpc.pb.go

<ul><li>Auto-generated gRPC service definitions for <code>NATSAccountService</code> with <br>six RPC methods<br> <li> Implements stateless NATS JWT signing operations for operator <br>bootstrap, tenant account creation, and user credentials<br> <li> Includes client and server interfaces with full gRPC handler <br>implementations and service registration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-af98ae5f073d25a2ea0a044c996542fc65d215f6a70f14a9fba0447d87b34e11">+376/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mock_armis.go</strong><dd><code>Remove KVWriter from Armis mock interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sync/integrations/armis/mock_armis.go

<ul><li>Updated mock generation command to remove <code>KVWriter</code> interface from <br>mocked interfaces<br> <li> Reflects removal of KV write functionality from Armis integration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-54fcd2e5cc009f705d49f5acabba4c8bf66841758c70ea6b8474f7e9318e8e46">+2/-40</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>edge_onboarding.go</strong><dd><code>Poller to gateway terminology refactoring and sync support</code></dd></summary>
<hr>

pkg/core/edge_onboarding.go

<ul><li>Comprehensive refactoring renaming <code>poller</code> terminology to <code>gateway</code> <br>throughout the file (100+ occurrences)<br> <li> Updates type names, function names, variable names, and comments to <br>reflect gateway-centric architecture<br> <li> Adds support for <code>EdgeOnboardingComponentTypeSync</code> component type in <br>package creation and validation<br> <li> Updates KV configuration paths from <code>config/pollers/</code> to <br><code>config/gateways/</code> and related metadata keys</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-85874e3c4bdcc9110db09909f10648d44cdee554b26c987f910502321eb20b5c">+208/-206</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>SNMP checker gateway terminology update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/checkers/snmp/main.go

<ul><li>Updates SNMP checker service instantiation from <code>NewSNMPPollerService</code> <br>to <code>NewSNMPGatewayService</code><br> <li> Changes struct type from <code>snmp.Poller</code> to <code>snmp.Gateway</code> for consistency <br>with gateway terminology</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-f25402eade63525184cb5e7437accff93c7b9338eebe81add6dc5f2a9eb12550">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>.bazelignore</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-a5641cd37d6ad98b32cdfce1980836cc68312277bc6a7052f55da02ada5bc6cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.bazelrc</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-544556920c45b42cbfe40159b082ce8af6bd929e492d076769226265f215832f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env-sample</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-c4368a972a7fa60d9c4e333cebf68cdb9a67acb810451125c02e3b7eb2594e3d">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+177/-11</a></td>

</tr>

<tr>
  <td><strong>INSTALL.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MODULE.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Makefile</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+55/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README-Docker.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9fd61d24482efe68c22d8d41e2a1dcc440f39195aa56e7a050f2abe598179efd">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ROADMAP.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-884fa9353a5226345e44fbabea3300efc7a87dfbcde0b6a42521ca51823f1b68">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-0e80ea46aeb61a873324685edb96eae864c7a2004fbb7ee404b4ec951190ba10">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mix_release.bzl</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-86ec281f99363b6b6eb1f49e21d83b7eeca93a35b552b9f305fffc6855e38ccd">+124/-49</a></td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-143f8d1549d52f28906f19ce28e5568a5be474470ff103c2c1e63c3e6b08d670">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-bfd308915d0cf522e7fc76600dee687617dc69165ab22502a1d219850c0c0860">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-5b1bc8fe77422534739bdd3a38dc20d2634a86c171265c34e1b5d0c5a61b6bab">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-61358711e980ccf505246fd3915f97cbd3a380e9b66f6fa5aad46749968c5ca3">+174/-74</a></td>

</tr>

<tr>
  <td><strong>build.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-251e7a923f45f8f903e510d10f183366bda06d281c8ecc3669e1858256e2186d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monitoring.proto</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-b56f709f4a0a3db694f2124353908318631f23e20b7846bc4b8ee869e2e0632a">+3/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-bce0f4ca6548712f224b73816825d28e831acbbff7dbed3c98671ed50f65d028">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2e9751b437fa61442aac074c7a4a912d0ac50ac3ea156ac8aedd8478d21c6bdb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monitoring.proto</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9faf6025eb0d3d38383f5b7ad2b733abeb38454d5e4de3e83994e94b12d87a50">+2/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2c4395fee16396339c3eea518ad9bec739174c67c9cedf62e6848c17136dd33e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-ed4d81d29a7267f93fd77e17993fd3491b9ef6ded18490b4514d10ed1d803bc2">+16/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-05038f3867985e757de9027609950e682bad6d1992dac6acd7c28962a3c65dc4">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>grpc_server.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e4564a93f6cf84ff91cd3d8141fc9272ec9b4ec19defd107afa42be01fcfed5b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>message_processor.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9fcbc5358a9009e60a8cd22d21e5a9ea652787c727732d0b869e0865495114c3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-97f7335def0ad5d644b594a1076ae2d7080b11259cbb8de22c7946cc8e4b39f8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer-with-otel.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-68375f1f7847e1fbdf75664f6be65b1ad94ae6ce86ed73fc5964d65054668acb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zen-consumer.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4d308af9802a93a0f656e8c02a3b5fcd8991407bb18360f087470db74e1f9524">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4ad8a289575edf3b163088617b7a40ae1305c29ced0c7d59b3751c57d6938072">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2423ef78d36e905ae993b69ff59f5df6b2e1b9492fb0fa8c6d0aad7c76d2d229">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-ef778d85ac6f9652c25cb0d631f0fe8dfb3edac4dde5d719a4fc2926fb5c3216">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-c62c0139ebdb337369f4067567cd2c52b8e7decb3ddfabc77f9f67b2f6e5789c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-5e7731adfb877918cd65d9d5531621312496450fd550fea2682efca4ca8fe816">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-0b0725713b87dca1de57200214a4fe04633f0d856c39aa8032280227bf8e8141">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-f425b4378f84e0ba0c6f532facff17ff5d55b4dc6033d8bf35130a159cd2ba32">+9/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-af9f49f931e282dca53d1f0521b036d222fe671f77e61a876a84cf4c6d7cca4d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats_output.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-a82e2e4d413539bf0b414b5629665b19648447523994cba639c4d1238aa5a0c1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-c64b9ace832b8ea57a2be62f84166e03bb1904882635d444ec76a880cdf14cc0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-abbaec651da3d6af96b482e0f77bb909b65dbe0cabd78b5803769cc9dab0a1b0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nats_output.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-6b585ea3564a481174e04da1270e2e13edd4e2b980d02a2652d6d21e6d82a498">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-3891f667deb20fd26e296d3e2742c57378d3764fe1743118e612465ae360391f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e1f7c698e0e3a4e6afa971c1140e71cbf22593fbb19c81cb26b02c15c5dc46ec">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9edc2486fff55fc399e0ac96dba5137948a7ea7285f5ef7846835355684b7ab5">+0/-111</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4b8ec845da50cd58d011e69f9d1c30530ee1968df26616b8768bb1fc03433bbe">+0/-138</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BUILD.bazel</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4f5d2ea4260d490a0d6f28adde0b35eca8af77d22f3ee366a783946c53687619">+0/-25</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-bcac20d6b3cb81f0059e766839ba1ee59a885009249501b0ba1182ebb1daea25">+0/-77</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-78dc6bc53f1c760c66f43ff5f486bfe78a65bee8b2e0d4862293ec0892da2b29">+0/-123</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-bc6eeb1b05bcb9179525e32fac1de9926b5823ec3504be546ab10c5c9740f544">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-c89b88ba4d2bf0a054d0ba69a672a92c30140b8d19503d67b980a218ffe3106d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.rs</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-33b655d8730ae3e9c844ee280787d11f1b0d5343119188273f89558805f814ba">+23/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.elx.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9562070d7ad4a3e9b2d06567008cf35de1d96448d914b3b45bf6c36d97cdd914">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.spiffe.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-603fd9e7d40841d174f26b95d0cb0c9537430bf3f7a5da3ccbba4ea3d8ac66c9">+8/-158</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+318/-269</a></td>

</tr>

<tr>
  <td><strong>Dockerfile.agent-gateway</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-332bc81a932ae08efa711a71b60fe0954d99bf17ebdab00a3baaa177a44de8b0">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.core-elx</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-5ec7a971285669999af442a0c7f141c34f7fd9180257307f5c4ed12f789a2182">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.poller</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d3ba129830fb366bfe23b00db4ef6218b10fc981d3c04842b1b3b3b367a8982f">+0/-70</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.sync</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-0227933b9961fd553af1d229e89d71a0271fdc475081bbcef49b587941af1eda">+0/-95</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.tools</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-0258db71e4070e342198965f1d046f3097640850b037df8a2287a7e239630add">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile.web-ng</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-92d43af1965575d56c3380ecc8a81024aac2ff36f039ec2d3839e9fc7852bc10">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent-minimal.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-1f09fad94636c90373af8e270f6ba0332ae4f4d1df50a4909729280a3a9691e6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-5d33fe703515d03076d31261ecf946e9c6fc668cf5bf65099d49b670739e455e">+5/-20</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-008f2216f159a9bd5db9cc90baaf6f1e64487df7af05b56ab3b9d6c4946aa95f">+7/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bootstrap-nested-spire.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-ab4746a08fb1e0b307a1e47660cd22182e283a087cba87dcbff0fdfe750f44f1">+0/-80</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-3f2719d3dbfe042e8383739e3c78e74e5f851a44e5e46bea8e79c4b79fdcc34f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasvc.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-3a45619e57f1e6e9a31486ec7fffb33ef246e271f82bac272ee0a946b88da70a">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db-event-writer.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9fc51271f7ef5bb460160013e24e44e829b730656891d26fc49d5fe72fbb3147">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db-event-writer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-7a33f95f7545499abf0ed9fc91b58499ab209639e4885019579c959583fc7496">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FRICTION_POINTS.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-b0653c58880f810ba832c0500733d63de309db98b43009fe73a1862494cf41bd">+0/-355</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-31849f033cfc932acee35f549c069abb1f36101c352e553dd6bff8713b29f98c">+0/-207</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SETUP_GUIDE.md</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-b4914f8640a78038e45f51235a624535672680dc902de5f107fc051f4f281913">+0/-307</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.edge-e2e.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-575d19ea771bdf8102cb9729db43a1bfd6afc2527160e54105beeac2e314f362">+0/-27</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manage-packages.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-3c2ff6febbddb956c71557894adaf7d0a39a1f20dda120fe126364946bc47280">+0/-211</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup-edge-e2e.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2714e2c7e111f69ea9e9f5ddd7f6a70fa5ea96e3a53b851cb13b8b8b7cd12917">+0/-198</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>edge-poller-restart.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-96a8fe52c38fd0d7c14895127df34a27be311cac89c53d28ee178661b629bd22">+0/-178</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>downstream-agent.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-747de0375ced42af978ca7dac239862bdabb7f6bd0bd634f134b485517a7b4ee">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>env</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-686f1a954c542f2ec9bf14c3170648b65190ad242c7f3a95a0f872ae41b8b1c6">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-025f5b5ab79526cf549ca1fdb90dd659ba76b438f05a7f77d916d18728c4b572">+0/-51</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>upstream-agent.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e8a869ddf4affa31536a8d4e4e6f09c40072a7026da2c609d93c6ecf04138902">+0/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-83d6800b184a5233c66c69766286b0a60fece1bc64addb112d9f8dc019437f05">+13/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-poller.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e202d27e3331088745eb55cdd2b3e40ac3f5df109d9ff5c76c0faed60772807a">+0/-274</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>entrypoint-sync.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-9d5620b8e6833309dbafb8ee6b6b75c3b942d163c3fe7f1a9827958b2d640265">+0/-96</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fix-cert-permissions.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-17ea40a11edcaa7c85bb4215fda46b5a32505246fef0ab5f3ed47b28470c5ec8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flowgger.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-824f8797b418d4b9f5ea41e4a3741a0ed64b881f343072464489a76b7ea01008">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate-certs.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-8298241543b4744a6ac7780c760ac5b5a0a87ba62de19c8612ebe1aba0996ebd">+214/-12</a></td>

</tr>

<tr>
  <td><strong>nats.docker.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-06f2012494f428fe1bfb304972061c2094e0d99da88ba9af6914f7776872e6eb">+16/-160</a></td>

</tr>

<tr>
  <td><strong>netflow-consumer.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-f15920e8498a24f71ce3eec4f48fe8fefbb1765a90362998af779a660fcef9e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>otel.docker.toml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d4af38790e3657b7589cd37a7539d5308b032f11caba7aa740ddc86bf99f4415">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_hba.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-7bd5f7292054916c7e5997f4c84ac9ec07d4c945621a48936c2aed0575fb96eb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pg_ident.conf</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-e7b8ce062e32c61fdc3bcc9e525c1f1df1c8008fbc02b11409e58c67baa17cc5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>poller-stack.compose.yml</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-f3b5c991c2c1f7646db0ca4ed9bcb5df0f313ce6a05d8f3c890f80c873f776f5">+0/-121</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.docker.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d64ebb69ec31e831efd187c47a5bfff2573960306b177f6464e91cb44a3c709d">+0/-128</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.mtls.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-ef5d74bb3607431245c2bf06169d7fee89cae817e114035075b59a671229ab46">+0/-135</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>poller.spiffe.json</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-4e04bd23a0216287d5c0bb3831e0f95e7922ed03e8386a10ae7f4873e4fdb538">+0/-55</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>refresh-upstream-credentials.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d3b3a8fcdea1b49c9e1c0ecc12d61fb6d416313520e8ad52edbee9094dbdc271">+0/-248</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>seed-poller-kv.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-c12070f475dbe7dc83e747fa6ec9d2ebdbdd97921a54f372abc89a102b783ad7">+0/-83</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup-edge-poller.sh</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-d7aec89d87f4cc98f4d6935e49a8f6ce571bc6dda254d894e93b60922f3a775f">+0/-204</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2233/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

