### PR TITLE
2322 cleanup fix device details page

### DIFF
--- a/openspec/changes/fix-device-details-ui/proposal.md
+++ b/openspec/changes/fix-device-details-ui/proposal.md
@@ -1,0 +1,13 @@
+# Change: Fix device details sysmon visualizations
+
+## Why
+Device detail pages are showing sysmon metrics for devices that do not report them, and sysmon CPU/memory/disk metrics render as tables that are hard to read. Auto-generated visualizations for "Categories: type_id by modified" add noise without value.
+
+## What Changes
+- Gate sysmon metric panels so they only appear for devices with sysmon metrics data or agent-backed sysmon status
+- Render sysmon CPU, memory, and disk metrics as graphs instead of tables
+- Remove the default/auto visualization for "Categories: type_id by modified"
+
+## Impact
+- Affected specs: build-web-ui
+- Affected code: web-ng device detail UI, metrics/visualization components, device detail data fetch

--- a/openspec/changes/fix-device-details-ui/specs/build-web-ui/spec.md
+++ b/openspec/changes/fix-device-details-ui/specs/build-web-ui/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Sysmon metrics only for eligible devices
+The device detail view SHALL show sysmon metrics panels only when the device has sysmon metrics data or a sysmon status record.
+
+#### Scenario: Non-sysmon device detail view
+- **GIVEN** a device without sysmon metrics data or sysmon status
+- **WHEN** an admin views the device detail page
+- **THEN** no sysmon metrics panels are displayed
+
+#### Scenario: Sysmon device detail view
+- **GIVEN** a device with sysmon metrics data or sysmon status
+- **WHEN** an admin views the device detail page
+- **THEN** sysmon metrics panels are displayed
+
+### Requirement: Sysmon metrics rendered as graphs
+The device detail view SHALL render sysmon CPU, memory, and disk metrics as graphs instead of tables.
+
+#### Scenario: Sysmon CPU metrics visualization
+- **GIVEN** a device with sysmon CPU metrics
+- **WHEN** an admin views the device detail page
+- **THEN** CPU metrics render as a graph
+
+#### Scenario: Sysmon memory metrics visualization
+- **GIVEN** a device with sysmon memory metrics
+- **WHEN** an admin views the device detail page
+- **THEN** memory metrics render as a graph
+
+#### Scenario: Sysmon disk metrics visualization
+- **GIVEN** a device with sysmon disk metrics
+- **WHEN** an admin views the device detail page
+- **THEN** disk metrics render as a graph
+
+### Requirement: Suppress low-value auto visualizations
+The device detail view SHALL NOT auto-create a visualization for the dimension "type_id by modified".
+
+#### Scenario: Default device detail visualizations
+- **GIVEN** an admin opens a device detail page
+- **WHEN** default visualizations are generated
+- **THEN** no visualization is created for "Categories: type_id by modified"

--- a/openspec/changes/fix-device-details-ui/tasks.md
+++ b/openspec/changes/fix-device-details-ui/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+- [x] Locate the device detail view and sysmon metrics rendering in web-ng
+- [x] Add gating so sysmon metrics panels render only when the device has sysmon metrics data or sysmon status
+- [x] Update sysmon CPU, memory, and disk views to use graph visualizations instead of tables
+- [x] Remove or disable the auto visualization for "Categories: type_id by modified"
+- [ ] Add or update UI tests/fixtures for device detail sysmon panels (if coverage exists)
+
+## 2. Validation
+- [ ] Confirm a non-sysmon device detail page shows no sysmon metrics section
+- [ ] Confirm CPU, memory, and disk sysmon metrics render as graphs for sysmon devices
+- [ ] Confirm the "Categories: type_id by modified" visualization no longer appears by default

--- a/web-ng/lib/serviceradar_web_ng_web/components/srql_components.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/srql_components.ex
@@ -74,6 +74,13 @@ defmodule ServiceRadarWebNGWeb.SRQLComponents do
       assigns.columns
       |> normalize_columns(assigns.rows, assigns.max_columns)
 
+    columns =
+      if Enum.any?(assigns.rows, fn row -> is_map(row) and Map.has_key?(row, "_sparkline") end) do
+        columns ++ ["_sparkline"]
+      else
+        columns
+      end
+
     assigns = assign(assigns, :columns, columns)
 
     ~H"""
@@ -87,7 +94,11 @@ defmodule ServiceRadarWebNGWeb.SRQLComponents do
           <tr>
             <%= for col <- @columns do %>
               <th class="whitespace-nowrap text-xs font-semibold text-base-content/70 bg-base-200/60">
-                {col}
+                <%= if col == "_sparkline" do %>
+                  Trend
+                <% else %>
+                  {col}
+                <% end %>
               </th>
             <% end %>
           </tr>
@@ -106,7 +117,11 @@ defmodule ServiceRadarWebNGWeb.SRQLComponents do
             <tr id={"#{@id}-row-#{idx}"} class="hover:bg-base-200/40">
               <%= for col <- @columns do %>
                 <td class="whitespace-nowrap text-xs max-w-[24rem] truncate">
-                  <.srql_cell col={col} value={Map.get(row, col)} />
+                  <%= if col == "_sparkline" do %>
+                    <.srql_sparkline points={Map.get(row, "_sparkline")} />
+                  <% else %>
+                    <.srql_cell col={col} value={Map.get(row, col)} />
+                  <% end %>
                 </td>
               <% end %>
             </tr>
@@ -254,6 +269,26 @@ defmodule ServiceRadarWebNGWeb.SRQLComponents do
 
   defp ensure_positive_max(value) when is_number(value) and value > 0, do: value
   defp ensure_positive_max(_value), do: 1.0
+
+  attr :points, :list, default: []
+
+  def srql_sparkline(assigns) do
+    assigns = assign(assigns, :spark, sparkline(assigns.points))
+
+    ~H"""
+    <div class="w-24 h-6">
+      <svg viewBox="0 0 400 120" class="w-full h-full">
+        <polyline
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          class="text-primary"
+          points={@spark}
+        />
+      </svg>
+    </div>
+    """
+  end
 
   defp sparkline(points) when is_list(points) do
     values = Enum.map(points, fn {_dt, v} -> v end)

--- a/web-ng/lib/serviceradar_web_ng_web/dashboard/plugins/table.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/dashboard/plugins/table.ex
@@ -23,6 +23,7 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Table do
       srql_response
       |> Map.get("results", [])
       |> normalize_results()
+      |> attach_sparklines()
 
     {:ok, %{results: results}}
   end
@@ -45,6 +46,187 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Table do
   end
 
   defp normalize_results(_), do: []
+
+  defp attach_sparklines(results) when is_list(results) do
+    if length(results) < 5 do
+      results
+    else
+      with {:ok, spec} <- infer_sparkline_spec(results),
+           {:ok, spark_by_series} <- build_sparklines(results, spec),
+           true <- map_size(spark_by_series) > 0 do
+        Enum.map(results, fn
+          %{} = row ->
+            series_key = series_value(row, spec.series_key)
+            spark = Map.get(spark_by_series, series_key)
+            if is_list(spark), do: Map.put(row, "_sparkline", spark), else: row
+
+          other ->
+            other
+        end)
+      else
+        _ -> results
+      end
+    end
+  end
+
+  defp attach_sparklines(results), do: results
+
+  defp infer_sparkline_spec(results) do
+    keys =
+      results
+      |> Enum.find(&is_map/1)
+      |> case do
+        %{} = row -> Map.keys(row) |> Enum.map(&to_string/1)
+        _ -> []
+      end
+
+    x =
+      Enum.find(keys, fn k ->
+        k in ["timestamp", "ts", "time", "bucket", "inserted_at", "observed_at"]
+      end)
+
+    y =
+      Enum.find(keys, fn k -> k in ["value", "avg", "min", "max", "count"] end) ||
+        Enum.find(keys, fn k -> String.contains?(k, "usage") end) ||
+        Enum.find(keys, fn k -> numeric_column?(results, k) end)
+
+    series_key =
+      Enum.find(keys, fn k ->
+        k in [
+          "series",
+          "uid",
+          "device_id",
+          "agent_id",
+          "host_id",
+          "gateway_id",
+          "mount_point",
+          "interface",
+          "if_index",
+          "name",
+          "metric_name"
+        ]
+      end)
+
+    cond do
+      is_binary(x) and is_binary(y) ->
+        {:ok, %{x: x, y: y, series_key: series_key || "series"}}
+
+      true ->
+        {:error, :no_sparkline_spec}
+    end
+  end
+
+  defp build_sparklines(results, %{x: x, y: y, series_key: series_key}) do
+    rows =
+      results
+      |> Enum.filter(&is_map/1)
+      |> Enum.take(200)
+
+    points =
+      Enum.reduce(rows, %{}, fn row, acc ->
+        with {:ok, dt} <- parse_datetime(Map.get(row, x)),
+             {:ok, value} <- parse_number(Map.get(row, y)) do
+          series = series_value(row, series_key)
+          Map.update(acc, series, [{dt, value}], fn existing -> existing ++ [{dt, value}] end)
+        else
+          _ -> acc
+        end
+      end)
+
+    series_count = map_size(points)
+    max_points = points |> Map.values() |> Enum.map(&length/1) |> Enum.max(fn -> 0 end)
+
+    if series_count == 0 or series_count > 12 or max_points < 3 do
+      {:error, :sparklines_not_worth_it}
+    else
+      sparklines =
+        points
+        |> Enum.map(fn {series, series_points} ->
+          {series, Enum.take(series_points, 60)}
+        end)
+        |> Enum.into(%{})
+
+      {:ok, sparklines}
+    end
+  end
+
+  defp series_value(row, series_key) when is_map(row) do
+    value =
+      row
+      |> Map.get(series_key)
+      |> safe_to_string()
+      |> String.trim()
+
+    if value == "", do: "overall", else: value
+  end
+
+  defp series_value(_row, _series_key), do: "overall"
+
+  defp parse_number(value) when is_integer(value), do: {:ok, value * 1.0}
+  defp parse_number(value) when is_float(value), do: {:ok, value}
+
+  defp parse_number(value) when is_binary(value) do
+    value = String.trim(value)
+
+    cond do
+      value == "" ->
+        {:error, :empty}
+
+      match?({_, ""}, Float.parse(value)) ->
+        {v, ""} = Float.parse(value)
+        {:ok, v}
+
+      match?({_, ""}, Integer.parse(value)) ->
+        {v, ""} = Integer.parse(value)
+        {:ok, v * 1.0}
+
+      true ->
+        {:error, :nan}
+    end
+  end
+
+  defp parse_number(_), do: {:error, :not_numeric}
+
+  defp parse_datetime(%DateTime{} = dt), do: {:ok, dt}
+
+  defp parse_datetime(%NaiveDateTime{} = ndt) do
+    {:ok, DateTime.from_naive!(ndt, "Etc/UTC")}
+  end
+
+  defp parse_datetime(value) when is_binary(value) do
+    value = String.trim(value)
+
+    with {:error, _} <- DateTime.from_iso8601(value),
+         {:ok, ndt} <- NaiveDateTime.from_iso8601(value) do
+      {:ok, DateTime.from_naive!(ndt, "Etc/UTC")}
+    else
+      {:ok, dt, _offset} -> {:ok, dt}
+      {:error, _} -> {:error, :invalid_datetime}
+    end
+  end
+
+  defp parse_datetime(_), do: {:error, :not_datetime}
+
+  defp numeric_column?(rows, key) do
+    Enum.any?(rows, fn row ->
+      case Map.get(row, key) do
+        v when is_integer(v) or is_float(v) ->
+          true
+
+        v when is_binary(v) ->
+          match?({_, ""}, Float.parse(v)) or match?({_, ""}, Integer.parse(v))
+
+        _ ->
+          false
+      end
+    end)
+  end
+
+  defp safe_to_string(nil), do: ""
+  defp safe_to_string(value) when is_binary(value), do: value
+  defp safe_to_string(value) when is_integer(value), do: Integer.to_string(value)
+  defp safe_to_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp safe_to_string(value), do: inspect(value)
 
   @impl true
   def render(assigns) do

--- a/web-ng/lib/serviceradar_web_ng_web/dashboard/plugins/timeseries.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/dashboard/plugins/timeseries.ex
@@ -6,6 +6,7 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Timeseries do
   @behaviour ServiceRadarWebNGWeb.Dashboard.Plugin
 
   import ServiceRadarWebNGWeb.UIComponents, only: [ui_panel: 1]
+  alias ServiceRadarWebNGWeb.SRQL.Viz
 
   @max_series 6
   @max_points 200
@@ -27,6 +28,10 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Timeseries do
     end)
   end
 
+  def supports?(%{"results" => results}) when is_list(results) do
+    match?({:timeseries, _}, Viz.infer(results))
+  end
+
   def supports?(_), do: false
 
   @impl true
@@ -35,6 +40,18 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Timeseries do
     with {:ok, spec} <- parse_timeseries_spec(viz),
          {:ok, series_points} <- extract_series_points(results, spec) do
       {:ok, %{spec: spec, series_points: series_points}}
+    end
+  end
+
+  def build(%{"results" => results} = _srql_response) when is_list(results) do
+    case infer_timeseries_spec(results) do
+      {:ok, spec} ->
+        with {:ok, series_points} <- extract_series_points(results, spec) do
+          {:ok, %{spec: spec, series_points: series_points}}
+        end
+
+      _ ->
+        {:error, :invalid_response}
     end
   end
 
@@ -61,6 +78,13 @@ defmodule ServiceRadarWebNGWeb.Dashboard.Plugins.Timeseries do
   end
 
   defp parse_timeseries_spec(_), do: {:error, :missing_suggestions}
+
+  defp infer_timeseries_spec(results) when is_list(results) do
+    case Viz.infer(results) do
+      {:timeseries, %{x: x, y: y}} -> {:ok, %{x: x, y: y, series: nil}}
+      _ -> {:error, :missing_timeseries}
+    end
+  end
 
   defp extract_series_points(results, %{x: x, y: y, series: series_key}) do
     rows =

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -1761,35 +1761,36 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
     case srql_module.query(query, %{scope: scope}) do
       {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
-        rows = Enum.filter(rows, &row_matches_identity?(&1, identity))
-
-        if rows == [] do
-          nil
-        else
-          # Get unique cores and calculate average
-          values =
-            Enum.map(rows, fn r -> extract_numeric(Map.get(r, "value")) end)
-            |> Enum.filter(&is_number/1)
-
-          cores =
-            rows
-            |> Enum.map(fn r -> Map.get(r, "core") || Map.get(r, "cpu_core") end)
-            |> Enum.filter(&is_binary/1)
-            |> Enum.uniq()
-            |> length()
-
-          avg = if values != [], do: Enum.sum(values) / length(values), else: 0.0
-
-          %{
-            avg_usage: Float.round(avg * 1.0, 1),
-            core_count: max(cores, 1),
-            timestamp: Map.get(List.first(rows), "timestamp")
-          }
-        end
+        rows
+        |> Enum.filter(&row_matches_identity?(&1, identity))
+        |> build_cpu_summary()
 
       _ ->
         nil
     end
+  end
+
+  defp build_cpu_summary([]), do: nil
+
+  defp build_cpu_summary(rows) do
+    values =
+      Enum.map(rows, fn r -> extract_numeric(Map.get(r, "value")) end)
+      |> Enum.filter(&is_number/1)
+
+    cores =
+      rows
+      |> Enum.map(fn r -> Map.get(r, "core") || Map.get(r, "cpu_core") end)
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+      |> length()
+
+    avg = if values != [], do: Enum.sum(values) / length(values), else: 0.0
+
+    %{
+      avg_usage: Float.round(avg * 1.0, 1),
+      core_count: max(cores, 1),
+      timestamp: Map.get(List.first(rows), "timestamp")
+    }
   end
 
   defp load_memory_summary(srql_module, identity, scope) do
@@ -1828,8 +1829,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
         # Group by mount point and take the latest for each
         rows
-        |> Enum.filter(&is_map/1)
-        |> Enum.filter(&row_matches_identity?(&1, identity))
+        |> Enum.filter(fn row -> is_map(row) and row_matches_identity?(row, identity) end)
         |> Enum.group_by(&disk_mount/1)
         |> Enum.map(fn {mount, disk_rows} ->
           build_disk_entry(mount, List.first(disk_rows))

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -4,7 +4,9 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   import ServiceRadarWebNGWeb.UIComponents
 
   alias ServiceRadarWebNGWeb.Dashboard.Engine
+  alias ServiceRadarWebNGWeb.Dashboard.Plugins.Categories, as: CategoriesPlugin
   alias ServiceRadarWebNGWeb.Dashboard.Plugins.Table, as: TablePlugin
+  alias ServiceRadarWebNGWeb.SRQL.Viz
   alias ServiceRadar.Inventory.Device
   alias ServiceRadar.SweepJobs.SweepHostResult
   alias ServiceRadar.AgentConfig.Compilers.SysmonCompiler
@@ -41,6 +43,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
      |> assign(:results, [])
      |> assign(:panels, [])
      |> assign(:metric_sections, [])
+     |> assign(:sysmon_presence, false)
      |> assign(:sysmon_summary, nil)
      |> assign(:sysmon_profile_info, nil)
      |> assign(:available_profiles, [])
@@ -108,8 +111,12 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
     srql_response = %{"results" => results, "viz" => viz}
 
-    metric_sections = load_metric_sections(srql_module, uid, scope)
-    sysmon_summary = load_sysmon_summary(srql_module, uid, scope)
+    device_row = List.first(Enum.filter(results, &is_map/1))
+    sysmon_identity = sysmon_identity(device_row, uid)
+
+    metric_sections = load_metric_sections(srql_module, sysmon_identity, scope)
+    sysmon_summary = load_sysmon_summary(srql_module, sysmon_identity, scope)
+    sysmon_presence = load_sysmon_presence(srql_module, sysmon_identity, scope)
     availability = load_availability(srql_module, uid, scope)
     healthcheck_summary = load_healthcheck_summary(srql_module, uid, scope)
 
@@ -125,8 +132,9 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
      |> assign(:device_uid, uid)
      |> assign(:limit, limit)
      |> assign(:results, results)
-     |> assign(:panels, Engine.build_panels(srql_response))
+     |> assign(:panels, srql_response |> Engine.build_panels() |> drop_low_value_categories())
      |> assign(:metric_sections, metric_sections)
+     |> assign(:sysmon_presence, sysmon_presence)
      |> assign(:sysmon_summary, sysmon_summary)
      |> assign(:sysmon_profile_info, sysmon_profile_info)
      |> assign(:available_profiles, available_profiles)
@@ -238,11 +246,16 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       assigns
       |> assign(:device_row, device_row)
       |> assign(:can_edit, can_edit_device?(assigns.current_scope))
+      |> assign(:sysmon_metrics_visible, sysmon_metrics_visible?(assigns))
       |> assign(
         :metric_sections_to_render,
-        Enum.filter(assigns.metric_sections, fn section ->
-          is_binary(Map.get(section, :error)) or Map.get(section, :panels, []) != []
-        end)
+        if sysmon_metrics_visible?(assigns) do
+          Enum.filter(assigns.metric_sections, fn section ->
+            is_binary(Map.get(section, :error)) or Map.get(section, :panels, []) != []
+          end)
+        else
+          []
+        end
       )
 
     ~H"""
@@ -446,7 +459,10 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
             device_uid={@device_uid}
           />
 
-          <.sysmon_summary_section :if={is_map(@sysmon_summary)} summary={@sysmon_summary} />
+          <.sysmon_summary_section
+            :if={@sysmon_metrics_visible and is_map(@sysmon_summary)}
+            summary={@sysmon_summary}
+          />
 
           <%= for section <- @metric_sections_to_render do %>
             <div class="rounded-xl border border-base-200 bg-base-100 shadow-sm">
@@ -1041,11 +1057,13 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
   defp escape_value(other), do: escape_value(to_string(other))
 
-  defp load_metric_sections(srql_module, device_uid, scope) do
-    device_uid = escape_value(device_uid)
+  defp load_metric_sections(_srql_module, identity, _scope)
+       when identity == %{} or identity == nil,
+       do: []
 
+  defp load_metric_sections(srql_module, identity, scope) do
     metric_section_specs()
-    |> Enum.map(&build_metric_section(srql_module, &1, device_uid, scope))
+    |> Enum.map(&build_metric_section(srql_module, &1, identity, scope))
   end
 
   defp metric_section_specs do
@@ -1074,8 +1092,8 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     ]
   end
 
-  defp build_metric_section(srql_module, spec, device_uid, scope) do
-    query = metric_query(spec.entity, device_uid, spec.series)
+  defp build_metric_section(srql_module, spec, identity, scope) do
+    query = metric_query(spec.entity, identity, spec.series)
 
     base = %{
       key: spec.key,
@@ -1088,7 +1106,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
     case srql_module.query(query, %{scope: scope}) do
       {:ok, %{"results" => results} = resp} when is_list(results) and results != [] ->
-        panels = build_metric_panels(resp, results)
+        panels = build_metric_panels(resp, results, spec.series)
         %{base | panels: panels}
 
       {:ok, %{"results" => results}} when is_list(results) ->
@@ -1102,12 +1120,15 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     end
   end
 
-  defp build_metric_panels(resp, results) do
+  defp build_metric_panels(resp, results, series_field) do
     srql_response = %{"results" => results, "viz" => extract_viz(resp)}
 
-    srql_response
-    |> Engine.build_panels()
-    |> prefer_visual_panels(results)
+    panels =
+      srql_response
+      |> Engine.build_panels()
+      |> prefer_visual_panels(results)
+
+    maybe_force_timeseries(panels, results, series_field)
   end
 
   defp extract_viz(resp) do
@@ -1129,7 +1150,149 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
   defp prefer_visual_panels(panels, _results), do: panels
 
-  defp metric_query(entity, device_uid_escaped, series_field) do
+  defp maybe_force_timeseries(panels, results, series_field) do
+    has_visual = Enum.any?(panels, &(&1.plugin != TablePlugin))
+
+    if has_visual do
+      panels
+    else
+      case inferred_timeseries_viz(results, series_field) do
+        nil ->
+          panels
+
+        viz ->
+          %{"results" => results, "viz" => %{"suggestions" => [viz]}}
+          |> Engine.build_panels()
+          |> prefer_visual_panels(results)
+      end
+    end
+  end
+
+  defp inferred_timeseries_viz(results, series_field) do
+    case Viz.infer(results) do
+      {:timeseries, %{x: x, y: y}} ->
+        base = %{"kind" => "timeseries", "x" => x, "y" => y}
+
+        if is_binary(series_field) and String.trim(series_field) != "" do
+          Map.put(base, "series", series_field)
+        else
+          base
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp sysmon_metrics_visible?(assigns) do
+    sysmon_presence = Map.get(assigns, :sysmon_presence, false)
+    sysmon_summary = Map.get(assigns, :sysmon_summary)
+
+    sysmon_presence or is_map(sysmon_summary)
+  end
+
+  defp sysmon_identity(device_row, device_uid) do
+    device_uid =
+      case Map.get(device_row || %{}, "uid") || device_uid do
+        value when is_binary(value) -> String.trim(value)
+        _ -> ""
+      end
+
+    agent_id =
+      device_row
+      |> Map.get("agent_id")
+      |> case do
+        value when is_binary(value) -> String.trim(value)
+        _ -> ""
+      end
+
+    %{}
+    |> maybe_put_identity(:device_uid, device_uid)
+    |> maybe_put_identity(:agent_id, agent_id)
+  end
+
+  defp maybe_put_identity(identity, _key, ""), do: identity
+  defp maybe_put_identity(identity, _key, nil), do: identity
+
+  defp maybe_put_identity(identity, key, value) do
+    if is_binary(value) and String.trim(value) != "" do
+      Map.put(identity, key, value)
+    else
+      identity
+    end
+  end
+
+  defp sysmon_filter_tokens(identity) when identity == %{} or identity == nil, do: []
+
+  defp sysmon_filter_tokens(identity) do
+    tokens = []
+    device_uid = Map.get(identity, :device_uid)
+    agent_id = Map.get(identity, :agent_id)
+
+    tokens =
+      if is_binary(device_uid) and device_uid != "" do
+        tokens ++ ["device_id:\"#{escape_value(device_uid)}\""]
+      else
+        tokens
+      end
+
+    if is_binary(agent_id) and agent_id != "" do
+      tokens ++ ["agent_id:\"#{escape_value(agent_id)}\""]
+    else
+      tokens
+    end
+  end
+
+  defp row_matches_identity?(row, identity) when is_map(row) and is_map(identity) do
+    device_match =
+      case Map.get(identity, :device_uid) do
+        value when is_binary(value) and value != "" ->
+          Map.get(row, "uid") == value or Map.get(row, "device_id") == value
+
+        _ ->
+          true
+      end
+
+    agent_match =
+      case Map.get(identity, :agent_id) do
+        value when is_binary(value) and value != "" ->
+          Map.get(row, "agent_id") == value
+
+        _ ->
+          true
+      end
+
+    device_match and agent_match
+  end
+
+  defp row_matches_identity?(_row, _identity), do: false
+
+  defp drop_low_value_categories(panels) when is_list(panels) do
+    Enum.reject(panels, &low_value_categories_panel?/1)
+  end
+
+  defp drop_low_value_categories(_), do: []
+
+  defp low_value_categories_panel?(%{plugin: CategoriesPlugin, assigns: assigns}) do
+    case Map.get(assigns, :viz) do
+      {:categories, %{label: label, value: value}} ->
+        normalize_viz_key(label) == "modified" and normalize_viz_key(value) == "type_id"
+
+      _ ->
+        false
+    end
+  end
+
+  defp low_value_categories_panel?(_), do: false
+
+  defp normalize_viz_key(value) do
+    value
+    |> to_string()
+    |> String.trim()
+    |> String.downcase()
+  end
+
+  defp metric_query(entity, identity, series_field) do
     series_field =
       case series_field do
         nil -> nil
@@ -1140,13 +1303,13 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     tokens =
       [
         "in:#{entity}",
-        "uid:\"#{device_uid_escaped}\"",
         "time:last_24h",
         "bucket:5m",
         "agg:avg",
         "sort:timestamp:desc",
         "limit:#{@metrics_limit}"
       ]
+      |> Kernel.++(sysmon_filter_tokens(identity))
 
     tokens =
       if is_binary(series_field) and series_field != "" do
@@ -1543,14 +1706,16 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     }
   end
 
-  defp load_sysmon_summary(srql_module, device_uid, scope) do
-    escaped_id = escape_value(device_uid)
+  defp load_sysmon_summary(_srql_module, identity, _scope)
+       when identity == %{} or identity == nil,
+       do: nil
 
+  defp load_sysmon_summary(srql_module, identity, scope) do
     # Load CPU, Memory, Disk metrics in parallel (conceptually - in sequence here)
-    cpu_data = load_cpu_summary(srql_module, escaped_id, scope)
-    memory_data = load_memory_summary(srql_module, escaped_id, scope)
-    disk_data = load_disk_summary(srql_module, escaped_id, scope)
-    icmp_rtt = load_icmp_rtt(srql_module, escaped_id, scope)
+    cpu_data = load_cpu_summary(srql_module, identity, scope)
+    memory_data = load_memory_summary(srql_module, identity, scope)
+    disk_data = load_disk_summary(srql_module, identity, scope)
+    icmp_rtt = load_icmp_rtt(srql_module, identity, scope)
 
     has_sysmon_metrics = is_map(cpu_data) or is_map(memory_data) or disk_data != []
 
@@ -1566,65 +1731,105 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     end
   end
 
-  defp load_cpu_summary(srql_module, escaped_id, scope) do
-    query = "in:cpu_metrics uid:\"#{escaped_id}\" sort:timestamp:desc limit:64"
+  defp load_sysmon_presence(_srql_module, identity, _scope)
+       when identity == %{} or identity == nil,
+       do: false
+
+  defp load_sysmon_presence(srql_module, identity, scope) do
+    query =
+      [
+        "in:cpu_metrics",
+        Enum.join(sysmon_filter_tokens(identity), " "),
+        "time:last_24h",
+        "sort:timestamp:desc",
+        "limit:1"
+      ]
+      |> Enum.join(" ")
+
+    case srql_module.query(query, %{scope: scope}) do
+      {:ok, %{"results" => rows}} when is_list(rows) ->
+        Enum.any?(rows, &row_matches_identity?(&1, identity))
+
+      _ ->
+        false
+    end
+  end
+
+  defp load_cpu_summary(srql_module, identity, scope) do
+    query =
+      "in:cpu_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:64"
 
     case srql_module.query(query, %{scope: scope}) do
       {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
-        # Get unique cores and calculate average
-        values =
-          Enum.map(rows, fn r -> extract_numeric(Map.get(r, "value")) end)
-          |> Enum.filter(&is_number/1)
+        rows = Enum.filter(rows, &row_matches_identity?(&1, identity))
 
-        cores =
-          rows
-          |> Enum.map(fn r -> Map.get(r, "core") || Map.get(r, "cpu_core") end)
-          |> Enum.filter(&is_binary/1)
-          |> Enum.uniq()
-          |> length()
+        if rows == [] do
+          nil
+        else
+          # Get unique cores and calculate average
+          values =
+            Enum.map(rows, fn r -> extract_numeric(Map.get(r, "value")) end)
+            |> Enum.filter(&is_number/1)
 
-        avg = if values != [], do: Enum.sum(values) / length(values), else: 0.0
+          cores =
+            rows
+            |> Enum.map(fn r -> Map.get(r, "core") || Map.get(r, "cpu_core") end)
+            |> Enum.filter(&is_binary/1)
+            |> Enum.uniq()
+            |> length()
 
-        %{
-          avg_usage: Float.round(avg * 1.0, 1),
-          core_count: max(cores, 1),
-          timestamp: Map.get(List.first(rows), "timestamp")
-        }
+          avg = if values != [], do: Enum.sum(values) / length(values), else: 0.0
+
+          %{
+            avg_usage: Float.round(avg * 1.0, 1),
+            core_count: max(cores, 1),
+            timestamp: Map.get(List.first(rows), "timestamp")
+          }
+        end
 
       _ ->
         nil
     end
   end
 
-  defp load_memory_summary(srql_module, escaped_id, scope) do
-    query = "in:memory_metrics uid:\"#{escaped_id}\" sort:timestamp:desc limit:4"
+  defp load_memory_summary(srql_module, identity, scope) do
+    query =
+      "in:memory_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:4"
 
     case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => [row | _]}} when is_map(row) ->
-        used = extract_numeric(Map.get(row, "used_bytes") || Map.get(row, "value"))
-        total = extract_numeric(Map.get(row, "total_bytes"))
-        pct = percent_from_row(row, used, total)
+      {:ok, %{"results" => rows}} when is_list(rows) ->
+        row = Enum.find(rows, &row_matches_identity?(&1, identity))
 
-        %{
-          used_bytes: used || 0,
-          total_bytes: total || 0,
-          percent: Float.round(pct * 1.0, 1),
-          timestamp: Map.get(row, "timestamp")
-        }
+        if is_map(row) do
+          used = extract_numeric(Map.get(row, "used_bytes") || Map.get(row, "value"))
+          total = extract_numeric(Map.get(row, "total_bytes"))
+          pct = percent_from_row(row, used, total)
+
+          %{
+            used_bytes: used || 0,
+            total_bytes: total || 0,
+            percent: Float.round(pct * 1.0, 1),
+            timestamp: Map.get(row, "timestamp")
+          }
+        else
+          nil
+        end
 
       _ ->
         nil
     end
   end
 
-  defp load_disk_summary(srql_module, escaped_id, scope) do
-    query = "in:disk_metrics uid:\"#{escaped_id}\" sort:timestamp:desc limit:24"
+  defp load_disk_summary(srql_module, identity, scope) do
+    query =
+      "in:disk_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:24"
 
     case srql_module.query(query, %{scope: scope}) do
       {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
         # Group by mount point and take the latest for each
         rows
         |> Enum.filter(&is_map/1)
+        |> Enum.filter(&row_matches_identity?(&1, identity))
         |> Enum.group_by(&disk_mount/1)
         |> Enum.map(fn {mount, disk_rows} ->
           build_disk_entry(mount, List.first(disk_rows))
@@ -1636,16 +1841,22 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     end
   end
 
-  defp load_icmp_rtt(srql_module, escaped_id, scope) do
+  defp load_icmp_rtt(srql_module, identity, scope) do
     query =
-      "in:timeseries_metrics metric_type:icmp uid:\"#{escaped_id}\" sort:timestamp:desc limit:1"
+      "in:timeseries_metrics metric_type:icmp #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:1"
 
     case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => [row | _]}} when is_map(row) ->
-        row
-        |> Map.get("value")
-        |> extract_numeric()
-        |> normalize_icmp_rtt()
+      {:ok, %{"results" => rows}} when is_list(rows) ->
+        row = Enum.find(rows, &row_matches_identity?(&1, identity))
+
+        if is_map(row) do
+          row
+          |> Map.get("value")
+          |> extract_numeric()
+          |> normalize_icmp_rtt()
+        else
+          nil
+        end
 
       _ ->
         nil

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -6,6 +6,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   alias ServiceRadarWebNGWeb.Dashboard.Engine
   alias ServiceRadarWebNGWeb.Dashboard.Plugins.Categories, as: CategoriesPlugin
   alias ServiceRadarWebNGWeb.Dashboard.Plugins.Table, as: TablePlugin
+  alias ServiceRadarWebNGWeb.Dashboard.Plugins.Timeseries, as: TimeseriesPlugin
   alias ServiceRadarWebNGWeb.SRQL.Viz
   alias ServiceRadar.Inventory.Device
   alias ServiceRadar.SweepJobs.SweepHostResult
@@ -1127,8 +1128,11 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       srql_response
       |> Engine.build_panels()
       |> prefer_visual_panels(results)
+      |> drop_category_panels_when_timeseries()
 
-    maybe_force_timeseries(panels, results, series_field)
+    panels
+    |> maybe_force_timeseries(results, series_field)
+    |> drop_category_panels_when_timeseries()
   end
 
   defp extract_viz(resp) do
@@ -1149,6 +1153,18 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   end
 
   defp prefer_visual_panels(panels, _results), do: panels
+
+  defp drop_category_panels_when_timeseries(panels) when is_list(panels) do
+    has_timeseries = Enum.any?(panels, &(&1.plugin == TimeseriesPlugin))
+
+    if has_timeseries do
+      Enum.reject(panels, &(&1.plugin == CategoriesPlugin))
+    else
+      panels
+    end
+  end
+
+  defp drop_category_panels_when_timeseries(panels), do: panels
 
   defp maybe_force_timeseries(panels, results, series_field) do
     has_visual = Enum.any?(panels, &(&1.plugin != TablePlugin))

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -45,7 +45,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
      |> assign(:panels, [])
      |> assign(:metric_sections, [])
      |> assign(:sysmon_presence, false)
-     |> assign(:sysmon_summary, nil)
      |> assign(:sysmon_profile_info, nil)
      |> assign(:available_profiles, [])
      |> assign(:availability, nil)
@@ -116,7 +115,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     sysmon_identity = sysmon_identity(device_row, uid)
 
     metric_sections = load_metric_sections(srql_module, sysmon_identity, scope)
-    sysmon_summary = load_sysmon_summary(srql_module, sysmon_identity, scope)
     sysmon_presence = load_sysmon_presence(srql_module, sysmon_identity, scope)
     availability = load_availability(srql_module, uid, scope)
     healthcheck_summary = load_healthcheck_summary(srql_module, uid, scope)
@@ -136,7 +134,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
      |> assign(:panels, srql_response |> Engine.build_panels() |> drop_low_value_categories())
      |> assign(:metric_sections, metric_sections)
      |> assign(:sysmon_presence, sysmon_presence)
-     |> assign(:sysmon_summary, sysmon_summary)
      |> assign(:sysmon_profile_info, sysmon_profile_info)
      |> assign(:available_profiles, available_profiles)
      |> assign(:availability, availability)
@@ -458,11 +455,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
             profile_info={@sysmon_profile_info}
             available_profiles={@available_profiles}
             device_uid={@device_uid}
-          />
-
-          <.sysmon_summary_section
-            :if={@sysmon_metrics_visible and is_map(@sysmon_summary)}
-            summary={@sysmon_summary}
           />
 
           <%= for section <- @metric_sections_to_render do %>
@@ -1202,9 +1194,8 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
   defp sysmon_metrics_visible?(assigns) do
     sysmon_presence = Map.get(assigns, :sysmon_presence, false)
-    sysmon_summary = Map.get(assigns, :sysmon_summary)
 
-    sysmon_presence or is_map(sysmon_summary)
+    sysmon_presence
   end
 
   defp sysmon_identity(device_row, device_uid) do
@@ -1435,188 +1426,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   defp format_pct(_), do: "—"
 
   # ---------------------------------------------------------------------------
-  # Sysmon Summary Section
-  # ---------------------------------------------------------------------------
-
-  attr :summary, :map, required: true
-
-  def sysmon_summary_section(assigns) do
-    cpu = Map.get(assigns.summary, :cpu, %{})
-    memory = Map.get(assigns.summary, :memory, %{})
-    disks = Map.get(assigns.summary, :disks, [])
-    icmp_rtt = Map.get(assigns.summary, :icmp_rtt)
-
-    has_cpu = is_map(cpu) and not is_nil(Map.get(cpu, :timestamp))
-    has_memory = is_map(memory) and not is_nil(Map.get(memory, :timestamp))
-
-    assigns =
-      assigns
-      |> assign(:cpu, cpu)
-      |> assign(:memory, memory)
-      |> assign(:disks, disks)
-      |> assign(:icmp_rtt, icmp_rtt)
-      |> assign(:has_cpu, has_cpu)
-      |> assign(:has_memory, has_memory)
-
-    ~H"""
-    <div class="rounded-xl border border-base-200 bg-base-100 shadow-sm">
-      <div class="px-4 py-3 border-b border-base-200">
-        <span class="text-sm font-semibold">System Metrics (Sysmon)</span>
-      </div>
-
-      <div class="p-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <.metric_card
-          :if={@has_cpu}
-          title="CPU Usage"
-          value={format_pct(Map.get(@cpu, :avg_usage, 0.0))}
-          suffix="%"
-          subtitle={"#{Map.get(@cpu, :core_count, 0)} cores"}
-          icon="hero-cpu-chip"
-          color={cpu_color(Map.get(@cpu, :avg_usage, 0.0))}
-        />
-
-        <.metric_card
-          :if={@has_memory}
-          title="Memory"
-          value={format_pct(Map.get(@memory, :percent, 0.0))}
-          suffix="%"
-          subtitle={format_bytes(Map.get(@memory, :used_bytes, 0)) <> " / " <> format_bytes(Map.get(@memory, :total_bytes, 0))}
-          icon="hero-rectangle-stack"
-          color={memory_color(Map.get(@memory, :percent, 0.0))}
-        />
-
-        <.metric_card
-          :if={is_number(@icmp_rtt)}
-          title="Latency (ICMP)"
-          value={format_latency(@icmp_rtt)}
-          suffix="ms"
-          subtitle="Last check"
-          icon="hero-signal"
-          color={latency_color(@icmp_rtt)}
-        />
-
-        <.metric_card
-          :if={@disks != []}
-          title="Heaviest Disk"
-          value={format_pct(disk_max_percent(@disks))}
-          suffix="%"
-          subtitle={disk_max_mount(@disks)}
-          icon="hero-circle-stack"
-          color={disk_color(disk_max_percent(@disks))}
-        />
-      </div>
-
-      <div :if={@disks != []} class="px-4 pb-4">
-        <div class="text-xs font-semibold text-base-content/70 mb-2">Disk Utilization</div>
-        <div class="space-y-2">
-          <%= for disk <- Enum.take(Enum.sort_by(@disks, & &1.percent, :desc), 5) do %>
-            <.disk_bar disk={disk} />
-          <% end %>
-        </div>
-      </div>
-    </div>
-    """
-  end
-
-  attr :title, :string, required: true
-  attr :value, :string, required: true
-  attr :suffix, :string, default: ""
-  attr :subtitle, :string, default: ""
-  attr :icon, :string, required: true
-  attr :color, :string, default: "primary"
-
-  def metric_card(assigns) do
-    ~H"""
-    <div class="rounded-lg border border-base-200 bg-base-200/30 p-4">
-      <div class="flex items-center gap-2 mb-2">
-        <.icon name={@icon} class={["size-4", "text-#{@color}"]} />
-        <span class="text-xs text-base-content/70">{@title}</span>
-      </div>
-      <div class="flex items-baseline gap-1">
-        <span class={["text-2xl font-bold tabular-nums", "text-#{@color}"]}>{@value}</span>
-        <span class="text-sm text-base-content/60">{@suffix}</span>
-      </div>
-      <div :if={@subtitle != ""} class="text-xs text-base-content/50 mt-1">{@subtitle}</div>
-    </div>
-    """
-  end
-
-  attr :disk, :map, required: true
-
-  def disk_bar(assigns) do
-    pct = Map.get(assigns.disk, :percent, 0.0)
-    mount = Map.get(assigns.disk, :mount_point, "?")
-    used = format_bytes(Map.get(assigns.disk, :used_bytes, 0))
-    total = format_bytes(Map.get(assigns.disk, :total_bytes, 0))
-    color = disk_color(pct)
-
-    assigns =
-      assigns
-      |> assign(:pct, pct)
-      |> assign(:mount, mount)
-      |> assign(:used, used)
-      |> assign(:total, total)
-      |> assign(:color, color)
-
-    ~H"""
-    <div class="flex items-center gap-3">
-      <div class="w-24 truncate text-xs font-mono text-base-content/70" title={@mount}>{@mount}</div>
-      <div class="flex-1 h-2 bg-base-200 rounded-full overflow-hidden">
-        <div
-          class={["h-full rounded-full", "bg-#{@color}"]}
-          style={"width: #{min(@pct, 100)}%"}
-        />
-      </div>
-      <div class="w-24 text-right text-xs tabular-nums text-base-content/70">
-        {format_pct(@pct)}% <span class="text-base-content/50">({@used})</span>
-      </div>
-    </div>
-    """
-  end
-
-  defp cpu_color(pct) when pct >= 90, do: "error"
-  defp cpu_color(pct) when pct >= 70, do: "warning"
-  defp cpu_color(_), do: "success"
-
-  defp memory_color(pct) when pct >= 90, do: "error"
-  defp memory_color(pct) when pct >= 80, do: "warning"
-  defp memory_color(_), do: "info"
-
-  defp disk_color(pct) when pct >= 90, do: "error"
-  defp disk_color(pct) when pct >= 80, do: "warning"
-  defp disk_color(_), do: "primary"
-
-  defp latency_color(ms) when ms >= 200, do: "error"
-  defp latency_color(ms) when ms >= 100, do: "warning"
-  defp latency_color(_), do: "success"
-
-  defp disk_max_percent([]), do: 0.0
-
-  defp disk_max_percent(disks),
-    do: Enum.max_by(disks, & &1.percent, fn -> %{percent: 0.0} end).percent
-
-  defp disk_max_mount([]), do: "—"
-
-  defp disk_max_mount(disks),
-    do: Enum.max_by(disks, & &1.percent, fn -> %{mount_point: "—"} end).mount_point
-
-  defp format_bytes(bytes) when is_number(bytes) do
-    cond do
-      bytes >= 1_099_511_627_776 -> "#{Float.round(bytes / 1_099_511_627_776 * 1.0, 1)} TB"
-      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824 * 1.0, 1)} GB"
-      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576 * 1.0, 1)} MB"
-      bytes >= 1024 -> "#{Float.round(bytes / 1024 * 1.0, 1)} KB"
-      true -> "#{bytes} B"
-    end
-  end
-
-  defp format_bytes(_), do: "—"
-
-  defp format_latency(ms) when is_float(ms), do: :erlang.float_to_binary(ms, decimals: 1)
-  defp format_latency(ms) when is_integer(ms), do: Integer.to_string(ms)
-  defp format_latency(_), do: "—"
-
-  # ---------------------------------------------------------------------------
   # Data Loading Functions
   # ---------------------------------------------------------------------------
 
@@ -1722,31 +1531,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     }
   end
 
-  defp load_sysmon_summary(_srql_module, identity, _scope)
-       when identity == %{} or identity == nil,
-       do: nil
-
-  defp load_sysmon_summary(srql_module, identity, scope) do
-    # Load CPU, Memory, Disk metrics in parallel (conceptually - in sequence here)
-    cpu_data = load_cpu_summary(srql_module, identity, scope)
-    memory_data = load_memory_summary(srql_module, identity, scope)
-    disk_data = load_disk_summary(srql_module, identity, scope)
-    icmp_rtt = load_icmp_rtt(srql_module, identity, scope)
-
-    has_sysmon_metrics = is_map(cpu_data) or is_map(memory_data) or disk_data != []
-
-    if has_sysmon_metrics do
-      %{
-        cpu: cpu_data || %{},
-        memory: memory_data || %{},
-        disks: disk_data || [],
-        icmp_rtt: icmp_rtt
-      }
-    else
-      nil
-    end
-  end
-
   defp load_sysmon_presence(_srql_module, identity, _scope)
        when identity == %{} or identity == nil,
        do: false
@@ -1771,165 +1555,17 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     end
   end
 
-  defp load_cpu_summary(srql_module, identity, scope) do
-    query =
-      "in:cpu_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:64"
-
-    case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
-        rows
-        |> Enum.filter(&row_matches_identity?(&1, identity))
-        |> build_cpu_summary()
-
-      _ ->
-        nil
+  defp format_bytes(bytes) when is_number(bytes) do
+    cond do
+      bytes >= 1_099_511_627_776 -> "#{Float.round(bytes / 1_099_511_627_776 * 1.0, 1)} TB"
+      bytes >= 1_073_741_824 -> "#{Float.round(bytes / 1_073_741_824 * 1.0, 1)} GB"
+      bytes >= 1_048_576 -> "#{Float.round(bytes / 1_048_576 * 1.0, 1)} MB"
+      bytes >= 1024 -> "#{Float.round(bytes / 1024 * 1.0, 1)} KB"
+      true -> "#{bytes} B"
     end
   end
 
-  defp build_cpu_summary([]), do: nil
-
-  defp build_cpu_summary(rows) do
-    values =
-      Enum.map(rows, fn r -> extract_numeric(Map.get(r, "value")) end)
-      |> Enum.filter(&is_number/1)
-
-    cores =
-      rows
-      |> Enum.map(fn r -> Map.get(r, "core") || Map.get(r, "cpu_core") end)
-      |> Enum.filter(&is_binary/1)
-      |> Enum.uniq()
-      |> length()
-
-    avg = if values != [], do: Enum.sum(values) / length(values), else: 0.0
-
-    %{
-      avg_usage: Float.round(avg * 1.0, 1),
-      core_count: max(cores, 1),
-      timestamp: Map.get(List.first(rows), "timestamp")
-    }
-  end
-
-  defp load_memory_summary(srql_module, identity, scope) do
-    query =
-      "in:memory_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:4"
-
-    case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => rows}} when is_list(rows) ->
-        row = Enum.find(rows, &row_matches_identity?(&1, identity))
-
-        if is_map(row) do
-          used = extract_numeric(Map.get(row, "used_bytes") || Map.get(row, "value"))
-          total = extract_numeric(Map.get(row, "total_bytes"))
-          pct = percent_from_row(row, used, total)
-
-          %{
-            used_bytes: used || 0,
-            total_bytes: total || 0,
-            percent: Float.round(pct * 1.0, 1),
-            timestamp: Map.get(row, "timestamp")
-          }
-        else
-          nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp load_disk_summary(srql_module, identity, scope) do
-    query =
-      "in:disk_metrics #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:24"
-
-    case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => rows}} when is_list(rows) and rows != [] ->
-        # Group by mount point and take the latest for each
-        rows
-        |> Enum.filter(fn row -> is_map(row) and row_matches_identity?(row, identity) end)
-        |> Enum.group_by(&disk_mount/1)
-        |> Enum.map(fn {mount, disk_rows} ->
-          build_disk_entry(mount, List.first(disk_rows))
-        end)
-        |> Enum.sort_by(& &1.percent, :desc)
-
-      _ ->
-        []
-    end
-  end
-
-  defp load_icmp_rtt(srql_module, identity, scope) do
-    query =
-      "in:timeseries_metrics metric_type:icmp #{Enum.join(sysmon_filter_tokens(identity), " ")} sort:timestamp:desc limit:1"
-
-    case srql_module.query(query, %{scope: scope}) do
-      {:ok, %{"results" => rows}} when is_list(rows) ->
-        row = Enum.find(rows, &row_matches_identity?(&1, identity))
-
-        if is_map(row) do
-          row
-          |> Map.get("value")
-          |> extract_numeric()
-          |> normalize_icmp_rtt()
-        else
-          nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp percent_from_row(row, used, total) do
-    case Map.get(row, "percent") do
-      value when is_number(value) ->
-        value
-
-      _ ->
-        if is_number(used) and is_number(total) and total > 0 do
-          used / total * 100.0
-        else
-          0.0
-        end
-    end
-  end
-
-  defp disk_mount(row) do
-    Map.get(row, "mount_point") || Map.get(row, "mount") || "unknown"
-  end
-
-  defp build_disk_entry(mount, latest) do
-    used = extract_numeric(Map.get(latest, "used_bytes") || Map.get(latest, "value"))
-    total = extract_numeric(Map.get(latest, "total_bytes"))
-    pct = percent_from_row(latest, used, total)
-
-    %{
-      mount_point: mount,
-      used_bytes: used || 0,
-      total_bytes: total || 0,
-      percent: Float.round(pct * 1.0, 1)
-    }
-  end
-
-  defp normalize_icmp_rtt(value) when is_number(value) do
-    if value > 1_000_000.0 do
-      Float.round(value / 1_000_000.0, 2)
-    else
-      Float.round(value * 1.0, 2)
-    end
-  end
-
-  defp normalize_icmp_rtt(_), do: nil
-
-  defp extract_numeric(value) when is_number(value), do: value
-
-  defp extract_numeric(value) when is_binary(value) do
-    case Float.parse(String.trim(value)) do
-      {num, ""} -> num
-      _ -> nil
-    end
-  end
-
-  defp extract_numeric(_), do: nil
+  defp format_bytes(_), do: "—"
 
   # ---------------------------------------------------------------------------
   # Healthcheck Section (GRPC/Service Health)

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
@@ -1253,7 +1253,7 @@ defmodule ServiceRadarWebNGWeb.Settings.NetworksLive.Index do
           <div class="text-xs text-base-content/60">
             <span class="text-success">{@hosts_available}</span>
             <span :if={@hosts_failed > 0} class="text-error ml-1">/ {@hosts_failed} failed</span>
-            <span> of             {@hosts_processed} hosts</span>
+            <span> of              {@hosts_processed} hosts</span>
           </div>
           <div :if={@batch_info} class="text-xs text-base-content/40 mt-0.5">
             {@batch_info}

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
@@ -1253,7 +1253,7 @@ defmodule ServiceRadarWebNGWeb.Settings.NetworksLive.Index do
           <div class="text-xs text-base-content/60">
             <span class="text-success">{@hosts_available}</span>
             <span :if={@hosts_failed > 0} class="text-error ml-1">/ {@hosts_failed} failed</span>
-            <span> of              {@hosts_processed} hosts</span>
+            <span> of               {@hosts_processed} hosts</span>
           </div>
           <div :if={@batch_info} class="text-xs text-base-content/40 mt-0.5">
             {@batch_info}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Gate sysmon metrics panels to only show for devices with sysmon data

- Render sysmon CPU/memory/disk metrics as graphs instead of tables

- Remove low-value auto-generated category visualizations

- Improve device identity detection using agent_id and device_uid

- Add timeseries inference support for metric visualization fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Details Page"] --> B["Load Sysmon Identity"]
  B --> C["Check Sysmon Presence"]
  C --> D{Has Sysmon Data?}
  D -->|Yes| E["Show Sysmon Panels"]
  D -->|No| F["Hide Sysmon Panels"]
  E --> G["Render as Graphs"]
  A --> H["Build Panels"]
  H --> I["Filter Low-Value Categories"]
  H --> J["Infer Timeseries Viz"]
  J --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timeseries.ex</strong><dd><code>Add timeseries inference support for results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/dashboard/plugins/timeseries.ex

<ul><li>Add <code>Viz.infer/1</code> alias import for visualization inference<br> <li> Add <code>supports?/1</code> clause to detect timeseries from raw results<br> <li> Add <code>build/1</code> clause to handle results without explicit viz suggestions<br> <li> Add <code>infer_timeseries_spec/1</code> helper to infer timeseries structure</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-2dd46da2ac00979257fc2b79ad1c72441c867402317f0f903c6d76ae3c8faecd">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Refactor sysmon metrics gating and visualization rendering</code></dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex

<ul><li>Add sysmon identity detection from device row (device_uid and <br>agent_id)<br> <li> Add sysmon presence flag to track if device has sysmon metrics<br> <li> Gate sysmon metric panels visibility based on presence or summary data<br> <li> Filter out low-value category visualizations (type_id by modified)<br> <li> Refactor metric loading to use identity map instead of escaped <br>device_uid<br> <li> Add timeseries inference fallback for metric visualization<br> <li> Update sysmon summary/CPU/memory/disk loaders to filter by identity</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-92d8e0af57d2f65dfb8562e896dbea17ef9f47074ffd14f58261decc76f80c24">+277/-66</a></td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Minor whitespace formatting fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex

- Fix whitespace formatting in hosts summary display text


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-b2127e71582033bc6dfd2d7397f56bf43c1f7c613defffc504b3d8ee1e7406c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Add change proposal documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-device-details-ui/proposal.md

<ul><li>Document the problem: sysmon metrics showing for non-sysmon devices <br>and poor table rendering<br> <li> List three main changes: gating sysmon panels, rendering as graphs, <br>removing low-value visualizations<br> <li> Specify affected specs and code areas</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-e1fd5ff0cd72e0fee1795227b1f30abe3a8704554de4b6a7e16c16aa650fdf41">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add formal specification requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-device-details-ui/specs/build-web-ui/spec.md

<ul><li>Define requirement for sysmon metrics visibility gating<br> <li> Define requirement for graph rendering of sysmon metrics<br> <li> Define requirement to suppress type_id by modified visualization<br> <li> Include scenarios for each requirement with given/when/then format</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-e45a3611edb0f820076d71239c87339969bb50c06692a26ae373ac6b0b53b769">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Add implementation and validation tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-device-details-ui/tasks.md

<ul><li>List implementation tasks with completion status<br> <li> List validation tasks for testing the changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2324/files#diff-1cb6c954f90f6afcedfe3a8c605de0ebc4c5fd94f22e819de9ca37cf17504bd7">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

