### PR TITLE
fixing oban scheduler

### DIFF
--- a/elixir/serviceradar_core/lib/serviceradar/sweep_jobs/changes/schedule_sweep_monitor.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/sweep_jobs/changes/schedule_sweep_monitor.ex
@@ -43,14 +43,16 @@ defmodule ServiceRadar.SweepJobs.Changes.ScheduleSweepMonitor do
         )
 
       {:error, :oban_unavailable} ->
-        Logger.warning("Sweep monitor scheduling deferred (Oban unavailable)",
-          sweep_group_id: record.id
+        Logger.debug("Sweep monitor scheduling deferred (Oban unavailable)",
+          sweep_group_id: record.id,
+          note: "sweep schedule reconciler will enqueue when available"
         )
 
       {:error, {:oban_unavailable, message}} ->
-        Logger.warning("Sweep monitor scheduling deferred (Oban unavailable)",
+        Logger.debug("Sweep monitor scheduling deferred (Oban unavailable)",
           sweep_group_id: record.id,
-          reason: message
+          reason: message,
+          note: "sweep schedule reconciler will enqueue when available"
         )
 
       {:error, reason} ->
@@ -72,14 +74,16 @@ defmodule ServiceRadar.SweepJobs.Changes.ScheduleSweepMonitor do
         )
 
       {:error, :oban_unavailable} ->
-        Logger.warning("Sweep data cleanup scheduling deferred (Oban unavailable)",
-          sweep_group_id: record.id
+        Logger.debug("Sweep data cleanup scheduling deferred (Oban unavailable)",
+          sweep_group_id: record.id,
+          note: "sweep schedule reconciler will enqueue when available"
         )
 
       {:error, {:oban_unavailable, message}} ->
-        Logger.warning("Sweep data cleanup scheduling deferred (Oban unavailable)",
+        Logger.debug("Sweep data cleanup scheduling deferred (Oban unavailable)",
           sweep_group_id: record.id,
-          reason: message
+          reason: message,
+          note: "sweep schedule reconciler will enqueue when available"
         )
 
       {:error, reason} ->

--- a/web-ng/config/config.exs
+++ b/web-ng/config/config.exs
@@ -102,7 +102,7 @@ config :serviceradar_core, Oban,
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
     # No Cron plugin - core-elx handles all scheduled jobs
   ],
-  peer: Oban.Peers.Database
+  peer: {Oban.Peers.Database, []}
 
 # AshOban configuration
 config :ash_oban,

--- a/web-ng/config/runtime.exs
+++ b/web-ng/config/runtime.exs
@@ -178,7 +178,7 @@ if config_env() != :test do
   end
 
   oban_enabled =
-    System.get_env("SERVICERADAR_WEB_NG_OBAN_ENABLED", "false") in ~w(true 1 yes)
+    System.get_env("SERVICERADAR_WEB_NG_OBAN_ENABLED", "true") in ~w(true 1 yes)
 
   config :serviceradar_core, :oban_enabled, oban_enabled
 
@@ -212,7 +212,7 @@ if config_env() != :test do
       {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
       # No Cron plugin - core-elx handles all scheduled jobs
     ],
-    peer: Oban.Peers.Database
+    peer: {Oban.Peers.Database, []}
   ]
 
   oban_config =

--- a/web-ng/lib/serviceradar_web_ng/jobs/job_catalog.ex
+++ b/web-ng/lib/serviceradar_web_ng/jobs/job_catalog.ex
@@ -13,7 +13,8 @@ defmodule ServiceRadarWebNG.Jobs.JobCatalog do
 
   require Logger
 
-  alias ServiceRadar.Monitoring.PollingSchedule
+  alias ServiceRadar.Edge.OnboardingPackage
+  alias ServiceRadar.Monitoring.{Alert, PollingSchedule, ServiceCheck}
   alias ServiceRadar.Oban.Router
 
   @type job_entry :: %{
@@ -163,36 +164,46 @@ defmodule ServiceRadarWebNG.Jobs.JobCatalog do
   """
   @spec ash_oban_jobs() :: [job_entry()]
   def ash_oban_jobs do
-    # Get AshOban triggers from known resources
-    polling_schedule_triggers()
+    ash_oban_resources()
+    |> Enum.flat_map(&resource_triggers/1)
   end
 
-  # Get polling schedule triggers
-  defp polling_schedule_triggers do
-    case AshOban.Info.oban_triggers(PollingSchedule) do
+  defp ash_oban_resources do
+    [
+      PollingSchedule,
+      ServiceCheck,
+      Alert,
+      OnboardingPackage
+    ]
+  end
+
+  defp resource_triggers(resource) do
+    case AshOban.Info.oban_triggers(resource) do
       {:ok, triggers} ->
-        Enum.map(triggers, fn trigger ->
-          %{
-            id: "ash_oban:polling_schedule:#{trigger.name}",
-            name: humanize_trigger_name(trigger.name),
-            description: "Executes polling schedules for service checks",
-            source: :ash_oban,
-            cron: trigger.scheduler_cron,
-            queue: trigger.queue,
-            enabled: true,
-            worker: trigger.worker_module_name,
-            resource: PollingSchedule,
-            action: trigger.action,
-            last_run_at: nil,
-            next_run_at: next_run_at(trigger.scheduler_cron)
-          }
-        end)
+        Enum.map(triggers, &trigger_entry(resource, &1))
 
       _ ->
         []
     end
   rescue
     _ -> []
+  end
+
+  defp trigger_entry(resource, trigger) do
+    %{
+      id: "ash_oban:#{resource_id(resource)}:#{trigger.name}",
+      name: "#{resource_label(resource)}: #{humanize_trigger_name(trigger.name)}",
+      description: resource_description(resource),
+      source: :ash_oban,
+      cron: trigger.scheduler_cron,
+      queue: trigger.queue,
+      enabled: true,
+      worker: trigger.worker_module_name,
+      resource: resource,
+      action: trigger.action,
+      last_run_at: nil,
+      next_run_at: next_run_at(trigger.scheduler_cron)
+    }
   end
 
   @doc """
@@ -431,6 +442,37 @@ defmodule ServiceRadarWebNG.Jobs.JobCatalog do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
+
+  defp resource_label(resource) when is_atom(resource) do
+    resource
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp resource_id(resource) when is_atom(resource) do
+    resource
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+  end
+
+  defp resource_description(PollingSchedule),
+    do: "Executes polling schedules for service checks"
+
+  defp resource_description(ServiceCheck),
+    do: "Executes scheduled service checks"
+
+  defp resource_description(Alert),
+    do: "Sends alert notifications for active alert rules"
+
+  defp resource_description(OnboardingPackage),
+    do: "Expires edge onboarding packages"
+
+  defp resource_description(_),
+    do: "Executes scheduled actions for Ash resources"
 
   # Get last run time for a worker
   defp get_last_run(worker) when is_atom(worker) do

--- a/web-ng/lib/serviceradar_web_ng_web/user_auth.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/user_auth.ex
@@ -195,8 +195,14 @@ defmodule ServiceRadarWebNGWeb.UserAuth do
         |> redirect(to: ~p"/users/log-in")
         |> halt()
 
+      oban_access?(scope) and oban_running?() ->
+        conn
+
       oban_access?(scope) ->
         conn
+        |> put_flash(:error, "Oban is not running on this node.")
+        |> redirect(to: ~p"/admin/jobs")
+        |> halt()
 
       true ->
         conn
@@ -218,4 +224,13 @@ defmodule ServiceRadarWebNGWeb.UserAuth do
   end
 
   defp oban_access?(_), do: false
+
+  defp oban_running? do
+    case Oban.Registry.whereis(Oban) do
+      pid when is_pid(pid) -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
 end


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Changed Oban unavailable log level from warning to debug
  - Added note about sweep schedule reconciler handling

- Fixed Oban peer configuration to use tuple format

- Changed default Oban enabled state from false to true

- Refactored job catalog to support multiple AshOban resources
  - Added ServiceCheck, Alert, and OnboardingPackage resources
  - Generalized trigger entry creation logic

- Added Oban running status check for admin access control


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Oban Configuration"] -->|"peer tuple format"| B["Fixed Peer Setup"]
  C["Log Level Changes"] -->|"warning to debug"| D["Reduced Alert Noise"]
  E["Default Enabled"] -->|"false to true"| F["Oban Active by Default"]
  G["Job Catalog"] -->|"multi-resource support"| H["Enhanced Job Discovery"]
  I["Admin Access"] -->|"runtime check"| J["Oban Status Validation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedule_sweep_monitor.ex</strong><dd><code>Reduced log severity for Oban unavailable conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

elixir/serviceradar_core/lib/serviceradar/sweep_jobs/changes/schedule_sweep_monitor.ex

<ul><li>Changed log level from warning to debug for Oban unavailable errors<br> <li> Added explanatory note about sweep schedule reconciler handling<br> <li> Applied changes to both sweep monitor and data cleanup scheduling</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2350/files#diff-aea351916ba684aaab2941779c2750ebd099e2d30d0c929358f53aebc674b31f">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.exs</strong><dd><code>Fixed Oban peer configuration format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/config/config.exs

<ul><li>Updated Oban peer configuration from atom to tuple format<br> <li> Changed <code>Oban.Peers.Database</code> to <code>{Oban.Peers.Database, []}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2350/files#diff-da0b524f083d350207155c247526098fdd68866d64e7e4eae3d96fdae31bcfb6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.exs</strong><dd><code>Enabled Oban by default and fixed peer config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/config/runtime.exs

<ul><li>Changed default Oban enabled state from false to true<br> <li> Updated Oban peer configuration in runtime config to tuple format</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2350/files#diff-f1093c1a9d74ba3cd35f31e2c50dec60b4fb9c241fc5ff9f62bcbcc0559691ae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>job_catalog.ex</strong><dd><code>Refactored job catalog for multi-resource support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng/jobs/job_catalog.ex

<ul><li>Refactored to support multiple AshOban resources beyond <br>PollingSchedule<br> <li> Added ServiceCheck, Alert, and OnboardingPackage resources<br> <li> Generalized trigger entry creation with helper functions<br> <li> Added resource_label, resource_id, and resource_description functions</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2350/files#diff-6bbf0790c2cbff1e6e9136cb8b9c20a07dd30e83e119937a0e0fe90418b5e258">+64/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user_auth.ex</strong><dd><code>Added Oban runtime status validation for admin access</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/user_auth.ex

<ul><li>Added runtime check for Oban running status before granting access<br> <li> Modified admin access logic to verify Oban is active on current node<br> <li> Added oban_running? helper function using Oban.Registry</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2350/files#diff-eed904963eb2089bfce4e634d5229889213b12d02489e07af53f1b1982a42d78">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

