### PR TITLE
Refactor/zen tenant isolation

### DIFF
--- a/cmd/tenant-workload-operator/main.go
+++ b/cmd/tenant-workload-operator/main.go
@@ -79,6 +79,21 @@ const (
 	defaultWorkloadSetNamePrefix = "serviceradar-tenant"
 )
 
+var (
+	errNATSURLRequired               = errors.New("NATS_URL is required")
+	errTenantNATSCredsSecretTemplate = errors.New("TENANT_NATS_CREDS_SECRET_TEMPLATE must contain %s placeholder")
+	errTenantEventSubjectRequired    = errors.New("tenant event subject is required")
+	errMissingTenantIdentifiers      = errors.New("missing tenant identifiers in event")
+	errMissingTemplateSpec           = errors.New("missing template spec")
+	errMissingWorkloadSetSpec        = errors.New("missing workload set spec")
+	errNoTenantWorkloadTemplates     = errors.New("no tenant workload templates available")
+	errNATSCredsSecretMissing        = errors.New("nats creds secret missing")
+	errCoreAPIURLRequired            = errors.New("CORE_API_URL is required to fetch tenant creds")
+	errCoreAPIStatus                 = errors.New("core api status")
+	errCoreAPIResponseMissingCreds   = errors.New("core api response missing creds")
+	errInvalidNATSCAFile             = errors.New("invalid NATS CA file")
+)
+
 type Config struct {
 	Namespace                 string
 	TrustDomain               string
@@ -257,21 +272,25 @@ type TenantWorkloadRef struct {
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
 
 	cfg, err := loadConfig()
 	if err != nil {
+		stop()
 		log.Fatalf("config error: %v", err)
 	}
 
 	kubeClient, err := newKubeClient()
 	if err != nil {
+		stop()
 		log.Fatalf("kubernetes client error: %v", err)
 	}
 
 	if err := run(ctx, cfg, kubeClient); err != nil && !errors.Is(err, context.Canceled) {
+		stop()
 		log.Fatalf("operator error: %v", err)
 	}
+
+	stop()
 }
 
 func loadConfig() (Config, error) {
@@ -331,10 +350,10 @@ func loadConfig() (Config, error) {
 	}
 
 	if cfg.NATSURL == "" {
-		return Config{}, fmt.Errorf("NATS_URL is required")
+		return Config{}, errNATSURLRequired
 	}
 	if cfg.TenantNATSCredsSecretTmpl == "" || !strings.Contains(cfg.TenantNATSCredsSecretTmpl, "%s") {
-		return Config{}, fmt.Errorf("TENANT_NATS_CREDS_SECRET_TEMPLATE must contain %%s placeholder")
+		return Config{}, errTenantNATSCredsSecretTemplate
 	}
 	return cfg, nil
 }
@@ -444,7 +463,7 @@ func connectNATS(ctx context.Context, cfg Config) (*nats.Conn, jetstream.JetStre
 func ensureStream(ctx context.Context, js jetstream.JetStream, cfg Config) error {
 	subject := strings.TrimSpace(cfg.TenantSubject)
 	if subject == "" {
-		return fmt.Errorf("tenant event subject is required")
+		return errTenantEventSubjectRequired
 	}
 
 	stream, err := js.Stream(ctx, cfg.TenantStream)
@@ -551,7 +570,7 @@ func handleMessage(ctx context.Context, kubeClient client.Client, cfg Config, ms
 	}
 
 	if event.TenantID == "" || event.TenantSlug == "" {
-		return fmt.Errorf("missing tenant identifiers in event")
+		return errMissingTenantIdentifiers
 	}
 
 	isDelete := strings.EqualFold(event.EventType, "tenant.deleted") ||
@@ -654,7 +673,7 @@ func listTenantWorkloadSets(ctx context.Context, kubeClient client.Client, names
 func decodeTenantWorkloadTemplate(item unstructured.Unstructured) (TenantWorkloadTemplate, error) {
 	specMap, ok := item.Object["spec"].(map[string]interface{})
 	if !ok {
-		return TenantWorkloadTemplate{}, fmt.Errorf("missing template spec")
+		return TenantWorkloadTemplate{}, errMissingTemplateSpec
 	}
 	var spec TenantWorkloadTemplateSpec
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(specMap, &spec); err != nil {
@@ -674,7 +693,7 @@ func decodeTenantWorkloadTemplate(item unstructured.Unstructured) (TenantWorkloa
 func decodeTenantWorkloadSet(item unstructured.Unstructured) (TenantWorkloadSet, error) {
 	specMap, ok := item.Object["spec"].(map[string]interface{})
 	if !ok {
-		return TenantWorkloadSet{}, fmt.Errorf("missing workload set spec")
+		return TenantWorkloadSet{}, errMissingWorkloadSetSpec
 	}
 	var spec TenantWorkloadSetSpec
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(specMap, &spec); err != nil {
@@ -833,7 +852,7 @@ func resolveWorkloadRefs(
 	templates []TenantWorkloadTemplate,
 ) ([]TenantWorkloadRef, error) {
 	if len(templates) == 0 {
-		return nil, fmt.Errorf("no tenant workload templates available")
+		return nil, errNoTenantWorkloadTemplates
 	}
 
 	requested := event.Workloads
@@ -862,7 +881,7 @@ func resolveWorkloadRefs(
 	}
 
 	var refs []TenantWorkloadRef
-	var unknown []string
+	unknown := make([]string, 0, len(requested))
 	seen := map[string]bool{}
 	for _, workload := range requested {
 		normalized := normalizeWorkloadName(workload)
@@ -977,10 +996,7 @@ func ensureWorkloadResources(
 		}
 	}
 
-	podSpec, err := buildWorkloadPodSpec(cfg, set, template, serviceAccount, configMapName, natsSecretName)
-	if err != nil {
-		return err
-	}
+	podSpec := buildWorkloadPodSpec(cfg, set, template, serviceAccount, configMapName, natsSecretName)
 
 	switch strings.ToLower(template.Spec.WorkloadKind) {
 	case "daemonset":
@@ -988,7 +1004,7 @@ func ensureWorkloadResources(
 		_, err := controllerutil.CreateOrUpdate(ctx, kubeClient, daemonSet, func() error {
 			daemonSet.Labels = mergeLabels(daemonSet.Labels, labels)
 			daemonSet.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			daemonSet.Spec.Template.ObjectMeta.Labels = labels
+			daemonSet.Spec.Template.Labels = labels
 			daemonSet.Spec.Template.Spec = podSpec
 			return nil
 		})
@@ -1002,7 +1018,7 @@ func ensureWorkloadResources(
 			deployment.Labels = mergeLabels(deployment.Labels, labels)
 			deployment.Spec.Replicas = int32ptr(replicas)
 			deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			deployment.Spec.Template.ObjectMeta.Labels = labels
+			deployment.Spec.Template.Labels = labels
 			deployment.Spec.Template.Spec = podSpec
 			return nil
 		})
@@ -1123,7 +1139,7 @@ func buildWorkloadPodSpec(
 	serviceAccount string,
 	configMapName string,
 	natsSecretName string,
-) (corev1.PodSpec, error) {
+) corev1.PodSpec {
 	renderValues := templateRenderValues(cfg, set, template)
 	containerSpec := template.Spec.Container
 	container := corev1.Container{
@@ -1217,7 +1233,7 @@ func buildWorkloadPodSpec(
 		Containers:                   []corev1.Container{container},
 		Volumes:                      volumes,
 	}
-	return podSpec, nil
+	return podSpec
 }
 
 func ensureWorkloadConfigMap(
@@ -1238,10 +1254,7 @@ func ensureWorkloadConfigMap(
 	}
 
 	if template.Spec.ConfigMap != nil && strings.EqualFold(template.Spec.ConfigMap.Generator, "zen") {
-		config, err := buildZenConfig(cfg, set.Spec.TenantSlug)
-		if err != nil {
-			return "", err
-		}
+		config := buildZenConfig(cfg, set.Spec.TenantSlug)
 		payload, err := json.MarshalIndent(config, "", "  ")
 		if err != nil {
 			return "", fmt.Errorf("marshal zen config: %w", err)
@@ -1273,7 +1286,7 @@ func workloadConfigMapName(cfg Config, set TenantWorkloadSet, template TenantWor
 	return sanitizeName(rendered)
 }
 
-func buildZenConfig(cfg Config, tenantSlug string) (ZenConfig, error) {
+func buildZenConfig(cfg Config, tenantSlug string) ZenConfig {
 	credsPath := "/etc/serviceradar/creds/nats.creds"
 	subjectPrefix := strings.TrimSpace(tenantSlug)
 	zenConfig := ZenConfig{
@@ -1294,7 +1307,7 @@ func buildZenConfig(cfg Config, tenantSlug string) (ZenConfig, error) {
 			WorkloadSocket: cfg.SpireSocketPath,
 		},
 	}
-	return zenConfig, nil
+	return zenConfig
 }
 
 func ensureServiceAccount(
@@ -1375,7 +1388,7 @@ func ensureTenantCredsSecret(
 	}
 
 	if cfg.CoreAPIURL == "" || cfg.CoreAPIKey == "" {
-		return fmt.Errorf("nats creds secret missing: %s", secretName)
+		return fmt.Errorf("%w: %s", errNATSCredsSecretMissing, secretName)
 	}
 
 	creds, err := fetchTenantCreds(ctx, cfg, tenantID, workloadType)
@@ -1408,7 +1421,7 @@ func fetchTenantCreds(
 ) (string, error) {
 	baseURL := strings.TrimRight(cfg.CoreAPIURL, "/")
 	if baseURL == "" {
-		return "", fmt.Errorf("CORE_API_URL is required to fetch tenant creds")
+		return "", errCoreAPIURLRequired
 	}
 
 	endpoint, err := url.JoinPath(baseURL, "api/admin/tenant-workloads", tenantID, "credentials")
@@ -1437,14 +1450,18 @@ func fetchTenantCreds(
 	if err != nil {
 		return "", fmt.Errorf("core api request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("close core api response body: %v", err)
+		}
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("read core api response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("core api status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return "", fmt.Errorf("%w: %d: %s", errCoreAPIStatus, resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 
 	var response TenantCredentialResponse
@@ -1452,7 +1469,7 @@ func fetchTenantCreds(
 		return "", fmt.Errorf("decode core api response: %w", err)
 	}
 	if response.Creds == "" {
-		return "", fmt.Errorf("core api response missing creds")
+		return "", errCoreAPIResponseMissingCreds
 	}
 
 	return response.Creds, nil
@@ -1717,7 +1734,7 @@ func buildTLSConfig(cfg Config) (*tls.Config, error) {
 			return nil, fmt.Errorf("read NATS CA file: %w", err)
 		}
 		if !rootCAs.AppendCertsFromPEM(certBytes) {
-			return nil, fmt.Errorf("invalid NATS CA file")
+			return nil, errInvalidNATSCAFile
 		}
 		tlsConfig.RootCAs = rootCAs
 	}

--- a/elixir/serviceradar_core/lib/serviceradar/identity/platform_tenant_bootstrap.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/identity/platform_tenant_bootstrap.ex
@@ -11,8 +11,10 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
   alias ServiceRadar.Actors.SystemActor
   alias ServiceRadar.Identity.Changes.InitializeTenantInfrastructure
   alias ServiceRadar.Identity.Tenant
+  alias ServiceRadar.Identity.TenantLifecyclePublisher
 
   @zero_uuid "00000000-0000-0000-0000-000000000000"
+  @publish_retry_delay 10_000
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -48,12 +50,14 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
       {:ok, []} ->
         tenant = create_platform_tenant!(platform_slug)
         set_platform_tenant_id!(tenant.id, platform_slug)
+        publish_platform_lifecycle_event(:created, tenant)
         :ok
 
       {:ok, [tenant]} ->
         validate_platform_tenant!(tenant, platform_slug)
         ensure_platform_tenant_infrastructure!(tenant)
         set_platform_tenant_id!(tenant.id, platform_slug)
+        publish_platform_lifecycle_event(:updated, tenant)
         :ok
 
       {:ok, tenants} ->
@@ -188,6 +192,63 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
 
     if is_nil(default_tenant_id) or default_tenant_id == @zero_uuid do
       Application.put_env(:serviceradar_core, :default_tenant_id, platform_tenant_id)
+    end
+  end
+
+  @impl true
+  def handle_info({:publish_platform_event, tenant_id, event}, state) do
+    case fetch_platform_tenant(tenant_id) do
+      {:ok, tenant} ->
+        if publish_event(event, tenant) != :ok do
+          schedule_publish_retry(tenant_id, event)
+        end
+
+      {:error, reason} ->
+        Logger.warning("[PlatformTenantBootstrap] Retry publish failed to load tenant",
+          tenant_id: tenant_id,
+          reason: inspect(reason)
+        )
+
+        schedule_publish_retry(tenant_id, event)
+    end
+
+    {:noreply, state}
+  end
+
+  defp publish_platform_lifecycle_event(event, tenant) do
+    if publish_event(event, tenant) != :ok do
+      Logger.warning("[PlatformTenantBootstrap] Tenant lifecycle publish failed; retrying",
+        tenant_id: tenant.id,
+        event: event
+      )
+
+      schedule_publish_retry(tenant.id, event)
+    end
+  end
+
+  defp publish_event(:created, tenant), do: TenantLifecyclePublisher.publish_created(tenant)
+  defp publish_event(:updated, tenant), do: TenantLifecyclePublisher.publish_updated(tenant)
+  defp publish_event(:deleted, tenant), do: TenantLifecyclePublisher.publish_deleted(tenant)
+  defp publish_event(_event, tenant), do: TenantLifecyclePublisher.publish_updated(tenant)
+
+  defp schedule_publish_retry(tenant_id, event) do
+    Process.send_after(self(), {:publish_platform_event, tenant_id, event}, @publish_retry_delay)
+  end
+
+  defp fetch_platform_tenant(tenant_id) do
+    actor = SystemActor.platform(:platform_tenant_bootstrap)
+
+    query =
+      Tenant
+      |> Ash.Query.for_read(:read)
+      |> Ash.Query.filter(id == ^tenant_id)
+      |> Ash.Query.select([:id, :slug, :status, :plan, :is_platform_tenant, :nats_account_status])
+
+    case Ash.read(query, actor: actor) do
+      {:ok, [tenant]} -> {:ok, tenant}
+      {:ok, []} -> {:error, :not_found}
+      {:ok, tenants} -> {:error, {:unexpected_count, length(tenants)}}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/elixir/serviceradar_core/lib/serviceradar/identity/platform_tenant_bootstrap.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/identity/platform_tenant_bootstrap.ex
@@ -14,7 +14,8 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
   alias ServiceRadar.Identity.TenantLifecyclePublisher
 
   @zero_uuid "00000000-0000-0000-0000-000000000000"
-  @publish_retry_delay 10_000
+  @initial_publish_retry_delay 1_000
+  @max_publish_retry_delay 60_000
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -197,19 +198,39 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
 
   @impl true
   def handle_info({:publish_platform_event, tenant_id, event}, state) do
+    handle_info({:publish_platform_event, tenant_id, event, 1}, state)
+  end
+
+  def handle_info({:publish_platform_event, tenant_id, event, attempt}, state) do
     case fetch_platform_tenant(tenant_id) do
       {:ok, tenant} ->
         if publish_event(event, tenant) != :ok do
-          schedule_publish_retry(tenant_id, event)
+          schedule_publish_retry(tenant_id, event, attempt + 1)
         end
+
+      {:error, :not_found} ->
+        Logger.warning(
+          "[PlatformTenantBootstrap] Tenant not found during publish retry; stopping retries.",
+          tenant_id: tenant_id,
+          event: event
+        )
+
+      {:error, {:unexpected_count, count}} ->
+        Logger.error(
+          "[PlatformTenantBootstrap] Multiple tenants found during publish retry; stopping retries.",
+          tenant_id: tenant_id,
+          count: count,
+          event: event
+        )
 
       {:error, reason} ->
         Logger.warning("[PlatformTenantBootstrap] Retry publish failed to load tenant",
           tenant_id: tenant_id,
-          reason: inspect(reason)
+          reason: inspect(reason),
+          event: event
         )
 
-        schedule_publish_retry(tenant_id, event)
+        schedule_publish_retry(tenant_id, event, attempt + 1)
     end
 
     {:noreply, state}
@@ -222,7 +243,7 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
         event: event
       )
 
-      schedule_publish_retry(tenant.id, event)
+      schedule_publish_retry(tenant.id, event, 1)
     end
   end
 
@@ -231,8 +252,20 @@ defmodule ServiceRadar.Identity.PlatformTenantBootstrap do
   defp publish_event(:deleted, tenant), do: TenantLifecyclePublisher.publish_deleted(tenant)
   defp publish_event(_event, tenant), do: TenantLifecyclePublisher.publish_updated(tenant)
 
-  defp schedule_publish_retry(tenant_id, event) do
-    Process.send_after(self(), {:publish_platform_event, tenant_id, event}, @publish_retry_delay)
+  defp schedule_publish_retry(tenant_id, event, attempt) do
+    delay = calculate_publish_backoff(attempt)
+    Process.send_after(self(), {:publish_platform_event, tenant_id, event, attempt}, delay)
+  end
+
+  defp calculate_publish_backoff(attempt) do
+    exponent = min(max(attempt - 1, 0), 16)
+    base_delay =
+      @initial_publish_retry_delay
+      |> Kernel.*(Integer.pow(2, exponent))
+      |> min(@max_publish_retry_delay)
+
+    jitter = :rand.uniform(max(div(base_delay, 2), 1))
+    min(base_delay + jitter, @max_publish_retry_delay)
   end
 
   defp fetch_platform_tenant(tenant_id) do

--- a/elixir/serviceradar_core/lib/serviceradar/nats/service_account_bootstrap.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/nats/service_account_bootstrap.ex
@@ -7,16 +7,16 @@ defmodule ServiceRadar.NATS.ServiceAccountBootstrap do
   require Ash.Query
 
   alias ServiceRadar.Actors.SystemActor
+  alias ServiceRadar.Identity.Tenant
   alias ServiceRadar.Identity.TenantLifecyclePublisher
   alias ServiceRadar.Infrastructure.NatsServiceAccount
-  alias ServiceRadar.Identity.Tenant
   alias ServiceRadar.NATS.AccountClient
 
   @operator_account_name "tenant-workload-operator"
   @operator_account_slug "serviceradar-operator"
   @operator_user_name "tenant-workload-operator"
 
-  @spec ensure_operator_account() :: {:ok, %NatsServiceAccount{}} | {:error, term()}
+  @spec ensure_operator_account() :: {:ok, NatsServiceAccount.t()} | {:error, term()}
   def ensure_operator_account do
     case get_service_account() do
       {:ok, %NatsServiceAccount{status: :ready} = account} ->

--- a/elixir/serviceradar_core/lib/serviceradar/nats/workers/create_account_worker.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/nats/workers/create_account_worker.ex
@@ -33,8 +33,8 @@ defmodule ServiceRadar.NATS.Workers.CreateAccountWorker do
   alias ServiceRadar.Actors.SystemActor
   alias ServiceRadar.Events.JobWriter
   alias ServiceRadar.Identity.Tenant
-  alias ServiceRadar.NATS.AccountClient
   alias ServiceRadar.Identity.TenantLifecyclePublisher
+  alias ServiceRadar.NATS.AccountClient
 
   # Only select fields needed for NATS account creation.
   # Explicitly excludes encrypted fields (contact_email, contact_name,

--- a/elixir/serviceradar_core/priv/repo/tenant_migrations/20260111082000_update-zen-rule-identities.exs
+++ b/elixir/serviceradar_core/priv/repo/tenant_migrations/20260111082000_update-zen-rule-identities.exs
@@ -8,21 +8,26 @@ defmodule :"Elixir.ServiceRadar.Repo.TenantMigrations.Update-zen-rule-identities
   use Ecto.Migration
 
   def up do
+    # Drop old index if it exists (uses [:tenant_id, :name])
     drop_if_exists unique_index(:zen_rules, [:tenant_id, :name],
                      name: "zen_rules_unique_name_index"
                    )
 
-    create unique_index(:zen_rules, [:tenant_id, :subject, :name],
-             name: "zen_rules_unique_name_index"
-           )
+    # Create new index with subject field - skip if already exists
+    # (handles case where migration was partially run before)
+    execute """
+    CREATE UNIQUE INDEX IF NOT EXISTS zen_rules_unique_name_index
+    ON zen_rules (tenant_id, subject, name)
+    """
 
     drop_if_exists unique_index(:zen_rule_templates, [:tenant_id, :name],
                      name: "zen_rule_templates_unique_name_index"
                    )
 
-    create unique_index(:zen_rule_templates, [:tenant_id, :subject, :name],
-             name: "zen_rule_templates_unique_name_index"
-           )
+    execute """
+    CREATE UNIQUE INDEX IF NOT EXISTS zen_rule_templates_unique_name_index
+    ON zen_rule_templates (tenant_id, subject, name)
+    """
   end
 
   def down do

--- a/helm/serviceradar/files/generate-certs.sh
+++ b/helm/serviceradar/files/generate-certs.sh
@@ -19,6 +19,29 @@ if [ ! -f "$CERT_DIR/root.pem" ]; then
   openssl req -new -x509 -sha256 -key "$CERT_DIR/root-key.pem" -out "$CERT_DIR/root.pem" -days $DAYS_VALID -subj "/C=$COUNTRY/ST=$STATE/L=$LOCALITY/O=$ORGANIZATION/OU=$ORG_UNIT/CN=ServiceRadar Root CA"
   chmod 644 "$CERT_DIR/root.pem"; chmod 640 "$CERT_DIR/root-key.pem"
 fi
+if [ ! -f "$CERT_DIR/cnpg-ca.pem" ] || [ "$FORCE_REGENERATE" = "true" ]; then
+  openssl ecparam -name prime256v1 -genkey -noout -out "$CERT_DIR/cnpg-ca-key.pem"
+  cat > "$CERT_DIR/cnpg-ca.conf" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+[req_distinguished_name]
+C = $COUNTRY
+ST = $STATE
+L = $LOCALITY
+O = $ORGANIZATION
+OU = $ORG_UNIT
+CN = ServiceRadar CNPG CA
+[v3_ca]
+basicConstraints = critical, CA:TRUE, pathlen:0
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+EOF
+  openssl req -new -x509 -sha256 -key "$CERT_DIR/cnpg-ca-key.pem" -out "$CERT_DIR/cnpg-ca.pem" -days $DAYS_VALID -config "$CERT_DIR/cnpg-ca.conf"
+  rm "$CERT_DIR/cnpg-ca.conf"
+  chmod 644 "$CERT_DIR/cnpg-ca.pem"; chmod 600 "$CERT_DIR/cnpg-ca-key.pem"
+fi
 generate_cert() {
   local component=$1; local cn=$2; local san=$3
   if [ -f "$CERT_DIR/$component.pem" ] && [ "$FORCE_REGENERATE" != "true" ]; then return; fi
@@ -58,6 +81,30 @@ generate_cert "otel" "serviceradar-otel" "DNS:serviceradar-otel,DNS:otel,DNS:ote
 generate_cert "mapper" "serviceradar-mapper" "DNS:serviceradar-mapper,DNS:mapper,DNS:mapper.serviceradar,DNS:serviceradar-mapper.{{ .Release.Namespace }}.svc.cluster.local,DNS:localhost,IP:127.0.0.1"
 generate_cert "trapd" "serviceradar-trapd" "DNS:serviceradar-trapd,DNS:trapd,DNS:trapd.serviceradar,DNS:serviceradar-trapd.{{ .Release.Namespace }}.svc.cluster.local,DNS:localhost,IP:127.0.0.1"
 generate_cert "client" "serviceradar-debug-client" "DNS:serviceradar-tools,DNS:client,DNS:debug-client,DNS:localhost,IP:127.0.0.1"
+if [ ! -f "$CERT_DIR/cnpg-client.pem" ] || [ "$FORCE_REGENERATE" = "true" ]; then
+  openssl ecparam -name prime256v1 -genkey -noout -out "$CERT_DIR/cnpg-client-key.pem"
+  cat > "$CERT_DIR/cnpg-client.conf" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = $COUNTRY
+ST = $STATE
+L = $LOCALITY
+O = $ORGANIZATION
+OU = $ORG_UNIT
+CN = serviceradar-cnpg-client
+[v3_req]
+keyUsage = digitalSignature
+extendedKeyUsage = clientAuth
+subjectAltName = DNS:serviceradar-cnpg-client
+EOF
+  openssl req -new -sha256 -key "$CERT_DIR/cnpg-client-key.pem" -out "$CERT_DIR/cnpg-client.csr" -config "$CERT_DIR/cnpg-client.conf"
+  openssl x509 -req -in "$CERT_DIR/cnpg-client.csr" -CA "$CERT_DIR/cnpg-ca.pem" -CAkey "$CERT_DIR/cnpg-ca-key.pem" -CAcreateserial -out "$CERT_DIR/cnpg-client.pem" -days $DAYS_VALID -sha256 -extensions v3_req -extfile "$CERT_DIR/cnpg-client.conf"
+  rm "$CERT_DIR/cnpg-client.csr" "$CERT_DIR/cnpg-client.conf"
+  chmod 644 "$CERT_DIR/cnpg-client.pem"; chmod 640 "$CERT_DIR/cnpg-client-key.pem"
+fi
 if [ ! -f "$CERT_DIR/jwt-secret" ]; then openssl rand -hex 32 > "$CERT_DIR/jwt-secret"; chmod 640 "$CERT_DIR/jwt-secret"; fi
 if [ ! -f "$CERT_DIR/api-key" ]; then openssl rand -hex 32 > "$CERT_DIR/api-key"; chmod 640 "$CERT_DIR/api-key"; fi
 

--- a/helm/serviceradar/files/generate-certs.sh
+++ b/helm/serviceradar/files/generate-certs.sh
@@ -65,7 +65,7 @@ subjectAltName = $san
 EOF
   openssl req -new -sha256 -key "$CERT_DIR/$component-key.pem" -out "$CERT_DIR/$component.csr" -config "$CERT_DIR/$component.conf"
   openssl x509 -req -in "$CERT_DIR/$component.csr" -CA "$CERT_DIR/root.pem" -CAkey "$CERT_DIR/root-key.pem" -CAcreateserial -out "$CERT_DIR/$component.pem" -days $DAYS_VALID -sha256 -extensions v3_req -extfile "$CERT_DIR/$component.conf"
-  rm "$CERT_DIR/$component.csr" "$CERT_DIR/$component.conf"; chmod 644 "$CERT_DIR/$component.pem" "$CERT_DIR/$component-key.pem"
+  rm "$CERT_DIR/$component.csr" "$CERT_DIR/$component.conf"; chmod 644 "$CERT_DIR/$component.pem"; chmod 640 "$CERT_DIR/$component-key.pem"
 }
 generate_cert "nats" "serviceradar-nats" "DNS:serviceradar-nats,DNS:nats,DNS:nats.serviceradar,DNS:serviceradar-nats.{{ .Release.Namespace }}.svc.cluster.local,DNS:localhost,IP:127.0.0.1"
 generate_cert "core" "serviceradar-core" "DNS:serviceradar-core,DNS:core,DNS:core.serviceradar,DNS:serviceradar-core.{{ .Release.Namespace }}.svc.cluster.local,DNS:localhost,IP:127.0.0.1"

--- a/helm/serviceradar/files/serviceradar-config.yaml
+++ b/helm/serviceradar/files/serviceradar-config.yaml
@@ -533,11 +533,11 @@ data:
       {{ end }}
         "stream_name": "events",
         "consumer_name": "zen-consumer",
-        "subjects": ["*.logs.syslog", "*.logs.snmp", "*.logs.otel", "*.logs.internal.>"],
+        "subjects": ["logs.syslog", "logs.snmp", "logs.otel"],
         "decision_groups": [
           {
             "name": "syslog",
-            "subjects": ["*.logs.syslog"],
+            "subjects": ["logs.syslog"],
             "rules": [
               {"order": 1, "key": "strip_full_message"},
               {"order": 2, "key": "cef_severity"}
@@ -546,7 +546,7 @@ data:
           },
           {
             "name": "snmp",
-            "subjects": ["*.logs.snmp"],
+            "subjects": ["logs.snmp"],
             "rules": [
               {"order": 1, "key": "snmp_severity"}
             ],
@@ -554,19 +554,11 @@ data:
           },
           {
             "name": "otel_logs",
-            "subjects": ["*.logs.otel"],
+            "subjects": ["logs.otel"],
             "rules": [
               {"order": 1, "key": "passthrough"}
             ],
             "format": "protobuf"
-          },
-          {
-            "name": "internal_logs",
-            "subjects": ["*.logs.internal.>"],
-            "rules": [
-              {"order": 1, "key": "passthrough"}
-            ],
-            "format": "json"
           }
         ],
         "agent_id": "k8s-zen-consumer",

--- a/helm/serviceradar/templates/cnpg-client-ca-job.yaml
+++ b/helm/serviceradar/templates/cnpg-client-ca-job.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: serviceradar
     app.kubernetes.io/component: cnpg-client-ca
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,6 +22,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: serviceradar
     app.kubernetes.io/component: cnpg-client-ca
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -31,6 +39,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: serviceradar
     app.kubernetes.io/component: cnpg-client-ca
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,6 +60,9 @@ metadata:
   labels:
     app.kubernetes.io/part-of: serviceradar
     app.kubernetes.io/component: cnpg-client-ca
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 2
@@ -109,23 +124,6 @@ spec:
             has_secret=true
           fi
 
-          missing_keys=""
-          if [ "${has_secret}" = true ]; then
-            if ! jq -e '.data | has("ca.crt")' "${existing_secret}" >/dev/null; then
-              missing_keys="${missing_keys} ca.crt"
-            fi
-            if ! jq -e '.data | has("ca.key")' "${existing_secret}" >/dev/null; then
-              missing_keys="${missing_keys} ca.key"
-            fi
-            if [ -z "${missing_keys#"${missing_keys%%[![:space:]]*}"}" ]; then
-              echo "✅ CNPG client CA secret already present"
-              exit 0
-            fi
-            echo "ℹ️ CNPG client CA secret missing:${missing_keys}; patching in-place"
-          else
-            echo "ℹ️ CNPG client CA secret not found; creating"
-          fi
-
           CA_CERT_B64=$(base64 -w 0 "${CA_CERT}")
           CA_KEY_B64=$(base64 -w 0 "${CA_KEY}")
 
@@ -157,32 +155,19 @@ spec:
           fi
 
           patch_file=$(mktemp)
-          echo "[" > "${patch_file}"
-          first=1
-          add_patch() {
-            key="$1"
-            val="$2"
-            if [ "${first}" -eq 0 ]; then
-              echo "," >> "${patch_file}"
-            fi
-            first=0
-            printf '{"op":"add","path":"/data/%s","value":"%s"}' "${key}" "${val}" >> "${patch_file}"
-          }
-
-          if echo " ${missing_keys} " | grep -q " ca.crt "; then
-            add_patch "ca.crt" "${CA_CERT_B64}"
-          fi
-          if echo " ${missing_keys} " | grep -q " ca.key "; then
-            add_patch "ca.key" "${CA_KEY_B64}"
-          fi
-          echo "]" >> "${patch_file}"
+          cat <<EOF > "${patch_file}"
+          [
+            {"op":"add","path":"/data/ca.crt","value":"${CA_CERT_B64}"},
+            {"op":"add","path":"/data/ca.key","value":"${CA_KEY_B64}"}
+          ]
+          EOF
 
           curl -fsS --cacert "${CACERT}" --header "Authorization: Bearer ${TOKEN}" \
             --header "Content-Type: application/json-patch+json" \
             -X PATCH "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}" \
             -d @"${patch_file}"
 
-          echo "✅ Patched ${SECRET_NAME}"
+          echo "✅ Reconciled ${SECRET_NAME}"
         volumeMounts:
         - name: cert-data
           mountPath: /etc/serviceradar/certs

--- a/helm/serviceradar/templates/cnpg-client-ca-job.yaml
+++ b/helm/serviceradar/templates/cnpg-client-ca-job.yaml
@@ -77,8 +77,8 @@ spec:
 
           SECRET_NAME="${CNPG_CLIENT_CA_SECRET}"
           CERT_DIR="${CERT_DIR:-/etc/serviceradar/certs}"
-          CA_CERT="${CERT_DIR}/root.pem"
-          CA_KEY="${CERT_DIR}/root-key.pem"
+          CA_CERT="${CERT_DIR}/cnpg-ca.pem"
+          CA_KEY="${CERT_DIR}/cnpg-ca-key.pem"
 
           APISERVER="https://kubernetes.default.svc"
           SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"

--- a/helm/serviceradar/templates/core.yaml
+++ b/helm/serviceradar/templates/core.yaml
@@ -120,9 +120,9 @@ spec:
         - name: CNPG_CA_FILE
           value: {{ default "/etc/serviceradar/cnpg/ca.crt" $cnpg.caFile | quote }}
         - name: CNPG_CERT_FILE
-          value: "/etc/serviceradar/certs/core.pem"
+          value: {{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client.pem" $cnpg.clientCertName) | quote }}
         - name: CNPG_KEY_FILE
-          value: "/etc/serviceradar/certs/core-key.pem"
+          value: {{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client-key.pem" $cnpg.clientKeyName) | quote }}
         - name: DATASVC_HOST
           value: "serviceradar-datasvc"
         - name: DATASVC_PORT

--- a/helm/serviceradar/templates/core.yaml
+++ b/helm/serviceradar/templates/core.yaml
@@ -1,20 +1,29 @@
 {{- $trustDomain := .Values.spire.trustDomain | default "carverauto.dev" -}}
 {{- $spireNamespace := default .Release.Namespace .Values.spire.namespace -}}
-{{- $datasvcSA := .Values.spire.datasvcServiceAccount | default "serviceradar-datasvc" -}}
 {{- $coreSA := .Values.spire.coreServiceAccount | default "serviceradar-core" -}}
 {{- $cnpg := default (dict) .Values.cnpg -}}
 {{- $pg := default (dict) .Values.spire.postgres -}}
 {{- $cnpgClusterName := default "cnpg" $pg.clusterName -}}
+{{- $coreVals := default (dict) .Values.core -}}
+{{- $database := default (dict) $coreVals.database -}}
+{{- $syncIngestor := default (dict) $coreVals.syncIngestor -}}
+{{- $secrets := default "serviceradar-secrets" .Values.secrets.existingSecretName -}}
+{{- $clusterSelector := default "app.kubernetes.io/part-of=serviceradar" .Values.tenantWorkloadOperator.kubernetesSelector -}}
+{{- $clusterNodeBasename := default "serviceradar" .Values.tenantWorkloadOperator.kubernetesNodeBasename -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $coreSA }}
+  labels:
+    app.kubernetes.io/part-of: serviceradar
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: serviceradar-core
+  labels:
+    app.kubernetes.io/part-of: serviceradar
 spec:
   replicas: 1
   strategy:
@@ -26,103 +35,70 @@ spec:
     metadata:
       labels:
         app: serviceradar-core
+        app.kubernetes.io/part-of: serviceradar
       annotations:
         checksum/db-credentials: {{ include "serviceradar.dbCredentialsChecksum" . }}
     spec:
       {{- include "serviceradar.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $coreSA }}
-      initContainers:
-      - name: init-core-jwks
-        image: ghcr.io/carverauto/serviceradar-tools:{{ include "serviceradar.imageTag" (dict "Values" .Values "service" "tools") }}
-        imagePullPolicy: {{ include "serviceradar.imagePullPolicy" . }}
-        command:
-        - /bin/sh
-        - -c
-        - |
-          set -e
-          TEMPLATE=/etc/serviceradar/core.json
-          TARGET=/var/lib/serviceradar/core.json
-          mkdir -p /var/lib/serviceradar
-
-          PRESERVE_PRIV=""
-          PRESERVE_KID=""
-          if [ -f "$TARGET" ]; then
-            if jq -e . "$TARGET" >/dev/null 2>&1; then
-              PRESERVE_PRIV=$(jq -r '.auth.jwt_private_key_pem // empty' "$TARGET")
-              PRESERVE_KID=$(jq -r '.auth.jwt_key_id // empty' "$TARGET")
-            else
-              echo "Existing $TARGET contains invalid JSON; replacing with template contents"
-              rm -f "$TARGET"
-            fi
-          fi
-
-          cp "$TEMPLATE" "${TARGET}.tmp"
-
-          if [ -n "$PRESERVE_PRIV" ]; then
-            jq --arg priv "$PRESERVE_PRIV" --arg kid "$PRESERVE_KID" '
-              .auth = (.auth // {}) |
-              .auth.jwt_algorithm = "RS256" |
-              .auth.jwt_private_key_pem = $priv |
-              (if $kid != "" then .auth.jwt_key_id = $kid else . end)
-            ' "${TARGET}.tmp" > "$TARGET"
-            rm -f "${TARGET}.tmp"
-          else
-            mv "${TARGET}.tmp" "$TARGET"
-          fi
-
-          serviceradar-cli generate-jwt-keys --file "$TARGET" --bits 2048
-        volumeMounts:
-        - name: serviceradar-config
-          mountPath: /etc/serviceradar
-          readOnly: true
-        - name: core-data
-          mountPath: /var/lib/serviceradar
       containers:
-      - name: core
-        image: ghcr.io/carverauto/serviceradar-core:{{ include "serviceradar.imageTag" (dict "Values" .Values "service" "core") }}
+      - name: core-elx
+        image: ghcr.io/carverauto/serviceradar-core-elx:{{ include "serviceradar.imageTag" (dict "Values" .Values "service" "core") }}
         imagePullPolicy: {{ include "serviceradar.imagePullPolicy" . }}
-        command: ["/bin/bash"]
-        args:
-        - -c
-        - |
-          cp /etc/serviceradar/core-k8s-init.sh /tmp/core-k8s-init.sh
-          chmod +x /tmp/core-k8s-init.sh
-          exec /tmp/core-k8s-init.sh
         ports:
-        - containerPort: 8090
-          name: http
-        - containerPort: 50052
-          name: grpc
-        - containerPort: 9090
-          name: metrics
-        volumeMounts:
-        - name: serviceradar-config
-          mountPath: /etc/serviceradar
-        - name: core-data
-          mountPath: /var/lib/serviceradar
-        - name: cert-data
-          mountPath: /etc/serviceradar/certs
-          readOnly: true
-        - name: {{ $cnpgClusterName }}-ca
-          mountPath: /etc/serviceradar/cnpg
-          readOnly: true
-        - name: spire-agent-socket
-          mountPath: /run/spire/sockets
-          readOnly: true
+        - name: epmd
+          containerPort: 4369
+        - name: dist
+          containerPort: 9100
         env:
-        - name: WAIT_FOR_CNPG
+        - name: CLUSTER_ENABLED
           value: "true"
-        - name: INIT_DB
-          value: "true"
-        - name: CONFIG_WATCH_ENABLED
-          value: {{ ternary "true" "false" (default true .Values.core.configWatchEnabled) | quote }}
-{{ include "serviceradar.kvEnv" . | indent 8 }}
-        - name: CONFIG_PATH
-          value: "/var/lib/serviceradar/core.json"
-        - name: KUBERNETES_NAMESPACE
+        - name: CLUSTER_STRATEGY
+          value: "kubernetes"
+        - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: KUBERNETES_SELECTOR
+          value: {{ $clusterSelector | quote }}
+        - name: KUBERNETES_NODE_BASENAME
+          value: {{ $clusterNodeBasename | quote }}
+        - name: SPIFFE_TRUST_DOMAIN
+          value: {{ $trustDomain | quote }}
+        - name: SPIFFE_CERT_DIR
+          value: "/etc/serviceradar/certs"
+        - name: SPIFFE_WORKLOAD_API_SOCKET
+          value: "unix:///run/spire/sockets/agent.sock"
+        - name: SERVICERADAR_CLUSTER_COORDINATOR
+          value: "true"
+        - name: SERVICERADAR_CORE_RUN_MIGRATIONS
+          value: "true"
+        - name: SERVICERADAR_CORE_OBAN_ENABLED
+          value: "true"
+        - name: SERVICERADAR_CORE_REPO_ENABLED
+          value: "true"
+        - name: SERVICERADAR_CORE_REGISTRIES_ENABLED
+          value: "true"
+        - name: SERVICERADAR_CORE_VAULT_ENABLED
+          value: "true"
+        - name: SERVICERADAR_LOCAL_MAILER
+          value: "false"
+        - name: POOL_SIZE
+          value: {{ default 40 $database.poolSize | quote }}
+        - name: DATABASE_QUEUE_TARGET_MS
+          value: {{ default 2000 $database.queueTargetMs | quote }}
+        - name: DATABASE_QUEUE_INTERVAL_MS
+          value: {{ default 2000 $database.queueIntervalMs | quote }}
+        - name: SYNC_INGESTOR_BATCH_CONCURRENCY
+          value: {{ default 2 $syncIngestor.batchConcurrency | quote }}
+        - name: SYNC_INGESTOR_COALESCE_MS
+          value: {{ default 250 $syncIngestor.coalesceMs | quote }}
+        - name: SYNC_INGESTOR_MAX_INFLIGHT
+          value: {{ default 2 $syncIngestor.maxInflight | quote }}
+        - name: SYNC_INGESTOR_QUEUE_MAX_CHUNKS
+          value: {{ default 10 $syncIngestor.queueMaxChunks | quote }}
+        - name: SYNC_INGESTOR_ASYNC
+          value: {{ default true $syncIngestor.async | quote }}
         - name: CNPG_HOST
           value: {{ default (printf "%s-rw.%s.svc.cluster.local" $cnpgClusterName .Release.Namespace) $cnpg.host | quote }}
         - name: CNPG_PORT
@@ -134,41 +110,52 @@ spec:
             secretKeyRef:
               name: {{ default "serviceradar-db-credentials" $cnpg.credentialsSecret | quote }}
               key: username
-        - name: CNPG_SSLMODE
-          value: {{ default "verify-full" $cnpg.sslmode | quote }}
-        - name: CNPG_CERT_DIR
-          value: {{ default "/etc/serviceradar/certs" $cnpg.certDir | quote }}
-        - name: CNPG_CA_FILE
-          value: {{ default "/etc/serviceradar/cnpg/ca.crt" $cnpg.caFile | quote }}
         - name: CNPG_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ default "serviceradar-db-credentials" $cnpg.credentialsSecret | quote }}
               key: password
-        - name: API_KEY
+        - name: CNPG_SSL_MODE
+          value: {{ default "verify-full" $cnpg.sslmode | quote }}
+        - name: CNPG_CA_FILE
+          value: {{ default "/etc/serviceradar/cnpg/ca.crt" $cnpg.caFile | quote }}
+        - name: CNPG_CERT_FILE
+          value: "/etc/serviceradar/certs/core.pem"
+        - name: CNPG_KEY_FILE
+          value: "/etc/serviceradar/certs/core-key.pem"
+        - name: DATASVC_HOST
+          value: "serviceradar-datasvc"
+        - name: DATASVC_PORT
+          value: "50057"
+        - name: DATASVC_SSL
+          value: "true"
+        - name: DATASVC_CERT_DIR
+          value: "/etc/serviceradar/certs"
+        - name: DATASVC_CERT_NAME
+          value: "core"
+        - name: NATS_ENABLED
+          value: "true"
+        - name: NATS_URL
+          value: "tls://serviceradar-nats:4222"
+        - name: NATS_TLS
+          value: "true"
+        - name: NATS_SERVER_NAME
+          value: "serviceradar-nats"
+        - name: CLOAK_KEY
           valueFrom:
             secretKeyRef:
-              name: serviceradar-secrets
-              key: api-key
-        - name: JWT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: serviceradar-secrets
-              key: jwt-secret
-        - name: EDGE_ONBOARDING_ENCRYPTION_KEY
-          valueFrom:
-            secretKeyRef:
-              name: serviceradar-secrets
-              key: edge-onboarding-key
-        - name: AUTH_PROVIDER
-          value: "local"
-        - name: OAUTH_ENABLED
-          value: "false"
-        - name: ADMIN_BCRYPT_HASH
-          valueFrom:
-            secretKeyRef:
-              name: serviceradar-secrets
-              key: admin-bcrypt-hash
+              name: {{ $secrets | quote }}
+              key: cloak-key
+        volumeMounts:
+        - name: cert-data
+          mountPath: /etc/serviceradar/certs
+          readOnly: true
+        - name: {{ $cnpgClusterName }}-ca
+          mountPath: /etc/serviceradar/cnpg
+          readOnly: true
+        - name: spire-agent-socket
+          mountPath: /run/spire/sockets
+          readOnly: true
         resources:
           limits:
             cpu: "4"
@@ -177,26 +164,24 @@ spec:
             cpu: "500m"
             memory: "1Gi"
         livenessProbe:
-          tcpSocket:
-            port: 8090
-          initialDelaySeconds: 180
+          exec:
+            command:
+              - /app/bin/serviceradar_core_elx
+              - pid
+          initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3
         readinessProbe:
-          tcpSocket:
-            port: 8090
-          initialDelaySeconds: 60
+          exec:
+            command:
+              - /app/bin/serviceradar_core_elx
+              - pid
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
       volumes:
-      - name: serviceradar-config
-        configMap:
-          name: serviceradar-config
-      - name: core-data
-        persistentVolumeClaim:
-          claimName: serviceradar-core-data
       - name: cert-data
         persistentVolumeClaim:
           claimName: serviceradar-cert-data
@@ -212,27 +197,34 @@ apiVersion: v1
 kind: Service
 metadata:
   name: serviceradar-core
+  labels:
+    app.kubernetes.io/part-of: serviceradar
 spec:
   selector:
     app: serviceradar-core
   ports:
   - name: http
     port: 8090
-    targetPort: http
+    targetPort: 8090
   - name: grpc
     port: 50052
-    targetPort: grpc
+    targetPort: 50052
   - name: metrics
     port: 9090
-    targetPort: metrics
+    targetPort: 9090
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
+kind: Service
 metadata:
-  name: serviceradar-core-data
+  name: serviceradar-core-elx-headless
+  labels:
+    app.kubernetes.io/part-of: serviceradar
 spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: serviceradar-core
+  ports:
+  - name: epmd
+    port: 4369
+    targetPort: 4369

--- a/helm/serviceradar/templates/db-event-writer-config.yaml
+++ b/helm/serviceradar/templates/db-event-writer-config.yaml
@@ -38,8 +38,8 @@ data:
         "ssl_mode": "verify-full",
         "cert_dir": {{ default "/etc/serviceradar/certs" $cnpg.certDir | quote }},
         "tls": {
-          "cert_file": "/etc/serviceradar/certs/db-event-writer.pem",
-          "key_file": "/etc/serviceradar/certs/db-event-writer-key.pem",
+          "cert_file": "{{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client.pem" $cnpg.clientCertName) }}",
+          "key_file": "{{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client-key.pem" $cnpg.clientKeyName) }}",
           "ca_file": {{ default "/etc/serviceradar/cnpg/ca.crt" $cnpg.caFile | quote }}
         }
       },

--- a/helm/serviceradar/templates/spire-server.yaml
+++ b/helm/serviceradar/templates/spire-server.yaml
@@ -3,6 +3,7 @@
 {{- $bundle := default "spire-bundle" .Values.spire.bundleConfigMap }}
 {{- $serverVals := .Values.spire.server }}
 {{- $pg := .Values.spire.postgres }}
+{{- $cnpg := default (dict) .Values.cnpg }}
 {{- $trustDomain := .Values.spire.trustDomain }}
 {{- $clusterName := .Values.spire.clusterName }}
 {{- $agentSA := .Values.spire.agentServiceAccount }}
@@ -10,6 +11,8 @@
 {{- $pgHost := printf "%s-rw.%s.svc.cluster.local" (default "cnpg" $pg.clusterName) $ns }}
 {{- $dbUser := default "spire" $pg.username }}
 {{- $dbName := default "spire" $pg.database }}
+{{- $cnpgClientCert := default "cnpg-client.pem" $cnpg.clientCertName }}
+{{- $cnpgClientKey := default "cnpg-client-key.pem" $cnpg.clientKeyName }}
 {{- $tokenAudience := .Values.spire.tokenAudience | default "https://kubernetes.default.svc" }}
 {{- $cmVals := .Values.spire.controllerManager }}
 {{- $cmImageRepo := default "ghcr.io/spiffe/spire-controller-manager" $cmVals.image }}
@@ -135,7 +138,7 @@ data:
       DataStore "sql" {
         plugin_data {
           database_type = "postgres"
-          connection_string = "dbname={{ $dbName }} user={{ $dbUser }} password=__DB_PASSWORD__ host={{ $pgHost }} port=5432 sslmode=verify-full sslrootcert=/run/spire/cnpg/ca.crt sslcert=/run/spire/certs/client.pem sslkey=/run/spire/certs/client-key.pem"
+          connection_string = "dbname={{ $dbName }} user={{ $dbUser }} password=__DB_PASSWORD__ host={{ $pgHost }} port=5432 sslmode=verify-full sslrootcert=/run/spire/cnpg/ca.crt sslcert=/run/spire/certs/{{ $cnpgClientCert }} sslkey=/run/spire/certs/{{ $cnpgClientKey }}"
         }
       }
 
@@ -236,6 +239,8 @@ spec:
         app: {{ $serverName }}
     spec:
       serviceAccountName: spire-server
+      securityContext:
+        fsGroup: 0
       initContainers:
         - name: init-config
           image: {{ $serverVals.initConfigImage }}

--- a/helm/serviceradar/templates/web.yaml
+++ b/helm/serviceradar/templates/web.yaml
@@ -78,9 +78,9 @@ spec:
         - name: CNPG_CA_FILE
           value: {{ default "/etc/serviceradar/cnpg/ca.crt" $cnpg.caFile | quote }}
         - name: CNPG_CERT_FILE
-          value: "/etc/serviceradar/certs/web.pem"
+          value: {{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client.pem" $cnpg.clientCertName) | quote }}
         - name: CNPG_KEY_FILE
-          value: "/etc/serviceradar/certs/web-key.pem"
+          value: {{ printf "%s/%s" (default "/etc/serviceradar/certs" $cnpg.certDir) (default "cnpg-client-key.pem" $cnpg.clientKeyName) | quote }}
         volumeMounts:
         - name: cert-data
           mountPath: /etc/serviceradar/certs

--- a/helm/serviceradar/values-demo-staging.yaml
+++ b/helm/serviceradar/values-demo-staging.yaml
@@ -4,7 +4,7 @@
 namespace: demo-staging
 
 global:
-  imageTag: "sha-db7c1da12cfce410f33bf8cb9f43f3bc2608e467"
+  imageTag: "sha-ba527ff3f30d40490a811eec028fc5b55447f605"
   imagePullPolicy: Always
 
 image:

--- a/helm/serviceradar/values-demo-staging.yaml
+++ b/helm/serviceradar/values-demo-staging.yaml
@@ -4,7 +4,7 @@
 namespace: demo-staging
 
 global:
-  imageTag: "sha-ba527ff3f30d40490a811eec028fc5b55447f605"
+  imageTag: "sha-f54f38036d4df03b00a3c459f228188d6ce3d95b"
   imagePullPolicy: Always
 
 image:

--- a/helm/serviceradar/values.yaml
+++ b/helm/serviceradar/values.yaml
@@ -196,6 +196,8 @@ cnpg:
   sslmode: verify-full
   certDir: /etc/serviceradar/certs
   caFile: /etc/serviceradar/cnpg/ca.crt
+  clientCertName: cnpg-client.pem
+  clientKeyName: cnpg-client-key.pem
   clientCASecret: ""
   clientCAFromCerts: false
   requireClientCert: false


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Migrate core service to Elixir implementation with clustering support

- Fix JetStream subject configuration by removing invalid leading wildcards

- Correct tenant migration execution order for zen_rule_templates index updates

- Add platform tenant lifecycle event publishing with retry mechanism

- Implement CNPG certificate generation and client certificate authentication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Core Service"] -->|"Migrate to"| B["Core-ELX Elixir"]
  B -->|"Cluster via"| C["Kubernetes Discovery"]
  D["JetStream Config"] -->|"Fix subjects"| E["Remove wildcards"]
  E -->|"Match patterns"| F["logs.syslog/snmp/otel"]
  G["Migration Order"] -->|"Correct timing"| H["zen_rule_templates first"]
  H -->|"Then update"| I["Index creation"]
  J["Tenant Bootstrap"] -->|"Publish events"| K["TenantLifecyclePublisher"]
  K -->|"With retry"| L["Exponential backoff"]
  M["CNPG Certs"] -->|"Generate"| N["CA and Client Certs"]
  N -->|"Configure"| O["Database connections"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>platform_tenant_bootstrap.ex</strong><dd><code>Add tenant lifecycle event publishing with retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-10699868a7d10a4386ad293ed86e1e60a9e3c172bc2ea3d22f98c0efae666182">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate-certs.sh</strong><dd><code>Add CNPG CA and client certificate generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-224edb1896351749211a2a609692daa31f4f45cf175658124613b9dc08496d96">+48/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cnpg-client-ca-job.yaml</strong><dd><code>Add Helm hooks and simplify secret reconciliation logic</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-c5ed02183d64ba0434152f6d1b56e659fde6be1bbc4f9f7a07a29652028f2214">+24/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>core.yaml</strong><dd><code>Replace core with core-elx Elixir implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-06ab387d2c169d82a1de28b5e66c86f0417bd81b82a96246d0a2da8bfaa8d224">+127/-135</a></td>

</tr>

<tr>
  <td><strong>db-event-writer-config.yaml</strong><dd><code>Use configurable CNPG client certificate paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-4cce0ab31bec3428ffae6701d20ca14b0f27a1e8a810ba1c7388e5c7860c3254">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spire-server.yaml</strong><dd><code>Add CNPG client certificate configuration variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-7959f7b987adcd56306fe5ddf31fed367dd9bb995f9b82a8fa53553dac8e7077">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web.yaml</strong><dd><code>Use configurable CNPG client certificate paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-6e0340bf29070d4b88c305a585cf278672914f74f95dbcfde215da3fcbd0f562">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>20260111082000_update-zen-rule-identities.exs</strong><dd><code>Make index creation idempotent with IF NOT EXISTS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-12dc8193dab16db4228f0fbc403a8bd851b7265aef51a4da4f5673b0d4f38cd8">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serviceradar-config.yaml</strong><dd><code>Fix zen JetStream subject configuration patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-b8c8d2484103b11c396bc60d290c81df63c30a0f81103eceb5852a17e1d2b5e3">+4/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>values-demo-staging.yaml</strong><dd><code>Update image tag to latest commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-923e7e4134431f4ec89c77f227e8fc9546bcfdefc836c26da86f30e7847f0d3c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>values.yaml</strong><dd><code>Add CNPG client certificate name configuration options</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2275/files#diff-d4449c7cb70362554b274f81eae5a4b81a8e81df494282e383d1b7ea3871c452">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

