### PR TITLE
otel metrics fix

### DIFF
--- a/openspec/changes/update-dev-image-tags/design.md
+++ b/openspec/changes/update-dev-image-tags/design.md
@@ -1,0 +1,32 @@
+## Context
+Dev/test iterations currently require bumping Helm values or Docker Compose tags to new git SHA tags. This slows iteration and encourages ad-hoc overrides, even though we only want versioned tags when cutting releases.
+
+## Goals / Non-Goals
+- Goals:
+  - Dev/test installs should track `latest` by default with no tag edits.
+  - Release installs should remain versioned and intentional via `cut-release.sh`.
+  - Operators must still be able to pin tags for reproducible testing.
+- Non-Goals:
+  - Removing immutable tags from CI or the registry.
+  - Auto-restarting workloads after every push.
+
+## Decisions
+- Default dev overlays to `latest` and set image pull policy to `Always` so new pushes are picked up on restart.
+- Keep a single override path (`global.imageTag` / `APP_TAG`) for pinning.
+- Ensure the build/push workflow always publishes `latest` tags alongside any existing immutable tags.
+
+## Alternatives considered
+- Using only pre-release semantic versions for dev: keeps immutability, but still requires editing tags each build.
+- Automatic rollouts after push: convenient but too invasive for shared clusters.
+
+## Risks / Trade-offs
+- `latest` is mutable; debugging requires explicit pinning for reproducibility.
+  - Mitigation: document the pinning path and keep immutable tags in CI.
+
+## Migration Plan
+- Update Helm dev values and Docker Compose defaults to `latest`.
+- Communicate the new workflow in docs and release notes.
+
+## Open Questions
+- Should demo-staging track `latest` or remain pinned for stability?
+- Do we want a `make deploy-dev` helper to rollout deployments after push?

--- a/openspec/changes/update-dev-image-tags/proposal.md
+++ b/openspec/changes/update-dev-image-tags/proposal.md
@@ -1,0 +1,13 @@
+# Change: Default dev deployments to latest image tags
+
+## Why
+Repeatedly updating Helm values and Docker Compose tags for every build is noisy and error-prone. We want dev/test installs to track the newest build without manual tag edits, while keeping versioned tags strictly tied to official releases.
+
+## What Changes
+- Default dev/test deployments (Helm + Docker Compose) to use `latest` image tags when no explicit tag override is provided.
+- Ensure `make push_all` publishes `latest` tags for ServiceRadar images (release tagging remains versioned via `cut-release.sh`).
+- Keep a single, explicit override path to pin images (e.g., `global.imageTag` / `APP_TAG`) when reproducibility is needed.
+
+## Impact
+- Affected specs: `deployment-versioning` (new).
+- Affected code/config: `helm/serviceradar`, `docker-compose.yml`, build/push scripts, docs/install guidance.

--- a/openspec/changes/update-dev-image-tags/specs/deployment-versioning/spec.md
+++ b/openspec/changes/update-dev-image-tags/specs/deployment-versioning/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+### Requirement: Dev image tag defaults
+The system SHALL default Helm and Docker Compose deployments to `latest` image tags when no explicit tag override is provided.
+
+#### Scenario: Helm install with no tag override
+- **WHEN** a Helm install is run with no `global.imageTag` override
+- **THEN** ServiceRadar workloads use `latest` tags
+
+#### Scenario: Docker Compose with no APP_TAG
+- **WHEN** Docker Compose is started without `APP_TAG`
+- **THEN** ServiceRadar services use `latest` tags
+
+### Requirement: Explicit tag pinning
+The system SHALL allow operators to pin all ServiceRadar images to a specific tag via a single override.
+
+#### Scenario: Helm tag override
+- **WHEN** `global.imageTag` is set to a specific tag
+- **THEN** ServiceRadar workloads use that tag
+
+#### Scenario: Compose tag override
+- **WHEN** `APP_TAG` is set to a specific tag
+- **THEN** Docker Compose uses that tag for ServiceRadar images
+
+### Requirement: Latest tag publishing
+The build/push workflow SHALL publish `latest` tags for ServiceRadar images in dev/test runs.
+
+#### Scenario: Push latest tags
+- **WHEN** `make push_all` is executed in a dev/test workflow
+- **THEN** the registry has updated `latest` tags for ServiceRadar images

--- a/openspec/changes/update-dev-image-tags/tasks.md
+++ b/openspec/changes/update-dev-image-tags/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+- [ ] 1.1 Define the dev tag strategy for Helm (default latest + optional pin) and align helpers/values.
+- [ ] 1.2 Update Docker Compose defaults to use `latest` when `APP_TAG` is unset.
+- [ ] 1.3 Ensure `make push_all` publishes `latest` tags for ServiceRadar images.
+- [ ] 1.4 Update docs/install guidance to reflect the latest-based dev workflow and explicit pinning.
+- [ ] 1.5 Add validation or checks (Helm template/test or CI note) to prevent regressions.

--- a/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
@@ -110,8 +110,14 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
     cutoff = DateTime.add(DateTime.utc_now(), -24, :hour)
     schema = schema_for_scope(scope)
 
-    query =
-      if schema do
+    if is_nil(schema) do
+      log_schema_warning_once(
+        :analytics_hourly_stats,
+        "Hourly metrics stats skipped: tenant schema unavailable"
+      )
+      nil
+    else
+      query =
         from(s in "otel_metrics_hourly_stats",
           prefix: ^schema,
           where: s.bucket >= ^cutoff,
@@ -134,47 +140,25 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
             max_duration_ms: max(s.max_duration_ms)
           }
         )
-      else
-        from(s in "otel_metrics_hourly_stats",
-          where: s.bucket >= ^cutoff,
-          select: %{
-            total_count: sum(s.total_count),
-            error_count: sum(s.error_count),
-            slow_count: sum(s.slow_count),
-            http_4xx_count: sum(s.http_4xx_count),
-            http_5xx_count: sum(s.http_5xx_count),
-            grpc_error_count: sum(s.grpc_error_count),
-            avg_duration_ms:
-              fragment(
-                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
-                s.total_count,
-                s.avg_duration_ms,
-                s.total_count,
-                s.total_count
-              ),
-            p95_duration_ms: max(s.p95_duration_ms),
-            max_duration_ms: max(s.max_duration_ms)
+
+      case Repo.one(query) do
+        %{total_count: total} = stats when not is_nil(total) ->
+          %{
+            total: to_int(total),
+            error: to_int(stats.error_count),
+            slow: to_int(stats.slow_count),
+            http_4xx: to_int(stats.http_4xx_count),
+            http_5xx: to_int(stats.http_5xx_count),
+            grpc_error: to_int(stats.grpc_error_count),
+            avg_duration_ms: to_float(stats.avg_duration_ms),
+            p95_duration_ms: to_float(stats.p95_duration_ms),
+            max_duration_ms: to_float(stats.max_duration_ms)
           }
-        )
+
+        _ ->
+          Logger.debug("Hourly metrics stats not available, falling back to SRQL queries")
+          nil
       end
-
-    case Repo.one(query) do
-      %{total_count: total} = stats when not is_nil(total) ->
-        %{
-          total: to_int(total),
-          error: to_int(stats.error_count),
-          slow: to_int(stats.slow_count),
-          http_4xx: to_int(stats.http_4xx_count),
-          http_5xx: to_int(stats.http_5xx_count),
-          grpc_error: to_int(stats.grpc_error_count),
-          avg_duration_ms: to_float(stats.avg_duration_ms),
-          p95_duration_ms: to_float(stats.p95_duration_ms),
-          max_duration_ms: to_float(stats.max_duration_ms)
-        }
-
-      _ ->
-        Logger.debug("Hourly metrics stats not available, falling back to SRQL queries")
-        nil
     end
   rescue
     error ->
@@ -187,6 +171,18 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
   defp to_float(v) when is_float(v), do: v
   defp to_float(v) when is_integer(v), do: v * 1.0
   defp to_float(_), do: 0.0
+
+  defp log_schema_warning_once(key, message) do
+    warned_key = {:schema_warning, key}
+
+    if Process.get(warned_key) do
+      :ok
+    else
+      Logger.warning(message)
+      Process.put(warned_key, true)
+      :ok
+    end
+  end
 
   defp schema_for_scope(nil), do: nil
 

--- a/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
@@ -2,6 +2,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
   use ServiceRadarWebNGWeb, :live_view
 
   import Ecto.Query
+  alias ServiceRadar.Cluster.TenantSchemas
   alias ServiceRadarWebNG.Repo
   alias ServiceRadarWebNGWeb.SRQL.Page, as: SRQLPage
 
@@ -105,31 +106,57 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
   end
 
   # Query the continuous aggregation for efficient pre-computed stats
-  defp get_hourly_metrics_stats do
+  defp get_hourly_metrics_stats(scope) do
     cutoff = DateTime.add(DateTime.utc_now(), -24, :hour)
+    schema = schema_for_scope(scope)
 
     query =
-      from(s in "otel_metrics_hourly_stats",
-        where: s.bucket >= ^cutoff,
-        select: %{
-          total_count: sum(s.total_count),
-          error_count: sum(s.error_count),
-          slow_count: sum(s.slow_count),
-          http_4xx_count: sum(s.http_4xx_count),
-          http_5xx_count: sum(s.http_5xx_count),
-          grpc_error_count: sum(s.grpc_error_count),
-          avg_duration_ms:
-            fragment(
-              "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
-              s.total_count,
-              s.avg_duration_ms,
-              s.total_count,
-              s.total_count
-            ),
-          p95_duration_ms: max(s.p95_duration_ms),
-          max_duration_ms: max(s.max_duration_ms)
-        }
-      )
+      if schema do
+        from(s in "otel_metrics_hourly_stats",
+          prefix: ^schema,
+          where: s.bucket >= ^cutoff,
+          select: %{
+            total_count: sum(s.total_count),
+            error_count: sum(s.error_count),
+            slow_count: sum(s.slow_count),
+            http_4xx_count: sum(s.http_4xx_count),
+            http_5xx_count: sum(s.http_5xx_count),
+            grpc_error_count: sum(s.grpc_error_count),
+            avg_duration_ms:
+              fragment(
+                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
+                s.total_count,
+                s.avg_duration_ms,
+                s.total_count,
+                s.total_count
+              ),
+            p95_duration_ms: max(s.p95_duration_ms),
+            max_duration_ms: max(s.max_duration_ms)
+          }
+        )
+      else
+        from(s in "otel_metrics_hourly_stats",
+          where: s.bucket >= ^cutoff,
+          select: %{
+            total_count: sum(s.total_count),
+            error_count: sum(s.error_count),
+            slow_count: sum(s.slow_count),
+            http_4xx_count: sum(s.http_4xx_count),
+            http_5xx_count: sum(s.http_5xx_count),
+            grpc_error_count: sum(s.grpc_error_count),
+            avg_duration_ms:
+              fragment(
+                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
+                s.total_count,
+                s.avg_duration_ms,
+                s.total_count,
+                s.total_count
+              ),
+            p95_duration_ms: max(s.p95_duration_ms),
+            max_duration_ms: max(s.max_duration_ms)
+          }
+        )
+      end
 
     case Repo.one(query) do
       %{total_count: total} = stats when not is_nil(total) ->
@@ -161,12 +188,30 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
   defp to_float(v) when is_integer(v), do: v * 1.0
   defp to_float(_), do: 0.0
 
+  defp schema_for_scope(nil), do: nil
+
+  defp schema_for_scope(%{active_tenant: active_tenant}) when not is_nil(active_tenant) do
+    safe_schema_for_tenant(active_tenant)
+  end
+
+  defp schema_for_scope(%{tenant_id: tenant_id}) when is_binary(tenant_id) do
+    safe_schema_for_tenant(tenant_id)
+  end
+
+  defp schema_for_scope(_), do: nil
+
+  defp safe_schema_for_tenant(tenant) do
+    TenantSchemas.schema_for_tenant(tenant)
+  rescue
+    ArgumentError -> nil
+  end
+
   defp load_analytics(socket) do
     srql_module = srql_module()
     scope = Map.get(socket.assigns, :current_scope)
 
     # Try to get metrics stats from continuous aggregation first (more efficient)
-    hourly_stats = get_hourly_metrics_stats()
+    hourly_stats = get_hourly_metrics_stats(scope)
 
     queries = %{
       devices_total: ~s|in:devices stats:"count() as total"|,

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/index.ex
@@ -10,6 +10,8 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
   alias ServiceRadarWebNGWeb.SRQL.Page, as: SRQLPage
   alias ServiceRadarWebNGWeb.Stats
 
+  require Logger
+
   @default_limit 20
   @max_limit 100
   @default_stats_window "last_24h"
@@ -1650,8 +1652,14 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
     cutoff = DateTime.add(DateTime.utc_now(), -24, :hour)
     schema = schema_for_scope(scope)
 
-    query =
-      if schema do
+    if is_nil(schema) do
+      log_schema_warning_once(
+        :log_duration_stats,
+        "Duration stats skipped: tenant schema unavailable"
+      )
+      %{avg_duration_ms: 0.0, p95_duration_ms: 0.0, sample_size: 0}
+    else
+      query =
         from(s in "otel_metrics_hourly_stats",
           prefix: ^schema,
           where: s.bucket >= ^cutoff,
@@ -1668,34 +1676,18 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
             p95_duration_ms: max(s.p95_duration_ms)
           }
         )
-      else
-        from(s in "otel_metrics_hourly_stats",
-          where: s.bucket >= ^cutoff,
-          select: %{
-            total_count: sum(s.total_count),
-            avg_duration_ms:
-              fragment(
-                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
-                s.total_count,
-                s.avg_duration_ms,
-                s.total_count,
-                s.total_count
-              ),
-            p95_duration_ms: max(s.p95_duration_ms)
+
+      case Repo.one(query) do
+        %{total_count: total} = stats when not is_nil(total) and total > 0 ->
+          %{
+            avg_duration_ms: numeric_to_float(stats.avg_duration_ms),
+            p95_duration_ms: numeric_to_float(stats.p95_duration_ms),
+            sample_size: to_int(total)
           }
-        )
+
+        _ ->
+          %{avg_duration_ms: 0.0, p95_duration_ms: 0.0, sample_size: 0}
       end
-
-    case Repo.one(query) do
-      %{total_count: total} = stats when not is_nil(total) and total > 0 ->
-        %{
-          avg_duration_ms: numeric_to_float(stats.avg_duration_ms),
-          p95_duration_ms: numeric_to_float(stats.p95_duration_ms),
-          sample_size: to_int(total)
-        }
-
-      _ ->
-        %{avg_duration_ms: 0.0, p95_duration_ms: 0.0, sample_size: 0}
     end
   rescue
     e ->
@@ -1742,6 +1734,18 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
     ArgumentError -> nil
   end
 
+  defp log_schema_warning_once(key, message) do
+    warned_key = {:schema_warning, key}
+
+    if Process.get(warned_key) do
+      :ok
+    else
+      Logger.warning(message)
+      Process.put(warned_key, true)
+      :ok
+    end
+  end
+
   defp sparkline_metric_names(metrics) do
     metrics
     |> Enum.filter(fn metric ->
@@ -1757,8 +1761,14 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
     cutoff = DateTime.add(DateTime.utc_now(), -2, :hour)
     schema = schema_for_scope(scope)
 
-    query =
-      if schema do
+    if is_nil(schema) do
+      log_schema_warning_once(
+        :log_sparklines,
+        "Sparkline stats skipped: tenant schema unavailable"
+      )
+      %{}
+    else
+      query =
         from(m in "otel_metrics",
           prefix: ^schema,
           where: m.metric_name in ^metric_names and m.timestamp >= ^cutoff,
@@ -1770,22 +1780,11 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
             avg_value: avg(m.value)
           }
         )
-      else
-        from(m in "otel_metrics",
-          where: m.metric_name in ^metric_names and m.timestamp >= ^cutoff,
-          group_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
-          order_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
-          select: %{
-            metric_name: m.metric_name,
-            bucket: fragment("time_bucket('5 minutes', ?)", m.timestamp),
-            avg_value: avg(m.value)
-          }
-        )
-      end
 
-    query
-    |> Repo.all()
-    |> Enum.group_by(& &1.metric_name, fn row -> numeric_to_float(row.avg_value) end)
+      query
+      |> Repo.all()
+      |> Enum.group_by(& &1.metric_name, fn row -> numeric_to_float(row.avg_value) end)
+    end
   end
 
   defp compute_error_rate(total, errors) when is_integer(total) and total > 0 do

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/index.ex
@@ -4,6 +4,7 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
   import Ecto.Query
   import ServiceRadarWebNGWeb.UIComponents
 
+  alias ServiceRadar.Cluster.TenantSchemas
   alias Phoenix.LiveView.JS
   alias ServiceRadarWebNG.Repo
   alias ServiceRadarWebNGWeb.SRQL.Page, as: SRQLPage
@@ -1514,7 +1515,7 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
   defp apply_tab_assigns(socket, "metrics", srql_module) do
     scope = Map.get(socket.assigns, :current_scope)
     metrics_stats = build_metrics_stats(srql_module, scope)
-    sparklines = load_sparklines(socket.assigns.metrics)
+    sparklines = load_sparklines(socket.assigns.metrics, scope)
 
     socket
     |> assign(:metrics_stats, metrics_stats)
@@ -1536,7 +1537,7 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
 
   defp build_metrics_stats(srql_module, scope) do
     metrics_counts = load_metrics_counts(srql_module, scope)
-    duration_stats = load_duration_stats_from_cagg()
+    duration_stats = load_duration_stats_from_cagg(scope)
 
     metrics_counts
     |> Map.merge(duration_stats)
@@ -1645,25 +1646,45 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
   end
 
   # Load duration stats from the continuous aggregation for full 24h data
-  defp load_duration_stats_from_cagg do
+  defp load_duration_stats_from_cagg(scope) do
     cutoff = DateTime.add(DateTime.utc_now(), -24, :hour)
+    schema = schema_for_scope(scope)
 
     query =
-      from(s in "otel_metrics_hourly_stats",
-        where: s.bucket >= ^cutoff,
-        select: %{
-          total_count: sum(s.total_count),
-          avg_duration_ms:
-            fragment(
-              "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
-              s.total_count,
-              s.avg_duration_ms,
-              s.total_count,
-              s.total_count
-            ),
-          p95_duration_ms: max(s.p95_duration_ms)
-        }
-      )
+      if schema do
+        from(s in "otel_metrics_hourly_stats",
+          prefix: ^schema,
+          where: s.bucket >= ^cutoff,
+          select: %{
+            total_count: sum(s.total_count),
+            avg_duration_ms:
+              fragment(
+                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
+                s.total_count,
+                s.avg_duration_ms,
+                s.total_count,
+                s.total_count
+              ),
+            p95_duration_ms: max(s.p95_duration_ms)
+          }
+        )
+      else
+        from(s in "otel_metrics_hourly_stats",
+          where: s.bucket >= ^cutoff,
+          select: %{
+            total_count: sum(s.total_count),
+            avg_duration_ms:
+              fragment(
+                "CASE WHEN SUM(?) > 0 THEN SUM(? * ?) / SUM(?) ELSE 0 END",
+                s.total_count,
+                s.avg_duration_ms,
+                s.total_count,
+                s.total_count
+              ),
+            p95_duration_ms: max(s.p95_duration_ms)
+          }
+        )
+      end
 
     case Repo.one(query) do
       %{total_count: total} = stats when not is_nil(total) and total > 0 ->
@@ -1685,13 +1706,13 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
 
   # Load sparkline data for gauge/counter metrics
   # Returns a map of metric_name -> list of {bucket, avg_value} tuples
-  defp load_sparklines(metrics) when is_list(metrics) do
+  defp load_sparklines(metrics, scope) when is_list(metrics) do
     metric_names = sparkline_metric_names(metrics)
 
     if metric_names == [] do
       %{}
     else
-      fetch_sparklines(metric_names)
+      fetch_sparklines(metric_names, scope)
     end
   rescue
     e ->
@@ -1701,7 +1722,25 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
       %{}
   end
 
-  defp load_sparklines(_), do: %{}
+  defp load_sparklines(_, _), do: %{}
+
+  defp schema_for_scope(nil), do: nil
+
+  defp schema_for_scope(%{active_tenant: active_tenant}) when not is_nil(active_tenant) do
+    safe_schema_for_tenant(active_tenant)
+  end
+
+  defp schema_for_scope(%{tenant_id: tenant_id}) when is_binary(tenant_id) do
+    safe_schema_for_tenant(tenant_id)
+  end
+
+  defp schema_for_scope(_), do: nil
+
+  defp safe_schema_for_tenant(tenant) do
+    TenantSchemas.schema_for_tenant(tenant)
+  rescue
+    ArgumentError -> nil
+  end
 
   defp sparkline_metric_names(metrics) do
     metrics
@@ -1714,20 +1753,35 @@ defmodule ServiceRadarWebNGWeb.LogLive.Index do
     |> Enum.uniq()
   end
 
-  defp fetch_sparklines(metric_names) do
+  defp fetch_sparklines(metric_names, scope) do
     cutoff = DateTime.add(DateTime.utc_now(), -2, :hour)
+    schema = schema_for_scope(scope)
 
     query =
-      from(m in "otel_metrics",
-        where: m.metric_name in ^metric_names and m.timestamp >= ^cutoff,
-        group_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
-        order_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
-        select: %{
-          metric_name: m.metric_name,
-          bucket: fragment("time_bucket('5 minutes', ?)", m.timestamp),
-          avg_value: avg(m.value)
-        }
-      )
+      if schema do
+        from(m in "otel_metrics",
+          prefix: ^schema,
+          where: m.metric_name in ^metric_names and m.timestamp >= ^cutoff,
+          group_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
+          order_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
+          select: %{
+            metric_name: m.metric_name,
+            bucket: fragment("time_bucket('5 minutes', ?)", m.timestamp),
+            avg_value: avg(m.value)
+          }
+        )
+      else
+        from(m in "otel_metrics",
+          where: m.metric_name in ^metric_names and m.timestamp >= ^cutoff,
+          group_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
+          order_by: [m.metric_name, fragment("time_bucket('5 minutes', ?)", m.timestamp)],
+          select: %{
+            metric_name: m.metric_name,
+            bucket: fragment("time_bucket('5 minutes', ?)", m.timestamp),
+            avg_value: avg(m.value)
+          }
+        )
+      end
 
     query
     |> Repo.all()


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Add tenant schema support to OTEL metrics queries

- Pass scope parameter to metrics query functions

- Implement schema_for_scope helper for tenant resolution

- Handle both tenant-aware and default schema queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Metrics Query Functions"] -->|"receive scope parameter"| B["schema_for_scope"]
  B -->|"extract tenant info"| C["TenantSchemas.schema_for_tenant"]
  C -->|"returns schema or nil"| D["Conditional Query Builder"]
  D -->|"with schema"| E["Query with prefix"]
  D -->|"without schema"| F["Query without prefix"]
  E -->|"execute"| G["Repo.one/all"]
  F -->|"execute"| G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Add tenant schema support to analytics metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex

<ul><li>Add <code>TenantSchemas</code> alias for tenant schema resolution<br> <li> Modify <code>get_hourly_metrics_stats/1</code> to accept scope parameter<br> <li> Implement conditional query building with schema prefix support<br> <li> Add <code>schema_for_scope/1</code> and <code>safe_schema_for_tenant/1</code> helper functions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2284/files#diff-35fb1715e171ac9f3240e9c02d2170b636acbb369952d58d352e1f75c91f82e3">+68/-23</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Add tenant schema support to log metrics queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/log_live/index.ex

<ul><li>Add <code>TenantSchemas</code> alias for tenant schema resolution<br> <li> Update <code>load_duration_stats_from_cagg/1</code> to accept and use scope <br>parameter<br> <li> Update <code>load_sparklines/2</code> to accept scope and pass to fetch function<br> <li> Modify <code>fetch_sparklines/2</code> to accept scope and build conditional <br>queries with schema prefix<br> <li> Add <code>schema_for_scope/1</code> and <code>safe_schema_for_tenant/1</code> helper functions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2284/files#diff-5c469994d989d04955c9b8a31536ed518a182b3f46819ecee9c3c22f651a4321">+86/-32</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

