### PR TITLE
fixing rule builder

### DIFF
--- a/openspec/changes/fix-log-event-rule-builder/proposal.md
+++ b/openspec/changes/fix-log-event-rule-builder/proposal.md
@@ -1,0 +1,13 @@
+# Change: Fix log-to-event rule builder flow
+
+## Why
+Creating an event (response) rule from a log entry currently crashes the rule builder LiveView because the prefilled params are not compatible with Phoenix form expectations. This blocks a key workflow for turning log signals into alerting rules.
+
+## What Changes
+- Normalize log-derived prefill data so the rule builder form renders without runtime errors.
+- Ensure the rule builder can be opened from a log entry and saved with prefilled values.
+- Add regression coverage for the log-to-event rule creation flow.
+
+## Impact
+- Affected specs: observability-rule-management
+- Affected code: web-ng LiveView rule builder components and log detail UI

--- a/openspec/changes/fix-log-event-rule-builder/specs/observability-rule-management/spec.md
+++ b/openspec/changes/fix-log-event-rule-builder/specs/observability-rule-management/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+### Requirement: Unified Rule Builder UI
+The system SHALL provide a unified UI for managing log normalization rules (Zen) and response rules (stateful alert engine) without requiring users to edit raw JSON. The system SHALL allow operators to create a response rule from a log entry with prefilled fields.
+
+#### Scenario: Create a log normalization rule
+- **WHEN** an operator creates a log normalization rule in the UI
+- **THEN** the rule SHALL be saved for the tenant
+- **AND** the UI SHALL show the enabled rule in the list
+
+#### Scenario: Create a response rule
+- **WHEN** an operator creates a response rule in the UI
+- **THEN** the rule SHALL be saved for the tenant
+- **AND** the UI SHALL show the enabled rule in the list
+
+#### Scenario: Create a response rule from a log entry
+- **WHEN** an operator opens the rule builder from a log entry
+- **THEN** the rule builder SHALL render with log-derived fields prefilled
+- **AND** saving the rule SHALL succeed without runtime errors

--- a/openspec/changes/fix-log-event-rule-builder/tasks.md
+++ b/openspec/changes/fix-log-event-rule-builder/tasks.md
@@ -1,0 +1,5 @@
+## 1. Implementation
+- [x] 1.1 Trace the log-to-event rule creation flow to identify where atom-keyed maps and nil flags are introduced.
+- [x] 1.2 Normalize prefilled rule params to string-keyed form parameters and set safe defaults for optional fields.
+- [x] 1.3 Add tests for opening the rule builder from a log entry and saving a prefilled rule.
+- [ ] 1.4 Smoke-test the rule builder UI from a log entry in staging or local dev.

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -541,18 +541,18 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
 
   defp build_form(params) do
     data = %{
-      name: params["name"] || "",
-      body_contains: params["body_contains"] || "",
-      body_contains_enabled: to_boolean(params["body_contains_enabled"], false),
-      severity_text: params["severity_text"] || "",
-      severity_enabled: to_boolean(params["severity_enabled"], false),
-      service_name: params["service_name"] || "",
-      service_name_enabled: to_boolean(params["service_name_enabled"], false),
-      attribute_key: params["attribute_key"] || "",
-      attribute_value: params["attribute_value"] || "",
-      attribute_enabled: to_boolean(params["attribute_enabled"], false),
-      auto_alert: to_boolean(params["auto_alert"], false),
-      parsed_attributes: params["parsed_attributes"] || %{}
+      "name" => params["name"] || "",
+      "body_contains" => params["body_contains"] || "",
+      "body_contains_enabled" => to_boolean(params["body_contains_enabled"], false),
+      "severity_text" => params["severity_text"] || "",
+      "severity_enabled" => to_boolean(params["severity_enabled"], false),
+      "service_name" => params["service_name"] || "",
+      "service_name_enabled" => to_boolean(params["service_name_enabled"], false),
+      "attribute_key" => params["attribute_key"] || "",
+      "attribute_value" => params["attribute_value"] || "",
+      "attribute_enabled" => to_boolean(params["attribute_enabled"], false),
+      "auto_alert" => to_boolean(params["auto_alert"], false),
+      "parsed_attributes" => params["parsed_attributes"] || %{}
     }
 
     to_form(data, as: :rule)

--- a/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
@@ -124,6 +124,49 @@ defmodule ServiceRadarWebNGWeb.LogLive.ShowTest do
       Application.delete_env(:serviceradar_web_ng, :srql_module)
     end
 
+    test "creates promotion rule from log entry", %{conn: conn} do
+      user = operator_user_fixture()
+      conn = log_in_user(conn, user)
+      scope = ServiceRadarWebNG.Accounts.Scope.for_user(user)
+
+      Application.put_env(:serviceradar_web_ng, :srql_module, MockSRQLWithLog)
+
+      log_id = "550e8400-e29b-41d4-a716-446655440000"
+      {:ok, lv, _html} = live(conn, ~p"/observability/logs/#{log_id}")
+
+      lv
+      |> element("button", "Create Event Rule")
+      |> render_click()
+
+      unique = System.unique_integer([:positive])
+      rule_name = "log-promote-#{unique}"
+
+      lv
+      |> form("#rule-builder-form", %{
+        "rule" => %{
+          "name" => rule_name,
+          "body_contains_enabled" => "true",
+          "body_contains" => "Test error message",
+          "severity_enabled" => "true",
+          "severity_text" => "error",
+          "service_name_enabled" => "true",
+          "service_name" => "test-service"
+        }
+      })
+      |> render_submit()
+
+      refute has_element?(lv, "#rule_builder_modal")
+
+      rules = unwrap_page(Ash.read(ServiceRadar.Observability.LogPromotionRule, scope: scope))
+      rule = Enum.find(rules, &(&1.name == rule_name))
+      assert rule
+      assert rule.match["body_contains"] == "Test error message"
+      assert rule.match["severity_text"] == "error"
+      assert rule.match["service_name"] == "test-service"
+    after
+      Application.delete_env(:serviceradar_web_ng, :srql_module)
+    end
+
     test "closes modal when clicking cancel", %{conn: conn} do
       user = operator_user_fixture()
       conn = log_in_user(conn, user)
@@ -181,6 +224,10 @@ defmodule ServiceRadarWebNGWeb.LogLive.ShowTest do
   # Test helper that mirrors the component's RBAC check
   defp can_create_rules?(%{user: %{role: role}}) when role in [:operator, :admin], do: true
   defp can_create_rules?(_), do: false
+
+  defp unwrap_page({:ok, %Ash.Page.Keyset{results: results}}), do: results
+  defp unwrap_page({:ok, results}) when is_list(results), do: results
+  defp unwrap_page(_), do: []
 end
 
 # Mock SRQL module that returns no results


### PR DESCRIPTION
### **Label**
bug fix


___

### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix rule builder form data structure from atom keys to string keys
  - Prevents runtime errors when prefilling form from log entries

- Add comprehensive test for log-to-event rule creation workflow
  - Validates rule builder opens and saves with prefilled log data

- Document the fix and affected requirements in openspec
  - Clarifies the unified rule builder UI specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LogEntry["Log Entry"] -- "Create Event Rule" --> RuleBuilder["Rule Builder Component"]
  RuleBuilder -- "Prefill with string keys" --> FormData["Form Data Map"]
  FormData -- "Submit" --> SaveRule["Save Promotion Rule"]
  SaveRule -- "Success" --> RuleCreated["Rule Created"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder.ex</strong><dd><code>Normalize form data keys to strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex

<ul><li>Changed map keys in <code>build_form/1</code> from atom syntax to string keys<br> <li> Converts all 12 form field keys from <code>:name</code> to <code>"name"</code> format<br> <li> Ensures compatibility with Phoenix form expectations for prefilled <br>data</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2344/files#diff-0226580d3777904915943339ececa4e0e314a03a7c43a0e9afec64fe2a8f9354">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show_test.exs</strong><dd><code>Add test for log-to-event rule creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs

<ul><li>Added new test "creates promotion rule from log entry" with full <br>workflow<br> <li> Tests opening rule builder from log, prefilling fields, and saving <br>rule<br> <li> Validates saved rule contains correct match conditions from log data<br> <li> Added <code>unwrap_page/1</code> helper function to extract results from Ash <br>queries</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2344/files#diff-2d62472b3e212a4da643a2f66d2a07d358795602e680f31249a162b71fa0ea3b">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Document rule builder fix proposal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-event-rule-builder/proposal.md

<ul><li>Documents the bug where rule builder crashes with incompatible prefill <br>params<br> <li> Explains the fix normalizes log-derived data for form compatibility<br> <li> Lists impact on observability-rule-management specification</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2344/files#diff-74a820be5d9b425a3bfcde5e89d11ec8e8f6c14bb5e2bebf834f37bfd124f444">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Define unified rule builder requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-event-rule-builder/specs/observability-rule-management/spec.md

<ul><li>Adds modified requirement for "Unified Rule Builder UI"<br> <li> Defines three scenarios: create log normalization rule, response rule, <br>and from log entry<br> <li> Specifies that rule builder must render with prefilled fields from log <br>entry</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2344/files#diff-be649af9f6e0709f9e7be63469761c5bc62ce4f83ab3ffe6a023118b0efefb6f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Track implementation tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-event-rule-builder/tasks.md

<ul><li>Lists implementation tasks for the rule builder fix<br> <li> Marks tasks 1.1-1.3 as complete (tracing, normalization, testing)<br> <li> Task 1.4 (smoke testing) remains pending</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2344/files#diff-01a81039e821ab987ad72641650e4200a79488680a4f275069b8c7afada26122">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

