### PR TITLE
fixing zen crash

### DIFF
--- a/helm/serviceradar/templates/zen.yaml
+++ b/helm/serviceradar/templates/zen.yaml
@@ -31,7 +31,7 @@ spec:
         - name: cert-data
           mountPath: /etc/serviceradar/certs
           readOnly: true
-        {{- if or .Values.natsCreds.platform .Values.natsCreds.system }}
+        {{- if or .Values.natsCreds.platform .Values.natsCreds.system .Values.natsCreds.autoGenerate }}
         - name: nats-creds
           mountPath: /etc/serviceradar/creds
           readOnly: true
@@ -95,10 +95,10 @@ spec:
       - name: cert-data
         persistentVolumeClaim:
           claimName: serviceradar-cert-data
-      {{- if or .Values.natsCreds.platform .Values.natsCreds.system }}
+      {{- if or .Values.natsCreds.platform .Values.natsCreds.system .Values.natsCreds.autoGenerate }}
       - name: nats-creds
         secret:
-          name: serviceradar-nats-creds
+          secretName: serviceradar-nats-creds
       {{- end }}
       - name: zen-data
         persistentVolumeClaim:


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Add support for auto-generated NATS credentials in Zen deployment

- Fix incorrect YAML field name from `name` to `secretName`

- Ensure NATS credentials volume mounts when auto-generation is enabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zen Deployment Config"] -->|Add autoGenerate condition| B["NATS Volume Mount"]
  A -->|Fix secretName field| C["NATS Secret Reference"]
  B --> D["Proper credential mounting"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zen.yaml</strong><dd><code>Fix NATS credentials mounting and secret field name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/zen.yaml

<ul><li>Added <code>.Values.natsCreds.autoGenerate</code> condition to NATS credentials <br>volume mount check (line 29)<br> <li> Added <code>.Values.natsCreds.autoGenerate</code> condition to NATS credentials <br>volume definition check (line 93)<br> <li> Fixed incorrect YAML field name from <code>name</code> to <code>secretName</code> in NATS secret <br>reference (line 103)</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2283/files#diff-6ad57a6af05e6ac723002f0979b35265589bd65639d2ea1605465c695f51364b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

