### PR TITLE
mising files

### DIFF
--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -163,7 +163,10 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
         </h3>
         <p class="py-2 text-sm text-base-content/70">
           Configure match conditions to promote logs into events.
-          For advanced configuration, visit <.link navigate="/settings/rules?tab=events" class="link link-primary">Settings → Rules</.link>.
+          For advanced configuration, visit <.link
+            navigate="/settings/rules?tab=events"
+            class="link link-primary"
+          >Settings → Rules</.link>.
         </p>
 
         <.form
@@ -191,8 +194,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
           </div>
 
           <div class="divider text-xs text-base-content/50">Match Conditions</div>
-
-          <!-- Message Body Contains -->
+          
+    <!-- Message Body Contains -->
           <div class="form-control">
             <label class="label cursor-pointer justify-start gap-3">
               <input
@@ -216,11 +219,13 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               disabled={not @form[:body_contains_enabled].value}
             />
             <label class="label">
-              <span class="label-text-alt text-base-content/50">Case-insensitive substring match</span>
+              <span class="label-text-alt text-base-content/50">
+                Case-insensitive substring match
+              </span>
             </label>
           </div>
-
-          <!-- Severity -->
+          
+    <!-- Severity -->
           <div class="form-control">
             <label class="label cursor-pointer justify-start gap-3">
               <input
@@ -248,8 +253,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               <% end %>
             </select>
           </div>
-
-          <!-- Service Name -->
+          
+    <!-- Service Name -->
           <div class="form-control">
             <label class="label cursor-pointer justify-start gap-3">
               <input
@@ -273,8 +278,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               disabled={not @form[:service_name_enabled].value}
             />
           </div>
-
-          <!-- Attribute Match -->
+          
+    <!-- Attribute Match -->
           <div class="form-control">
             <label class="label cursor-pointer justify-start gap-3">
               <input
@@ -308,7 +313,10 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               />
             </div>
             <!-- Show parsed attributes as suggestions -->
-            <div :if={@form[:parsed_attributes].value && map_size(@form[:parsed_attributes].value) > 0} class="mt-2">
+            <div
+              :if={@form[:parsed_attributes].value && map_size(@form[:parsed_attributes].value) > 0}
+              class="mt-2"
+            >
               <span class="text-xs text-base-content/50">Available attributes:</span>
               <div class="flex flex-wrap gap-1 mt-1">
                 <%= for {key, value} <- flatten_for_suggestions(@form[:parsed_attributes].value) do %>
@@ -328,8 +336,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
           </div>
 
           <div class="divider text-xs text-base-content/50">Event Options</div>
-
-          <!-- Auto-create Alert -->
+          
+    <!-- Auto-create Alert -->
           <div class="form-control">
             <label class="label cursor-pointer justify-start gap-3">
               <input
@@ -347,8 +355,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               </div>
             </label>
           </div>
-
-          <!-- Rule Preview Section -->
+          
+    <!-- Rule Preview Section -->
           <div class="bg-base-200/50 rounded-lg p-4 mt-4">
             <div class="flex items-center justify-between mb-2">
               <span class="text-sm font-medium">Rule Preview</span>
@@ -360,7 +368,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
                 disabled={@preview_state == :loading}
               >
                 <.icon :if={@preview_state != :loading} name="hero-play" class="w-4 h-4" />
-                <span :if={@preview_state == :loading} class="loading loading-spinner loading-xs"></span>
+                <span :if={@preview_state == :loading} class="loading loading-spinner loading-xs">
+                </span>
                 Test Rule
               </button>
             </div>
@@ -386,7 +395,9 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
                 <div class="mt-1 space-y-1 max-h-32 overflow-y-auto">
                   <%= for log <- @preview_result.sample_logs do %>
                     <div class="text-xs font-mono bg-base-300/50 px-2 py-1 rounded flex gap-2">
-                      <span class="text-base-content/50">{format_preview_time(log["timestamp"])}</span>
+                      <span class="text-base-content/50">
+                        {format_preview_time(log["timestamp"])}
+                      </span>
                       <span class={severity_class(log["severity_text"])}>{log["severity_text"]}</span>
                       <span class="truncate">{truncate(log["body"] || log["message"], 60)}</span>
                     </div>
@@ -403,14 +414,14 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
               {@preview_error}
             </div>
           </div>
-
-          <!-- Validation Error -->
+          
+    <!-- Validation Error -->
           <div :if={@error} class="alert alert-error">
             <.icon name="hero-exclamation-circle" class="w-5 h-5" />
             <span>{@error}</span>
           </div>
-
-          <!-- Actions -->
+          
+    <!-- Actions -->
           <div class="modal-action">
             <button type="button" class="btn btn-ghost" phx-click="close" phx-target={@myself}>
               Cancel
@@ -530,7 +541,10 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
       nil ->
         socket
         |> assign(:preview_state, :error)
-        |> assign(:preview_error, "Query timed out after 5 seconds. Try narrowing your conditions.")
+        |> assign(
+          :preview_error,
+          "Query timed out after 5 seconds. Try narrowing your conditions."
+        )
 
       {:exit, reason} ->
         socket
@@ -639,7 +653,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
   end
 
   defp maybe_add_attribute_equals(match, params) do
-    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and has_value?(params["attribute_value"]) do
+    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and
+         has_value?(params["attribute_value"]) do
       Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
     else
       match
@@ -726,7 +741,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
     filters = []
 
     filters =
-      if form[:body_contains_enabled].value and String.trim(form[:body_contains].value || "") != "" do
+      if form[:body_contains_enabled].value and
+           String.trim(form[:body_contains].value || "") != "" do
         escaped = escape_srql_value(form[:body_contains].value)
         ["body:\"*#{escaped}*\"" | filters]
       else
@@ -816,7 +832,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
     |> Enum.reduce(%{}, &parse_key_value_pair/2)
   end
 
-  defp parse_key_value_pair([_full, key, json_value], acc) when binary_part(json_value, 0, 1) == "{" do
+  defp parse_key_value_pair([_full, key, json_value], acc)
+       when binary_part(json_value, 0, 1) == "{" do
     case Jason.decode(json_value) do
       {:ok, decoded} -> Map.put(acc, key, decoded)
       _ -> Map.put(acc, key, json_value)

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
@@ -71,7 +71,10 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
     {:noreply,
      socket
      |> assign(:show_rule_builder, false)
-     |> put_flash(:info, "Rule \"#{rule.name}\" created successfully. View it in Settings > Rules.")}
+     |> put_flash(
+       :info,
+       "Rule \"#{rule.name}\" created successfully. View it in Settings > Rules."
+     )}
   end
 
   def handle_info({:rule_creation_failed, reason}, socket) do
@@ -97,8 +100,7 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
               variant="primary"
               size="sm"
             >
-              <.icon name="hero-bolt" class="w-4 h-4" />
-              Create Event Rule
+              <.icon name="hero-bolt" class="w-4 h-4" /> Create Event Rule
             </.ui_button>
             <.ui_button href={~p"/observability?#{%{tab: "logs"}}"} variant="ghost" size="sm">
               Back to logs
@@ -116,8 +118,8 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
           <.log_details log={@log} />
         </div>
       </div>
-
-      <!-- Rule Builder Modal -->
+      
+    <!-- Rule Builder Modal -->
       <.live_component
         :if={@show_rule_builder}
         module={PromotionRuleBuilder}

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
@@ -1285,7 +1285,7 @@ defmodule ServiceRadarWebNGWeb.Settings.NetworksLive.Index do
           <div class="text-xs text-base-content/60">
             <span class="text-success">{@hosts_available}</span>
             <span :if={@hosts_failed > 0} class="text-error ml-1">/ {@hosts_failed} failed</span>
-            <span> of  {@hosts_processed} hosts</span>
+            <span> of   {@hosts_processed} hosts</span>
           </div>
           <div :if={@batch_info} class="text-xs text-base-content/40 mt-0.5">
             {@batch_info}

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/rules_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/rules_live/index.ex
@@ -461,7 +461,11 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLive.Index do
                       <div class="flex flex-col items-center gap-2">
                         <.icon name="hero-inbox" class="w-8 h-8 opacity-40" />
                         <p>No event promotion rules configured.</p>
-                        <button type="button" class="btn btn-primary btn-sm" phx-click="new_promotion_rule">
+                        <button
+                          type="button"
+                          class="btn btn-primary btn-sm"
+                          phx-click="new_promotion_rule"
+                        >
                           Create your first rule
                         </button>
                       </div>
@@ -538,8 +542,8 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLive.Index do
           </.ui_panel>
         </div>
       </.settings_shell>
-
-      <!-- Rule Builder Modal -->
+      
+    <!-- Rule Builder Modal -->
       <.live_component
         :if={@show_rule_builder}
         module={PromotionRuleBuilder}
@@ -609,7 +613,10 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLive.Index do
 
     conditions =
       if match["body_contains"] do
-        [{"hero-chat-bubble-bottom-center", "body: #{truncate(match["body_contains"], 15)}"} | conditions]
+        [
+          {"hero-chat-bubble-bottom-center", "body: #{truncate(match["body_contains"], 15)}"}
+          | conditions
+        ]
       else
         conditions
       end

--- a/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
@@ -407,7 +407,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
   end
 
   defp maybe_add_attribute_equals(match, params) do
-    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and has_value?(params["attribute_value"]) do
+    if params["attribute_enabled"] and has_value?(params["attribute_key"]) and
+         has_value?(params["attribute_value"]) do
       Map.put(match, "attribute_equals", %{params["attribute_key"] => params["attribute_value"]})
     else
       match
@@ -457,7 +458,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
     filters = []
 
     filters =
-      if form[:body_contains_enabled].value and String.trim(form[:body_contains].value || "") != "" do
+      if form[:body_contains_enabled].value and
+           String.trim(form[:body_contains].value || "") != "" do
         escaped = escape_srql_value(form[:body_contains].value)
         ["body:\"*#{escaped}*\"" | filters]
       else

--- a/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
@@ -241,19 +241,20 @@ end
 defmodule MockSRQLWithLog do
   def query(query) do
     if String.contains?(query, "in:logs") do
-      {:ok, %{
-        "results" => [
-          %{
-            "id" => "550e8400-e29b-41d4-a716-446655440000",
-            "body" => "Test error message",
-            "severity_text" => "ERROR",
-            "service_name" => "test-service",
-            "timestamp" => "2024-01-15T10:30:00Z",
-            "attributes" => %{"error" => "connection failed"}
-          }
-        ],
-        "total_count" => 1
-      }}
+      {:ok,
+       %{
+         "results" => [
+           %{
+             "id" => "550e8400-e29b-41d4-a716-446655440000",
+             "body" => "Test error message",
+             "severity_text" => "ERROR",
+             "service_name" => "test-service",
+             "timestamp" => "2024-01-15T10:30:00Z",
+             "attributes" => %{"error" => "connection failed"}
+           }
+         ],
+         "total_count" => 1
+       }}
     else
       {:ok, %{"results" => [], "total_count" => 0}}
     end

--- a/web-ng/test/serviceradar_web_ng_web/live/settings/rules_live_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/settings/rules_live_test.exs
@@ -162,12 +162,14 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
       rule_name = "edit-test-#{unique}"
 
       {:ok, rule} =
-        Ash.create(LogPromotionRule, %{
-          name: rule_name,
-          enabled: true,
-          priority: 100,
-          match: %{"body_contains" => "original error"}
-        }, scope: scope)
+        Ash.create(
+          LogPromotionRule,
+          %{
+            name: rule_name,
+            enabled: true,
+            priority: 100,
+            match: %{"body_contains" => "original error"}
+          }, scope: scope)
 
       {:ok, lv, _html} = live(conn, ~p"/settings/rules?tab=events")
 
@@ -201,12 +203,14 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
       unique = System.unique_integer([:positive])
 
       {:ok, rule} =
-        Ash.create(LogPromotionRule, %{
-          name: "toggle-test-#{unique}",
-          enabled: true,
-          priority: 100,
-          match: %{"body_contains" => "test"}
-        }, scope: scope)
+        Ash.create(
+          LogPromotionRule,
+          %{
+            name: "toggle-test-#{unique}",
+            enabled: true,
+            priority: 100,
+            match: %{"body_contains" => "test"}
+          }, scope: scope)
 
       {:ok, lv, _html} = live(conn, ~p"/settings/rules?tab=events")
 
@@ -224,16 +228,18 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
       unique = System.unique_integer([:positive])
 
       {:ok, _rule} =
-        Ash.create(LogPromotionRule, %{
-          name: "summary-test-#{unique}",
-          enabled: true,
-          priority: 100,
-          match: %{
-            "body_contains" => "error message",
-            "severity_text" => "error",
-            "service_name" => "test-service"
-          }
-        }, scope: scope)
+        Ash.create(
+          LogPromotionRule,
+          %{
+            name: "summary-test-#{unique}",
+            enabled: true,
+            priority: 100,
+            match: %{
+              "body_contains" => "error message",
+              "severity_text" => "error",
+              "service_name" => "test-service"
+            }
+          }, scope: scope)
 
       {:ok, _lv, html} = live(conn, ~p"/settings/rules?tab=events")
 


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Formatting


___

### **Description**
- Code formatting and line wrapping improvements across multiple files

- Consistent indentation and spacing adjustments in Elixir components

- Multi-line attribute formatting for better readability

- Test file formatting updates to match code style standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Elixir Components"] -->|"Line wrapping & indentation"| B["Formatted Code"]
  C["Test Files"] -->|"Consistent spacing"| B
  D["HTML Attributes"] -->|"Multi-line formatting"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder.ex</strong><dd><code>Promotion rule builder component formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex

<ul><li>Reformatted multi-line HTML attributes and function calls for improved <br>readability<br> <li> Adjusted indentation and spacing around comments and dividers<br> <li> Split long conditional statements across multiple lines<br> <li> Improved formatting of nested elements and attribute lists</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-0226580d3777904915943339ececa4e0e314a03a7c43a0e9afec64fe2a8f9354">+42/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Log show live view formatting updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex

<ul><li>Reformatted icon and text elements on single line<br> <li> Adjusted comment spacing and indentation<br> <li> Improved multi-line attribute formatting for flash messages</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-4f9769353c55928a0d382cd7510379444445aea116e1ecdf7b8eb892d249ff26">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Networks live view spacing adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex

- Fixed spacing in text output for host count display


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-b2127e71582033bc6dfd2d7397f56bf43c1f7c613defffc504b3d8ee1e7406c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Rules live view component formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/settings/rules_live/index.ex

<ul><li>Reformatted multi-line button element attributes<br> <li> Adjusted comment spacing and indentation<br> <li> Improved formatting of list construction in helper function</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-ce489a06ca328b705897a7b71749c6519594920a192aa0d033944a046d743ef0">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder_test.exs</strong><dd><code>Promotion rule builder test formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs

<ul><li>Reformatted long conditional statements across multiple lines<br> <li> Consistent indentation adjustments in test helper functions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-4ff7f672a7acd6834d3e7eba25af462a2535e6ee010b511de8e57d12693703d4">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show_test.exs</strong><dd><code>Log live view test formatting updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs

<ul><li>Reformatted mock module return statements with improved indentation<br> <li> Multi-line map structure formatting for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-2d62472b3e212a4da643a2f66d2a07d358795602e680f31249a162b71fa0ea3b">+14/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rules_live_test.exs</strong><dd><code>Rules live view test formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/live/settings/rules_live_test.exs

<ul><li>Reformatted Ash.create function calls with multi-line parameter <br>formatting<br> <li> Consistent indentation for nested map structures in test setup<br> <li> Improved readability of test data creation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2346/files#diff-dddd0d747bd725738a10e74770d765ed98fb22cdd5cd702bcbe98cc47c5af5d0">+28/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

