### PR TITLE
rulebuilder testing/integration work

### DIFF
--- a/openspec/changes/add-log-to-event-ui/tasks.md
+++ b/openspec/changes/add-log-to-event-ui/tasks.md
@@ -27,7 +27,7 @@
 - [x] 3.4 Implement `handle_event("open_rule_builder", ...)` to extract log data and open modal
 - [x] 3.5 Pass parsed log attributes to rule builder for pre-population
 - [x] 3.6 Handle `{:rule_created, rule}` message to close modal and show success flash
-- [ ] 3.7 Handle `{:rule_creation_failed, reason}` for error display
+- [x] 3.7 Handle `{:rule_creation_failed, reason}` for error display
 
 ## 4. Rule Testing/Preview
 
@@ -73,4 +73,4 @@ Test files created:
 
 - [x] 8.1 Add inline help text explaining match conditions
 - [x] 8.2 Add help text explaining rule preview ("Tests against logs from the last hour")
-- [ ] 8.3 Link to Rules settings page for advanced configuration
+- [x] 8.3 Link to Rules settings page for advanced configuration

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -607,40 +607,48 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
   end
 
   defp build_match_map(params) do
-    match = %{}
-
-    match =
-      if params["body_contains_enabled"] and String.trim(params["body_contains"] || "") != "" do
-        Map.put(match, "body_contains", params["body_contains"])
-      else
-        match
-      end
-
-    match =
-      if params["severity_enabled"] and String.trim(params["severity_text"] || "") != "" do
-        Map.put(match, "severity_text", params["severity_text"])
-      else
-        match
-      end
-
-    match =
-      if params["service_name_enabled"] and String.trim(params["service_name"] || "") != "" do
-        Map.put(match, "service_name", params["service_name"])
-      else
-        match
-      end
-
-    match =
-      if params["attribute_enabled"] and
-           String.trim(params["attribute_key"] || "") != "" and
-           String.trim(params["attribute_value"] || "") != "" do
-        Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
-      else
-        match
-      end
-
-    match
+    %{}
+    |> maybe_add_body_contains(params)
+    |> maybe_add_severity(params)
+    |> maybe_add_service_name(params)
+    |> maybe_add_attribute_equals(params)
   end
+
+  defp maybe_add_body_contains(match, params) do
+    if params["body_contains_enabled"] and has_value?(params["body_contains"]) do
+      Map.put(match, "body_contains", params["body_contains"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_severity(match, params) do
+    if params["severity_enabled"] and has_value?(params["severity_text"]) do
+      Map.put(match, "severity_text", params["severity_text"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_service_name(match, params) do
+    if params["service_name_enabled"] and has_value?(params["service_name"]) do
+      Map.put(match, "service_name", params["service_name"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_attribute_equals(match, params) do
+    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and has_value?(params["attribute_value"]) do
+      Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
+    else
+      match
+    end
+  end
+
+  defp has_value?(nil), do: false
+  defp has_value?(value) when is_binary(value), do: String.trim(value) != ""
+  defp has_value?(_), do: false
 
   defp build_event_map(params) do
     if params["auto_alert"] do
@@ -785,28 +793,38 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
 
     cond do
       String.starts_with?(value, "{") ->
-        case Jason.decode(value) do
-          {:ok, decoded} when is_map(decoded) -> decoded
-          _ -> %{}
-        end
+        parse_json_attributes(value)
 
       String.contains?(value, "=") ->
-        ~r/(\w+)=(\{[^}]*\}|[^,]+?)(?=,\w+=|$)/
-        |> Regex.scan(value)
-        |> Enum.reduce(%{}, fn
-          [_full, key, json_value], acc when binary_part(json_value, 0, 1) == "{" ->
-            case Jason.decode(json_value) do
-              {:ok, decoded} -> Map.put(acc, key, decoded)
-              _ -> Map.put(acc, key, json_value)
-            end
-
-          [_full, key, plain_value], acc ->
-            Map.put(acc, key, String.trim(plain_value))
-        end)
+        parse_key_value_attributes(value)
 
       true ->
         %{}
     end
+  end
+
+  defp parse_json_attributes(value) do
+    case Jason.decode(value) do
+      {:ok, decoded} when is_map(decoded) -> decoded
+      _ -> %{}
+    end
+  end
+
+  defp parse_key_value_attributes(value) do
+    ~r/(\w+)=(\{[^}]*\}|[^,]+?)(?=,\w+=|$)/
+    |> Regex.scan(value)
+    |> Enum.reduce(%{}, &parse_key_value_pair/2)
+  end
+
+  defp parse_key_value_pair([_full, key, json_value], acc) when binary_part(json_value, 0, 1) == "{" do
+    case Jason.decode(json_value) do
+      {:ok, decoded} -> Map.put(acc, key, decoded)
+      _ -> Map.put(acc, key, json_value)
+    end
+  end
+
+  defp parse_key_value_pair([_full, key, plain_value], acc) do
+    Map.put(acc, key, String.trim(plain_value))
   end
 
   defp flatten_for_suggestions(attributes) when is_map(attributes) do
@@ -857,8 +875,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
   defp format_error(reason), do: inspect(reason)
 
   defp format_ash_error(%Ash.Error.Invalid{errors: errors}) do
-    errors
-    |> Enum.map(fn
+    Enum.map_join(errors, ", ", fn
       %{field: field, message: message} when is_atom(field) ->
         "#{field}: #{message}"
 
@@ -868,7 +885,6 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
       other ->
         inspect(other)
     end)
-    |> Enum.join(", ")
   end
 
   defp srql_module do

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -163,6 +163,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
         </h3>
         <p class="py-2 text-sm text-base-content/70">
           Configure match conditions to promote logs into events.
+          For advanced configuration, visit <.link navigate="/settings/rules?tab=events" class="link link-primary">Settings → Rules</.link>.
         </p>
 
         <.form

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
@@ -74,6 +74,12 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
      |> put_flash(:info, "Rule \"#{rule.name}\" created successfully. View it in Settings > Rules.")}
   end
 
+  def handle_info({:rule_creation_failed, reason}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Failed to create rule: #{format_error(reason)}")}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
@@ -375,40 +375,48 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
   end
 
   defp build_match_map(params) do
-    match = %{}
-
-    match =
-      if params["body_contains_enabled"] and String.trim(params["body_contains"] || "") != "" do
-        Map.put(match, "body_contains", params["body_contains"])
-      else
-        match
-      end
-
-    match =
-      if params["severity_enabled"] and String.trim(params["severity_text"] || "") != "" do
-        Map.put(match, "severity_text", params["severity_text"])
-      else
-        match
-      end
-
-    match =
-      if params["service_name_enabled"] and String.trim(params["service_name"] || "") != "" do
-        Map.put(match, "service_name", params["service_name"])
-      else
-        match
-      end
-
-    match =
-      if params["attribute_enabled"] and
-           String.trim(params["attribute_key"] || "") != "" and
-           String.trim(params["attribute_value"] || "") != "" do
-        Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
-      else
-        match
-      end
-
-    match
+    %{}
+    |> maybe_add_body_contains(params)
+    |> maybe_add_severity(params)
+    |> maybe_add_service_name(params)
+    |> maybe_add_attribute_equals(params)
   end
+
+  defp maybe_add_body_contains(match, params) do
+    if params["body_contains_enabled"] and has_value?(params["body_contains"]) do
+      Map.put(match, "body_contains", params["body_contains"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_severity(match, params) do
+    if params["severity_enabled"] and has_value?(params["severity_text"]) do
+      Map.put(match, "severity_text", params["severity_text"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_service_name(match, params) do
+    if params["service_name_enabled"] and has_value?(params["service_name"]) do
+      Map.put(match, "service_name", params["service_name"])
+    else
+      match
+    end
+  end
+
+  defp maybe_add_attribute_equals(match, params) do
+    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and has_value?(params["attribute_value"]) do
+      Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
+    else
+      match
+    end
+  end
+
+  defp has_value?(nil), do: false
+  defp has_value?(value) when is_binary(value), do: String.trim(value) != ""
+  defp has_value?(_), do: false
 
   defp build_event_map(params) do
     if params["auto_alert"] do


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add error handling for rule creation failures with user feedback

- Link to Settings Rules page for advanced configuration options

- Mark completed tasks in project tracking documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rule Creation"] --> B{"Success or Failure?"}
  B -->|Success| C["Show Success Flash"]
  B -->|Failure| D["Handle Error Message"]
  D --> E["Display Error Flash"]
  C --> F["Close Modal"]
  E --> F
  G["Rule Builder UI"] --> H["Add Settings Link"]
  H --> I["Navigate to Rules Settings"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder.ex</strong><dd><code>Add settings link for advanced rule configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex

<ul><li>Add inline link to Settings Rules page for advanced configuration<br> <li> Link navigates to <code>/settings/rules?tab=events</code> with primary styling<br> <li> Improves user discoverability of advanced rule configuration options</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2342/files#diff-0226580d3777904915943339ececa4e0e314a03a7c43a0e9afec64fe2a8f9354">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Add error handling for failed rule creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex

<ul><li>Implement <code>handle_info/2</code> handler for <code>{:rule_creation_failed, reason}</code> <br>message<br> <li> Display formatted error message to user via error flash notification<br> <li> Gracefully handle rule creation failures with user-friendly feedback</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2342/files#diff-4f9769353c55928a0d382cd7510379444445aea116e1ecdf7b8eb892d249ff26">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Mark completed rule builder implementation tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-log-to-event-ui/tasks.md

<ul><li>Mark task 3.7 as completed for rule creation error handling<br> <li> Mark task 8.3 as completed for settings page link implementation<br> <li> Update project tracking to reflect finished implementation work</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2342/files#diff-ee81afe728f07f39c4cd4f0da61e541d8a818cb2f8f24c83b81c952dc1c85098">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

