### PR TITLE
Bug/agent crashing k8s

### DIFF
--- a/openspec/changes/fix-agent-kv-removal-crash/proposal.md
+++ b/openspec/changes/fix-agent-kv-removal-crash/proposal.md
@@ -8,9 +8,8 @@ The serviceradar-agent is crashing in demo-staging with a fatal error: `CONFIG_S
 ### Issue 1: Agent Crash (Primary - Blocking)
 - **Root Cause**: The agent deployment has `CONFIG_SOURCE=kv` environment variable set
 - **Impact**: Agent pod is in CrashLoopBackOff, unable to load any configs
-- **Code Path**: `pkg/config/config.go:241` returns `errKVConfigRemoved` when `CONFIG_SOURCE=kv`
-- **Fix Status**: Code fix exists in commit `7b21d33af` (sets `CONFIG_SOURCE=file`), but ArgoCD hasn't synced demo-staging
-- **Resolution**: Force ArgoCD sync to deploy the fix
+- **Code Path**: `pkg/config/config.go:241` returned `errKVConfigRemoved` when `CONFIG_SOURCE=kv`
+- **Resolution**: Made CONFIG_SOURCE=kv idempotent - logs deprecation warning and falls back to file config instead of crashing
 
 ### Issue 2: "Checker request" Logs (Not a Bug - Just Noise)
 - **Root Cause**: The agent's push loop calls `server.GetStatus()` internally to collect checker statuses before pushing to gateway (`push_loop.go:638`)
@@ -32,25 +31,27 @@ The serviceradar-agent is crashing in demo-staging with a fatal error: `CONFIG_S
 
 ### Code Changes
 
-1. **pkg/agent/server.go** - Fix noisy logging:
+1. **pkg/config/config.go** - Make CONFIG_SOURCE=kv idempotent:
+   - Changed from returning fatal error to logging warning and using file config
+   - Removed unused `errKVConfigRemoved` error variable
+
+2. **pkg/agent/server.go** - Fix noisy logging:
    - Line 538: Remove or downgrade "GatewayId is empty" warning (internal calls are expected)
    - Line 1122: Downgrade "Checker request" from INFO to DEBUG
 
-2. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/application.ex**:
-   - Remove `ServiceRadarAgentGateway.AgentClient` from supervisor children (line 140)
-   - Remove `ServiceRadarAgentGateway.TaskExecutor` from supervisor children (line 143)
+3. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/application.ex**:
+   - Remove `ServiceRadarAgentGateway.AgentClient` from supervisor children
+   - Remove `ServiceRadarAgentGateway.TaskExecutor` from supervisor children
 
-3. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_client.ex**:
-   - Add deprecation notice to module doc
-   - Keep file for reference (can be deleted in future cleanup)
+4. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/agent_client.ex**:
+   - Delete entirely (legacy polling code, no longer needed)
 
-4. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/task_executor.ex**:
-   - Add deprecation notice to module doc
-   - Keep file for reference (can be deleted in future cleanup)
+5. **elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/task_executor.ex**:
+   - Delete entirely (legacy polling code, no longer needed)
 
 ### Deployment Changes
 
-1. Verify ArgoCD demo-staging syncs to latest staging branch
+1. Remove serviceradar-snmp-checker deployment from demo-staging (functionality now in agent)
 2. Confirm agent restarts without crash
 3. Validate push loop works correctly
 

--- a/openspec/changes/fix-agent-kv-removal-crash/specs/agent-configuration/spec.md
+++ b/openspec/changes/fix-agent-kv-removal-crash/specs/agent-configuration/spec.md
@@ -11,11 +11,12 @@ The `serviceradar-agent` MUST load all configuration from local filesystem or gR
 - **THEN** configuration is loaded from the local filesystem
 - **AND** the agent starts successfully
 
-#### Scenario: Agent rejects KV configuration source
+#### Scenario: Agent handles deprecated KV configuration source gracefully
 - **GIVEN** the agent has `CONFIG_SOURCE=kv` environment variable
 - **WHEN** the agent attempts to load configuration
-- **THEN** the agent fails with error "CONFIG_SOURCE=kv is no longer supported"
-- **AND** the agent does not start
+- **THEN** the agent logs a deprecation warning
+- **AND** the agent falls back to file-based configuration
+- **AND** the agent starts successfully
 
 #### Scenario: Agent uses environment-based configuration
 - **GIVEN** the agent has `CONFIG_SOURCE=env` environment variable

--- a/openspec/changes/fix-agent-kv-removal-crash/tasks.md
+++ b/openspec/changes/fix-agent-kv-removal-crash/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Immediate Fix - Agent Crash (Blocking)
-- [ ] 1.1 Verify ArgoCD demo-staging app has synced to latest staging branch (commit 7b21d33af or later)
-- [ ] 1.2 If not synced, trigger ArgoCD refresh/sync: `argocd app sync serviceradar-demo-staging`
-- [ ] 1.3 Verify serviceradar-agent pod restarts successfully without crash
-- [ ] 1.4 Confirm `CONFIG_SOURCE=file` in running agent: `kubectl get deployment serviceradar-agent -n demo-staging -o yaml | grep CONFIG_SOURCE`
+- [x] 1.1 Made CONFIG_SOURCE=kv idempotent (logs warning, falls back to file instead of crashing)
+- [x] 1.2 Manually set CONFIG_SOURCE=file on demo-staging deployment
+- [x] 1.3 Verified serviceradar-agent pod restarts successfully without crash
+- [x] 1.4 Removed serviceradar-snmp-checker deployment and service from demo-staging (functionality baked into agent)
 
 ## 2. Fix Noisy Logging in Go Agent
 - [x] 2.1 In `pkg/agent/server.go:538`, remove the "GatewayId is empty in request" warning (internal calls are expected)
@@ -13,12 +13,12 @@
 - [x] 3.1 In `elixir/serviceradar_agent_gateway/lib/serviceradar_agent_gateway/application.ex`:
   - Remove `ServiceRadarAgentGateway.AgentClient` from supervisor children
   - Remove `ServiceRadarAgentGateway.TaskExecutor` from supervisor children
-- [x] 3.2 Add deprecation notice to `agent_client.ex` module doc
-- [x] 3.3 Add similar deprecation notice to `task_executor.ex`
+- [x] 3.2 Delete `agent_client.ex` module entirely (not just deprecate)
+- [x] 3.3 Delete `task_executor.ex` module entirely (not just deprecate)
 - [x] 3.4 Verify gateway compiles successfully
 
 ## 4. Validation
-- [ ] 4.1 Deploy changes to demo-staging
+- [x] 4.1 Agent running in demo-staging without crash
 - [ ] 4.2 Verify agent logs no longer show "Checker request" at INFO level
 - [ ] 4.3 Verify agent logs no longer show "GatewayId is empty in request" warnings
 - [ ] 4.4 Verify agent push loop works correctly (status pushed to gateway)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	errInvalidConfigSource = errors.New("invalid CONFIG_SOURCE value")
-	errKVConfigRemoved     = errors.New("CONFIG_SOURCE=kv is no longer supported")
 	errInvalidConfigPtr    = errors.New("config must be a non-nil pointer")
 )
 
@@ -238,7 +237,9 @@ func (c *Config) loadAndValidateWithSource(ctx context.Context, path string, cfg
 
 	switch source {
 	case "kv":
-		return errKVConfigRemoved
+		// KV config source removed - treat as no-op and use file config instead
+		c.logger.Warn().Msg("CONFIG_SOURCE=kv is deprecated and no longer supported; using file configuration instead")
+		loader = c.defaultLoader
 	case configSourceEnv:
 		// Use environment variables with optional prefix
 		prefix := os.Getenv("CONFIG_ENV_PREFIX")


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Made CONFIG_SOURCE=kv idempotent instead of crashing
  - Logs deprecation warning and falls back to file config
  - Removes fatal error that caused agent pod CrashLoopBackOff

- Updated OpenSpec proposal and specs to reflect graceful fallback behavior

- Updated task completion status for agent crash resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CONFIG_SOURCE=kv set"] -->|Previously| B["Fatal error crash"]
  A -->|Now| C["Log deprecation warning"]
  C --> D["Fall back to file config"]
  D --> E["Agent starts successfully"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Make KV config source idempotent with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/config/config.go

<ul><li>Removed <code>errKVConfigRemoved</code> error variable declaration<br> <li> Changed <code>case "kv"</code> handler from returning fatal error to logging <br>deprecation warning<br> <li> Set <code>loader = c.defaultLoader</code> to fall back to file-based configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2349/files#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Update proposal with idempotent KV config behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-agent-kv-removal-crash/proposal.md

<ul><li>Updated Issue 1 resolution from "force ArgoCD sync" to "made <br>CONFIG_SOURCE=kv idempotent"<br> <li> Changed code path description from present tense to past tense<br> <li> Reordered code changes section to prioritize config.go fix<br> <li> Updated deployment changes to reflect actual implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2349/files#diff-1eb96a33b075ff8a9734ead4853f20914d3b9ca35de85b9d5c4ef35d2d97b7b4">+15/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Update spec for graceful KV config deprecation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-agent-kv-removal-crash/specs/agent-configuration/spec.md

<ul><li>Renamed scenario from "Agent rejects KV configuration source" to <br>"Agent handles deprecated KV configuration source gracefully"<br> <li> Changed expected behavior from failure to graceful fallback with <br>deprecation warning<br> <li> Updated assertions to expect successful agent startup with file config <br>fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2349/files#diff-56b407d5c0fd7c0d2ef554abf0c359cd033ce04195fcc3af34637b5324d540a2">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Mark agent crash fix tasks as completed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-agent-kv-removal-crash/tasks.md

<ul><li>Marked section 1 tasks as completed with actual implementation details<br> <li> Updated task 3.2 and 3.3 to reflect module deletion instead of <br>deprecation<br> <li> Updated task 4.1 status to completed</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2349/files#diff-0253693147c3e954ed11efc9238c012f87c33803523e194e26a94090a1c647ea">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

