### PR TITLE
adding missing files

### DIFF
--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -7,6 +7,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   require Ash.Query
 
   alias ServiceRadarWebNGWeb.SRQL.Page, as: SRQLPage
+  alias ServiceRadarWebNG.Accounts.Scope
   alias ServiceRadar.Inventory.Device
   alias ServiceRadar.SysmonProfiles.SysmonProfile
 
@@ -192,16 +193,24 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
         {:noreply, assign(socket, :csv_errors, ["No CSV data to import. Preview first."])}
 
       devices when is_list(devices) and devices != [] ->
-        # TODO: Actually create devices via Ash
-        # For now, show success message with count
-        count = length(devices)
+        scope = socket.assigns.current_scope
 
-        {:noreply,
-         socket
-         |> assign(:show_import_modal, false)
-         |> assign(:csv_preview, nil)
-         |> assign(:csv_errors, [])
-         |> put_flash(:info, "CSV import functionality coming soon. #{count} device(s) would be imported.")}
+        case import_devices(scope, devices) do
+          {:ok, {created, skipped}} ->
+            {:noreply,
+             socket
+             |> assign(:show_import_modal, false)
+             |> assign(:csv_preview, nil)
+             |> assign(:csv_errors, [])
+             |> put_flash(:info, import_success_message(created, skipped))
+             |> push_patch(to: ~p"/devices")}
+
+          {:error, errors} when is_list(errors) ->
+            {:noreply, assign(socket, :csv_errors, errors)}
+
+          {:error, reason} ->
+            {:noreply, assign(socket, :csv_errors, ["Import failed: #{inspect(reason)}"])}
+        end
 
       _ ->
         {:noreply, assign(socket, :csv_errors, ["No valid devices in CSV"])}
@@ -212,14 +221,33 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     {:noreply, assign(socket, :add_device_form, to_form(params, as: :device))}
   end
 
-  def handle_event("save_device", %{"device" => _params}, socket) do
-    # For now, just close the modal and show a flash message
-    # Full implementation would create the device via Ash
-    {:noreply,
-     socket
-     |> assign(:show_add_device_modal, false)
-     |> assign(:add_device_form, to_form(%{}, as: :device))
-     |> put_flash(:info, "Device creation not yet implemented. Use Network Discovery to add devices.")}
+  def handle_event("save_device", %{"device" => params}, socket) do
+    scope = socket.assigns.current_scope
+
+    case create_device(scope, params) do
+      {:ok, device} ->
+        {:noreply,
+         socket
+         |> assign(:show_add_device_modal, false)
+         |> assign(:add_device_form, to_form(%{}, as: :device))
+         |> put_flash(:info, "Device '#{device.hostname || device.ip}' created successfully.")
+         |> push_patch(to: ~p"/devices")}
+
+      {:error, %Ash.Error.Invalid{} = error} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, format_device_error(error))}
+
+      {:error, :already_exists} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "A device with this IP address already exists.")}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Failed to create device: #{inspect(reason)}")}
+    end
   end
 
   def handle_event("srql_builder_add_filter", params, socket) do
@@ -1911,4 +1939,203 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
   end
+
+  # Device creation helpers
+
+  defp import_success_message(created, skipped) when skipped > 0 and created > 0 do
+    "Created #{created} device(s). #{skipped} device(s) skipped (already exist)."
+  end
+
+  defp import_success_message(_created, skipped) when skipped > 0 do
+    "All #{skipped} device(s) already exist."
+  end
+
+  defp import_success_message(created, _skipped) do
+    "Created #{created} device(s) successfully."
+  end
+
+  defp import_devices(scope, devices) do
+    tenant_id = Scope.tenant_id(scope)
+
+    if is_nil(tenant_id) do
+      {:error, :no_tenant}
+    else
+      tenant_schema = ServiceRadarWebNGWeb.TenantResolver.schema_for_tenant_id(tenant_id)
+      actor = build_device_actor(scope)
+      do_import_devices(devices, actor, tenant_schema)
+    end
+  end
+
+  defp do_import_devices(devices, actor, tenant_schema) do
+    {created, skipped, errors} =
+      Enum.reduce(devices, {0, 0, []}, fn device_data, acc ->
+        process_device_import(device_data, actor, tenant_schema, acc)
+      end)
+
+    if errors == [], do: {:ok, {created, skipped}}, else: {:error, Enum.reverse(errors)}
+  end
+
+  defp process_device_import(device_data, actor, tenant_schema, {created, skipped, errors}) do
+    case create_single_device(device_data, actor, tenant_schema) do
+      {:ok, _device} ->
+        {created + 1, skipped, errors}
+
+      {:error, :already_exists} ->
+        {created, skipped + 1, errors}
+
+      {:error, reason} ->
+        error_msg = "Row #{created + skipped + 1}: #{format_create_error(reason)}"
+        {created, skipped, [error_msg | errors]}
+    end
+  end
+
+  defp create_device(scope, params) do
+    tenant_id = Scope.tenant_id(scope)
+
+    if is_nil(tenant_id) do
+      {:error, :no_tenant}
+    else
+      tenant_schema = ServiceRadarWebNGWeb.TenantResolver.schema_for_tenant_id(tenant_id)
+      actor = build_device_actor(scope)
+
+      # Build device data from form params
+      device_data = %{
+        hostname: params["hostname"],
+        ip: params["ip"],
+        type: params["type"],
+        tags: parse_form_tags(params["tags"])
+      }
+
+      create_single_device(device_data, actor, tenant_schema)
+    end
+  end
+
+  defp create_single_device(device_data, actor, tenant_schema) do
+    # Generate a UID based on IP (or use a UUID)
+    uid = generate_device_uid(device_data.ip)
+
+    # First check if device already exists
+    case Device.get_by_uid(uid, actor: actor, tenant: tenant_schema) do
+      {:ok, _existing} ->
+        {:error, :already_exists}
+
+      {:error, %Ash.Error.Query.NotFound{}} ->
+        # Device doesn't exist, create it
+        now = DateTime.utc_now()
+
+        attrs = %{
+          uid: uid,
+          hostname: device_data.hostname,
+          ip: device_data.ip,
+          name: device_data.hostname || device_data.ip,
+          type: device_data[:type],
+          type_id: parse_type_id(device_data[:type]),
+          tags: normalize_tags(device_data[:tags]),
+          discovery_sources: ["manual"],
+          first_seen_time: now,
+          last_seen_time: now,
+          created_time: now
+        }
+        |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
+        |> Map.new()
+
+        Device
+        |> Ash.Changeset.for_create(:create, attrs)
+        |> Ash.create(actor: actor, tenant: tenant_schema)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp generate_device_uid(ip) when is_binary(ip) do
+    # Generate a deterministic UID based on IP
+    # This allows for upsert behavior on re-import
+    :crypto.hash(:sha256, "manual:#{ip}")
+    |> Base.encode16(case: :lower)
+    |> String.slice(0, 32)
+  end
+
+  defp generate_device_uid(_), do: Ash.UUID.generate()
+
+  defp parse_type_id(nil), do: 0
+  defp parse_type_id(""), do: 0
+  defp parse_type_id("server"), do: 1
+  defp parse_type_id("Server"), do: 1
+  defp parse_type_id("desktop"), do: 2
+  defp parse_type_id("Desktop"), do: 2
+  defp parse_type_id("laptop"), do: 3
+  defp parse_type_id("Laptop"), do: 3
+  defp parse_type_id("switch"), do: 10
+  defp parse_type_id("Switch"), do: 10
+  defp parse_type_id("router"), do: 12
+  defp parse_type_id("Router"), do: 12
+  defp parse_type_id("firewall"), do: 9
+  defp parse_type_id("Firewall"), do: 9
+  defp parse_type_id(_), do: 0
+
+  defp normalize_tags(nil), do: %{}
+  defp normalize_tags(tags) when is_map(tags), do: tags
+  defp normalize_tags(tags) when is_list(tags) do
+    Enum.reduce(tags, %{}, fn tag, acc ->
+      case String.split(tag, "=", parts: 2) do
+        [key, value] -> Map.put(acc, String.trim(key), String.trim(value))
+        [key] -> Map.put(acc, String.trim(key), nil)
+      end
+    end)
+  end
+  defp normalize_tags(_), do: %{}
+
+  defp parse_form_tags(nil), do: []
+  defp parse_form_tags(""), do: []
+  defp parse_form_tags(tags_string) when is_binary(tags_string) do
+    tags_string
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp build_device_actor(scope) do
+    case scope do
+      %{user: user} when not is_nil(user) ->
+        %{
+          id: user.id,
+          email: user.email,
+          role: user.role,
+          tenant_id: Scope.tenant_id(scope)
+        }
+
+      _ ->
+        %{
+          id: "system",
+          email: "system@serviceradar",
+          role: :admin,
+          tenant_id: Scope.tenant_id(scope)
+        }
+    end
+  end
+
+  defp format_device_error(%Ash.Error.Invalid{errors: errors}) do
+    Enum.map_join(errors, ", ", &format_single_device_error/1)
+  end
+
+  defp format_device_error(error), do: inspect(error)
+
+  defp format_create_error(%Ash.Error.Invalid{errors: errors}) do
+    Enum.map_join(errors, ", ", &format_single_device_error/1)
+  end
+
+  defp format_create_error(error), do: inspect(error)
+
+  defp format_single_device_error(%Ash.Error.Changes.InvalidAttribute{field: field, message: msg}),
+    do: "#{field}: #{msg}"
+
+  defp format_single_device_error(%Ash.Error.Changes.Required{field: field}),
+    do: "#{field} is required"
+
+  defp format_single_device_error(%{message: msg}) when is_binary(msg),
+    do: msg
+
+  defp format_single_device_error(err),
+    do: inspect(err)
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -6,6 +6,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   alias ServiceRadarWebNGWeb.Dashboard.Engine
   alias ServiceRadarWebNGWeb.Dashboard.Plugins.Table, as: TablePlugin
   alias ServiceRadarWebNG.Accounts.Scope
+  alias ServiceRadar.Inventory.Device
   alias ServiceRadar.SweepJobs.SweepHostResult
   alias ServiceRadar.AgentConfig.Compilers.SysmonCompiler
   alias ServiceRadar.SysmonProfiles.SysmonProfile
@@ -195,13 +196,28 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     {:noreply, assign(socket, :device_form, to_form(params, as: :device))}
   end
 
-  def handle_event("save_device", %{"device" => _params}, socket) do
-    # TODO: Implement actual device update via Ash
-    # For now, show a flash message indicating the feature is in progress
-    {:noreply,
-     socket
-     |> assign(:editing, false)
-     |> put_flash(:info, "Device update functionality coming soon.")}
+  def handle_event("save_device", %{"device" => params}, socket) do
+    scope = socket.assigns.current_scope
+    device_uid = socket.assigns.device_uid
+
+    case update_device(scope, device_uid, params) do
+      {:ok, _device} ->
+        {:noreply,
+         socket
+         |> assign(:editing, false)
+         |> put_flash(:info, "Device updated successfully.")
+         |> push_patch(to: ~p"/devices/#{device_uid}")}
+
+      {:error, %Ash.Error.Invalid{} = error} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, format_ash_error(error))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Failed to update device: #{inspect(reason)}")}
+    end
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
@@ -2264,4 +2280,92 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   end
 
   defp membership_admin?(_, _), do: false
+
+  # Update device via Ash
+  defp update_device(scope, device_uid, params) do
+    tenant_id = Scope.tenant_id(scope)
+
+    if is_nil(tenant_id) do
+      {:error, :no_tenant}
+    else
+      tenant_schema = ServiceRadarWebNGWeb.TenantResolver.schema_for_tenant_id(tenant_id)
+      actor = build_device_actor(scope)
+
+      # Parse tags from newline-separated string to map
+      attrs = %{
+        hostname: params["hostname"],
+        ip: params["ip"],
+        vendor_name: params["vendor_name"],
+        model: params["model"],
+        tags: parse_tags_input(params["tags"])
+      }
+      |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
+      |> Map.new()
+
+      # First get the device, then update it
+      case Device.get_by_uid(device_uid, actor: actor, tenant: tenant_schema) do
+        {:ok, device} ->
+          device
+          |> Ash.Changeset.for_update(:update, attrs)
+          |> Ash.update(actor: actor, tenant: tenant_schema)
+
+        {:error, _} = error ->
+          error
+      end
+    end
+  end
+
+  defp build_device_actor(scope) do
+    case scope do
+      %{user: user} when not is_nil(user) ->
+        %{
+          id: user.id,
+          email: user.email,
+          role: user.role,
+          tenant_id: Scope.tenant_id(scope)
+        }
+
+      _ ->
+        %{
+          id: "system",
+          email: "system@serviceradar",
+          role: :admin,
+          tenant_id: Scope.tenant_id(scope)
+        }
+    end
+  end
+
+  defp parse_tags_input(nil), do: %{}
+  defp parse_tags_input(""), do: %{}
+
+  defp parse_tags_input(tags_string) when is_binary(tags_string) do
+    tags_string
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.reduce(%{}, fn line, acc ->
+      case String.split(line, "=", parts: 2) do
+        [key, value] -> Map.put(acc, String.trim(key), String.trim(value))
+        [key] -> Map.put(acc, String.trim(key), nil)
+      end
+    end)
+  end
+
+  defp format_ash_error(%Ash.Error.Invalid{errors: errors}) do
+    Enum.map_join(errors, ", ", &format_single_ash_error/1)
+  end
+
+  defp format_ash_error(error), do: inspect(error)
+
+  defp format_single_ash_error(%Ash.Error.Changes.InvalidAttribute{field: field, message: msg}),
+    do: "#{field}: #{msg}"
+
+  defp format_single_ash_error(%Ash.Error.Changes.Required{field: field}),
+    do: "#{field} is required"
+
+  defp format_single_ash_error(%{message: msg}) when is_binary(msg),
+    do: msg
+
+  defp format_single_ash_error(err),
+    do: inspect(err)
 end


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Implement device creation and CSV import functionality via Ash

- Add device update capability with proper error handling

- Support device UID generation and duplicate detection

- Include tag parsing and device actor building helpers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Live Views"] -->|"import_devices"| B["CSV Import Handler"]
  A -->|"create_device"| C["Device Creation"]
  A -->|"update_device"| D["Device Update"]
  B --> E["Ash Device Create"]
  C --> E
  D --> F["Ash Device Update"]
  E -->|"check duplicates"| G["Device UID Lookup"]
  F --> G
  E -->|"success/error"| H["Flash Messages"]
  F --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Device creation and CSV import implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex

<ul><li>Added <code>Scope</code> alias for tenant and user context management<br> <li> Implemented <code>import_devices/2</code> function to handle CSV device imports <br>with duplicate detection<br> <li> Replaced placeholder <code>save_device</code> handler with actual device creation <br>via Ash<br> <li> Added helper functions for device UID generation, type parsing, tag <br>normalization, and error formatting<br> <li> Implemented <code>create_single_device/3</code> to create devices with validation <br>and duplicate checking</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2315/files#diff-261a01f4876e5984e1d9e9b38a3540675dfb0272abc30e6bdb2a4fa610353cc7">+244/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Device update functionality with Ash integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex

<ul><li>Added <code>Device</code> alias for device resource access<br> <li> Implemented <code>update_device/3</code> function to update device attributes via <br>Ash<br> <li> Replaced placeholder <code>save_device</code> handler with actual device update <br>logic<br> <li> Added helper functions for tag input parsing and Ash error formatting<br> <li> Included <code>build_device_actor/1</code> to construct actor context for Ash <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2315/files#diff-92d8e0af57d2f65dfb8562e896dbea17ef9f47074ffd14f58261decc76f80c24">+111/-7</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

