### PR TITLE
adding stats cards to devices page

### DIFF
--- a/openspec/changes/add-device-stats-cards/design.md
+++ b/openspec/changes/add-device-stats-cards/design.md
@@ -1,0 +1,181 @@
+## Context
+
+The devices dashboard needs summary statistics (total count, availability breakdown, vendor distribution). Rather than creating a separate API endpoint and pre-computed CAGGs, we extend SRQL with GROUP BY support for devices. This gives users a powerful reporting/search tool while powering the dashboard stats.
+
+**Stakeholders**: Operators viewing the devices dashboard, users creating custom reports via SRQL.
+
+**Constraints**:
+- SRQL is the canonical query interface - avoid bypassing it
+- SRQL is Rust, called via Rustler NIF from web-ng
+- Must follow existing patterns in `otel_metrics.rs` for GROUP BY
+
+## Goals / Non-Goals
+
+**Goals**:
+- Enable `in:devices stats:count() as count by field` queries
+- Power dashboard stats cards with SRQL queries
+- Give users flexible device analytics via SRQL
+- Follow established SRQL patterns (no hacks)
+
+**Non-Goals**:
+- Pre-computed CAGGs (SRQL queries are fast enough for dashboard use)
+- Custom API endpoints (SRQL handles this)
+- Historical stats trending (future enhancement)
+
+## Decisions
+
+### Decision 1: Extend SRQL with GROUP BY for Devices
+
+**What**: Add GROUP BY support to `devices.rs` following the `otel_metrics.rs` pattern.
+
+**Why**:
+- SRQL is the canonical query interface - users expect it to work
+- Pattern already exists and is proven (otel_metrics, logs)
+- No new API surface area to maintain
+- Users get the same power for custom reports
+
+**Implementation approach**:
+- Add `DeviceGroupField` enum for supported grouping fields
+- Build raw SQL with GROUP BY (Diesel doesn't support this directly)
+- Return JSONB array with field value and count
+
+### Decision 2: No CAGGs Needed Initially
+
+**What**: Use direct SRQL queries against `ocsf_devices` table without pre-computed aggregates.
+
+**Why**:
+- Device counts are simple aggregations, not time-series rollups
+- Table has indexes on key fields (tenant_id, type_id, vendor_name, etc.)
+- Can add CAGGs later if performance becomes an issue at scale
+- Simpler implementation with fewer moving parts
+
+**Trade-off**: Queries hit the table directly. If this becomes slow at 100k+ devices, we can add a CAGG and have SRQL query it instead.
+
+### Decision 3: Stats Cards Use Parallel SRQL Queries
+
+**What**: Dashboard loads stats via multiple parallel SRQL queries.
+
+**Why**:
+- Each stat card is independent
+- Parallel queries complete faster than sequential
+- Failures are isolated (one card can fail without breaking others)
+- Same pattern used in analytics page
+
+## SRQL Query Examples
+
+**Simple counts (already working):**
+```
+in:devices stats:count() as total
+in:devices is_available:true stats:count() as available
+in:devices is_available:false stats:count() as unavailable
+```
+
+**Grouped stats (new capability):**
+```
+in:devices stats:count() as count by type
+// Returns: [{"type": "Server", "count": 45}, {"type": "Router", "count": 23}, ...]
+
+in:devices stats:count() as count by vendor_name
+// Returns: [{"vendor_name": "Cisco", "count": 200}, {"vendor_name": "Dell", "count": 150}, ...]
+
+in:devices stats:count() as count by risk_level
+// Returns: [{"risk_level": "High", "count": 50}, {"risk_level": "Low", "count": 1000}, ...]
+
+in:devices stats:count() as count by is_available
+// Returns: [{"is_available": true, "count": 950}, {"is_available": false, "count": 50}]
+```
+
+**Combined filters + grouping:**
+```
+in:devices vendor_name:Cisco stats:count() as count by type
+// Returns Cisco devices grouped by type
+```
+
+## Implementation Details
+
+### Rust Changes (devices.rs)
+
+```rust
+// New enum for groupable fields
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeviceGroupField {
+    Type,
+    VendorName,
+    RiskLevel,
+    IsAvailable,
+    GatewayId,
+}
+
+impl DeviceGroupField {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "type" | "device_type" => Some(Self::Type),
+            "vendor_name" | "vendor" => Some(Self::VendorName),
+            "risk_level" => Some(Self::RiskLevel),
+            "is_available" | "available" => Some(Self::IsAvailable),
+            "gateway_id" => Some(Self::GatewayId),
+            _ => None,
+        }
+    }
+
+    fn sql_column(&self) -> &'static str {
+        match self {
+            Self::Type => "COALESCE(type, 'Unknown')",
+            Self::VendorName => "COALESCE(vendor_name, 'Unknown')",
+            Self::RiskLevel => "COALESCE(risk_level, 'Unknown')",
+            Self::IsAvailable => "COALESCE(is_available, false)",
+            Self::GatewayId => "gateway_id",
+        }
+    }
+}
+```
+
+### SQL Generation Pattern
+
+Following `otel_metrics.rs` lines 381-406:
+
+```sql
+SELECT jsonb_build_object(
+    'type', COALESCE(type, 'Unknown'),
+    'count', COUNT(*)
+) AS payload
+FROM ocsf_devices
+WHERE tenant_id = $1
+GROUP BY COALESCE(type, 'Unknown')
+ORDER BY COUNT(*) DESC
+LIMIT 20
+```
+
+### UI Stats Cards
+
+```
+┌─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+│   Total     │  Available  │ Unavailable │  By Type    │ Top Vendors │
+│   52,341    │   51,200    │    1,141    │  Server: 15k│  Cisco: 20k │
+│             │    97.8%    │    ⚠️ 2.2%  │  Switch: 12k│  Dell: 15k  │
+│             │             │             │  Router: 8k │  HP: 10k    │
+└─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+```
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Query performance at scale | Add indexes; can add CAGG later if needed |
+| GROUP BY adds Rust complexity | Follow existing otel_metrics pattern exactly |
+| Multiple parallel queries | Use Task.async_stream with timeout |
+
+## Migration Plan
+
+1. Implement SRQL GROUP BY support in Rust
+2. Add tests for new query syntax
+3. Update web-ng catalog with stats_fields
+4. Implement UI stats cards
+5. Deploy and monitor query performance
+
+**Rollback**: Remove UI component; SRQL changes are additive and backward-compatible.
+
+## Open Questions
+
+- [ ] Should we limit GROUP BY results (e.g., top 20 vendors)? → Yes, add LIMIT 20 to prevent unbounded results
+- [ ] Do we need ORDER BY count DESC? → Yes, show most common first

--- a/openspec/changes/add-device-stats-cards/proposal.md
+++ b/openspec/changes/add-device-stats-cards/proposal.md
@@ -1,0 +1,30 @@
+# Change: Add Device Stats Cards to Devices Dashboard
+
+## Why
+
+The devices dashboard currently shows only a paginated table of devices without any summary statistics. Operators need at-a-glance visibility into device inventory health: total counts, availability status breakdown, and vendor distribution. By extending SRQL with GROUP BY support for devices, users also gain a powerful reporting/search tool for custom device analytics.
+
+Ref: GitHub Issue #2252
+
+## What Changes
+
+- **ADDED**: SRQL GROUP BY support for devices entity (Rust)
+  - Enables: `in:devices stats:count() as count by type`
+  - Enables: `in:devices stats:count() as count by vendor_name`
+  - Enables: `in:devices stats:count() as count by risk_level`
+  - Enables: `in:devices stats:count() as count by is_available`
+- **ADDED**: LiveView stats cards component above the devices table
+  - Uses SRQL queries to fetch stats (no custom API endpoint needed)
+  - Total devices, available/unavailable breakdown, type distribution, vendor distribution
+- **MODIFIED**: Devices index page to include stats cards header section
+
+**Note**: No custom API endpoint needed - all stats are queryable via SRQL, giving users the same power for custom reporting.
+
+## Impact
+
+- Affected specs: `device-inventory`, `srql`
+- Affected code:
+  - `rust/srql/src/query/devices.rs` - Add GROUP BY support following otel_metrics pattern
+  - `rust/srql/src/parser.rs` - May need minor parser updates for group field
+  - `web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex` - Stats cards UI
+  - `web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex` - Add stats_fields for devices

--- a/openspec/changes/add-device-stats-cards/specs/device-inventory/spec.md
+++ b/openspec/changes/add-device-stats-cards/specs/device-inventory/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Device Dashboard Stats Cards
+
+The system SHALL display summary statistics cards above the devices table on the devices dashboard page.
+
+The stats cards section SHALL include:
+- Total Devices card: Shows total device count
+- Available Devices card: Shows available count with success styling
+- Unavailable Devices card: Shows unavailable count with error styling when > 0
+- Device Types card: Shows breakdown of device types (top 5)
+- Top Vendors card: Shows breakdown by vendor (top 5)
+
+#### Scenario: Stats cards display on page load
+- **GIVEN** a user navigates to the devices dashboard
+- **WHEN** the page loads
+- **THEN** stats cards SHALL be displayed above the devices table
+- **AND** cards SHALL show current statistics via SRQL queries
+
+#### Scenario: Stats cards show loading state
+- **GIVEN** a user navigates to the devices dashboard
+- **WHEN** statistics are being fetched
+- **THEN** stats cards SHALL display skeleton placeholders
+
+#### Scenario: Unavailable devices highlighted
+- **GIVEN** there are unavailable devices in the inventory
+- **WHEN** the stats cards are displayed
+- **THEN** the Unavailable Devices card SHALL use error styling (red tone)
+- **AND** the count SHALL be prominently displayed
+
+#### Scenario: Stats cards are clickable filters
+- **GIVEN** the stats cards are displayed
+- **WHEN** a user clicks on the "Unavailable Devices" card
+- **THEN** the devices table SHALL filter to show only unavailable devices
+
+#### Scenario: Stats loaded via parallel SRQL queries
+- **GIVEN** the devices dashboard is loading
+- **WHEN** stats are fetched
+- **THEN** multiple SRQL queries SHALL execute in parallel
+- **AND** each card SHALL load independently

--- a/openspec/changes/add-device-stats-cards/specs/srql/spec.md
+++ b/openspec/changes/add-device-stats-cards/specs/srql/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Device Stats GROUP BY Support
+
+The SRQL service SHALL support GROUP BY aggregations for the devices entity using the syntax `stats:<agg>() as <alias> by <field>`.
+
+Supported grouping fields:
+- `type` / `device_type`: Device type classification
+- `vendor_name` / `vendor`: Device vendor/manufacturer
+- `risk_level`: Risk level classification
+- `is_available` / `available`: Availability status (boolean)
+- `gateway_id`: Gateway assignment
+
+The response SHALL return a JSONB array of objects, each containing the group field value and the aggregated count, ordered by count descending with a default limit of 20 results.
+
+#### Scenario: Group devices by type
+- **GIVEN** devices exist with various type values
+- **WHEN** a client sends `in:devices stats:count() as count by type`
+- **THEN** SRQL returns `{"results": [{"type": "Server", "count": 45}, {"type": "Router", "count": 23}, ...]}`
+- **AND** results are ordered by count descending
+
+#### Scenario: Group devices by vendor
+- **GIVEN** devices exist with various vendor_name values
+- **WHEN** a client sends `in:devices stats:count() as count by vendor_name`
+- **THEN** SRQL returns `{"results": [{"vendor_name": "Cisco", "count": 200}, {"vendor_name": "Dell", "count": 150}, ...]}`
+- **AND** results are limited to top 20 vendors
+
+#### Scenario: Group devices by availability
+- **GIVEN** devices exist with is_available true and false
+- **WHEN** a client sends `in:devices stats:count() as count by is_available`
+- **THEN** SRQL returns `{"results": [{"is_available": true, "count": 950}, {"is_available": false, "count": 50}]}`
+
+#### Scenario: Group devices by risk level
+- **GIVEN** devices exist with various risk_level values
+- **WHEN** a client sends `in:devices stats:count() as count by risk_level`
+- **THEN** SRQL returns `{"results": [{"risk_level": "Low", "count": 800}, {"risk_level": "High", "count": 50}, ...]}`
+
+#### Scenario: Combined filter with grouping
+- **GIVEN** devices exist from multiple vendors with various types
+- **WHEN** a client sends `in:devices vendor_name:Cisco stats:count() as count by type`
+- **THEN** SRQL returns only Cisco devices grouped by type
+
+#### Scenario: Null values handled as Unknown
+- **GIVEN** devices exist with NULL vendor_name values
+- **WHEN** a client sends `in:devices stats:count() as count by vendor_name`
+- **THEN** devices with NULL vendor_name SHALL be grouped under "Unknown"
+
+#### Scenario: Unsupported group field returns error
+- **GIVEN** a client wants to group by an unsupported field
+- **WHEN** they send `in:devices stats:count() as count by hostname`
+- **THEN** SRQL returns an error indicating the field does not support grouping

--- a/openspec/changes/add-device-stats-cards/tasks.md
+++ b/openspec/changes/add-device-stats-cards/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Add Device Stats Cards
+
+## 1. SRQL Rust Implementation
+
+- [x] 1.1 Add `DeviceGroupField` enum in `devices.rs` (type, vendor_name, risk_level, is_available, gateway_id)
+- [x] 1.2 Update `parse_stats_spec()` to extract GROUP BY field from query
+- [x] 1.3 Implement `build_grouped_stats_query()` following `otel_metrics.rs` pattern (lines 356-409)
+- [x] 1.4 Generate raw SQL with GROUP BY clause (Diesel doesn't support this directly)
+- [x] 1.5 Return JSONB array: `[{ "field": value, "alias": count }, ...]`
+- [x] 1.6 Add tests for grouped stats queries in devices module
+
+## 2. SRQL Parser Updates (if needed)
+
+- [x] 2.1 Verify parser handles `stats:count() as alias by field` syntax
+- [x] 2.2 Add `group_field` to `StatsSpec` struct if not present
+- [x] 2.3 Add parser tests for grouped stats syntax
+
+## 3. Web-NG SRQL Catalog
+
+- [x] 3.1 Add `stats_fields` to devices entity in `catalog.ex`
+- [x] 3.2 Document which fields support grouping: type, vendor_name, risk_level, is_available, gateway_id
+
+## 4. LiveView UI Layer
+
+- [x] 4.1 Create `device_stats_cards` component in device_live/index.ex
+  - Follow pattern from analytics_live/index.ex `stat_card` component
+  - Use daisyUI styling with tone-based colors
+- [x] 4.2 Add "Total Devices" stat card using `in:devices stats:count() as total`
+- [x] 4.3 Add "Available" stat card using `in:devices is_available:true stats:count() as available`
+- [x] 4.4 Add "Unavailable" stat card using `in:devices is_available:false stats:count() as unavailable`
+- [x] 4.5 Add "By Type" stat card using `in:devices stats:count() as count by type` (top 5)
+- [x] 4.6 Add "Top Vendors" stat card using `in:devices stats:count() as count by vendor_name` (top 5)
+- [x] 4.7 Wire up stats loading in mount/handle_params using SRQL NIF
+- [x] 4.8 Add async loading with skeleton placeholders
+- [x] 4.9 Make stat cards clickable to filter the devices table
+
+## 5. Testing
+
+- [x] 5.1 Add Rust unit tests for devices GROUP BY queries
+- [ ] 5.2 Add integration tests for SRQL grouped stats via NIF
+- [ ] 5.3 Add LiveView tests for stats cards rendering
+
+## 6. Documentation
+
+- [ ] 6.1 Update SRQL documentation with new devices stats examples
+- [ ] 6.2 Update device-inventory spec with stats requirements

--- a/rust/srql/src/parser.rs
+++ b/rust/srql/src/parser.rs
@@ -226,6 +226,7 @@ pub fn parse(input: &str) -> Result<QueryAst> {
             "stats" => {
                 let mut expr = value.as_scalar()?.to_string();
 
+                // Handle "as alias" part
                 if tokens
                     .peek()
                     .is_some_and(|next| next.as_str().eq_ignore_ascii_case("as"))
@@ -255,6 +256,40 @@ pub fn parse(input: &str) -> Result<QueryAst> {
 
                     expr.push_str(" as ");
                     expr.push_str(&alias);
+                }
+
+                // Handle "by field" part for GROUP BY
+                if tokens
+                    .peek()
+                    .is_some_and(|next| next.as_str().eq_ignore_ascii_case("by"))
+                {
+                    let _ = tokens.next();
+                    let field_token = tokens.next().ok_or_else(|| {
+                        ServiceError::InvalidRequest(
+                            "stats group by must be of the form 'stats:expr as alias by field'"
+                                .into(),
+                        )
+                    })?;
+                    if field_token.contains(':') {
+                        return Err(ServiceError::InvalidRequest(
+                            "stats group by must be of the form 'stats:expr as alias by field'"
+                                .into(),
+                        ));
+                    }
+
+                    let field = field_token
+                        .trim()
+                        .trim_matches('"')
+                        .trim_matches('\'')
+                        .to_string();
+                    if field.is_empty() {
+                        return Err(ServiceError::InvalidRequest(
+                            "stats group by field cannot be empty".into(),
+                        ));
+                    }
+
+                    expr.push_str(" by ");
+                    expr.push_str(&field);
                 }
 
                 if expr.trim().len() > MAX_STATS_EXPR_LEN {

--- a/rust/srql/src/query/devices.rs
+++ b/rust/srql/src/query/devices.rs
@@ -13,19 +13,108 @@ use crate::{
     },
     time::TimeRange,
 };
+use chrono::{DateTime, Utc};
 use diesel::dsl::{not, sql};
 use diesel::pg::Pg;
 use diesel::prelude::*;
-use diesel::query_builder::{AsQuery, BoxedSelectStatement, FromClause};
-use diesel::sql_types::{Array, BigInt, Bool, Text};
+use diesel::query_builder::{AsQuery, BoxedSelectStatement, BoxedSqlQuery, FromClause, SqlQuery};
+use diesel::sql_types::{Array, BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
 use diesel::PgTextExpressionMethods;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde_json::Value;
 
 type OcsfDevicesTable = crate::schema::ocsf_devices::table;
 type DeviceFromClause = FromClause<OcsfDevicesTable>;
 type DeviceQuery<'a> =
     BoxedSelectStatement<'a, <OcsfDevicesTable as AsQuery>::SqlType, DeviceFromClause, Pg>;
 type DeviceStatsQuery<'a> = BoxedSelectStatement<'a, BigInt, DeviceFromClause, Pg>;
+
+/// Groupable fields for device stats queries
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DeviceGroupField {
+    Type,
+    VendorName,
+    RiskLevel,
+    IsAvailable,
+    GatewayId,
+}
+
+impl DeviceGroupField {
+    fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "type" | "device_type" => Some(Self::Type),
+            "vendor_name" | "vendor" => Some(Self::VendorName),
+            "risk_level" | "risk" => Some(Self::RiskLevel),
+            "is_available" | "available" => Some(Self::IsAvailable),
+            "gateway_id" | "gateway" => Some(Self::GatewayId),
+            _ => None,
+        }
+    }
+
+    fn column(&self) -> &'static str {
+        match self {
+            Self::Type => "COALESCE(device_type, 'Unknown')",
+            Self::VendorName => "COALESCE(vendor_name, 'Unknown')",
+            Self::RiskLevel => "COALESCE(risk_level, 'Unknown')",
+            Self::IsAvailable => "COALESCE(is_available, false)",
+            Self::GatewayId => "gateway_id",
+        }
+    }
+
+    fn response_key(&self) -> &'static str {
+        match self {
+            Self::Type => "type",
+            Self::VendorName => "vendor_name",
+            Self::RiskLevel => "risk_level",
+            Self::IsAvailable => "is_available",
+            Self::GatewayId => "gateway_id",
+        }
+    }
+}
+
+/// SQL bind value for grouped stats queries
+#[derive(Debug, Clone)]
+enum DeviceSqlBindValue {
+    Text(String),
+    TextArray(Vec<String>),
+    Bool(bool),
+    Int(i64),
+    Timestamp(DateTime<Utc>),
+}
+
+impl DeviceSqlBindValue {
+    fn apply<'a>(&self, query: BoxedSqlQuery<'a, Pg, SqlQuery>) -> BoxedSqlQuery<'a, Pg, SqlQuery> {
+        match self {
+            DeviceSqlBindValue::Text(value) => query.bind::<Text, _>(value.clone()),
+            DeviceSqlBindValue::TextArray(values) => query.bind::<Array<Text>, _>(values.clone()),
+            DeviceSqlBindValue::Bool(value) => query.bind::<Bool, _>(*value),
+            DeviceSqlBindValue::Int(value) => query.bind::<BigInt, _>(*value),
+            DeviceSqlBindValue::Timestamp(value) => query.bind::<Timestamptz, _>(*value),
+        }
+    }
+}
+
+fn bind_param_from_device_stats(value: DeviceSqlBindValue) -> BindParam {
+    match value {
+        DeviceSqlBindValue::Text(value) => BindParam::Text(value),
+        DeviceSqlBindValue::TextArray(values) => BindParam::TextArray(values),
+        DeviceSqlBindValue::Bool(value) => BindParam::Bool(value),
+        DeviceSqlBindValue::Int(value) => BindParam::Int(value),
+        DeviceSqlBindValue::Timestamp(value) => BindParam::timestamptz(value),
+    }
+}
+
+#[derive(Debug, QueryableByName)]
+struct DeviceStatsPayload {
+    #[diesel(sql_type = Nullable<Jsonb>)]
+    payload: Option<Value>,
+}
+
+/// Grouped stats query result
+struct DeviceGroupedStatsSql {
+    sql: String,
+    binds: Vec<DeviceSqlBindValue>,
+}
 
 pub(super) async fn execute(
     conn: &mut AsyncPgConnection,
@@ -34,6 +123,24 @@ pub(super) async fn execute(
     ensure_entity(plan)?;
 
     if let Some(spec) = parse_stats_spec(plan.stats.as_ref().map(|s| s.as_raw()))? {
+        // Check if this is a grouped stats query
+        if spec.group_field.is_some() {
+            let grouped_sql = build_grouped_stats_query(plan, &spec)?;
+            let mut query = diesel::sql_query(&grouped_sql.sql).into_boxed();
+            for bind in grouped_sql.binds {
+                query = bind.apply(query);
+            }
+            let rows: Vec<DeviceStatsPayload> = query
+                .load(conn)
+                .await
+                .map_err(|err| ServiceError::Internal(err.into()))?;
+            return Ok(rows
+                .into_iter()
+                .filter_map(|row| row.payload)
+                .collect());
+        }
+
+        // Simple count (ungrouped)
         let query = build_stats_query(plan, &spec)?;
         let values: Vec<i64> = query
             .load(conn)
@@ -57,6 +164,19 @@ pub(super) async fn execute(
 pub(super) fn to_sql_and_params(plan: &QueryPlan) -> Result<(String, Vec<BindParam>)> {
     ensure_entity(plan)?;
     if let Some(spec) = parse_stats_spec(plan.stats.as_ref().map(|s| s.as_raw()))? {
+        // Check if this is a grouped stats query
+        if spec.group_field.is_some() {
+            let grouped_sql = build_grouped_stats_query(plan, &spec)?;
+            let sql = rewrite_placeholders(&grouped_sql.sql);
+            let params: Vec<BindParam> = grouped_sql
+                .binds
+                .into_iter()
+                .map(bind_param_from_device_stats)
+                .collect();
+            return Ok((sql, params));
+        }
+
+        // Simple count (ungrouped)
         let query = build_stats_query(plan, &spec)?;
         let sql = super::diesel_sql(&query)?;
 
@@ -146,6 +266,7 @@ fn build_query(plan: &QueryPlan) -> Result<DeviceQuery<'static>> {
 #[derive(Debug, Clone)]
 struct DeviceStatsSpec {
     alias: String,
+    group_field: Option<DeviceGroupField>,
 }
 
 fn parse_stats_spec(raw: Option<&str>) -> Result<Option<DeviceStatsSpec>> {
@@ -182,13 +303,271 @@ fn parse_stats_spec(raw: Option<&str>) -> Result<Option<DeviceStatsSpec>> {
         ));
     }
 
-    if tokens.len() > 3 {
+    // Parse optional "by <field>" clause
+    let mut group_field = None;
+    if tokens.len() >= 5 {
+        if !tokens[3].eq_ignore_ascii_case("by") {
+            return Err(ServiceError::InvalidRequest(
+                "expected 'by <field>' after stats alias".into(),
+            ));
+        }
+        group_field = Some(parse_group_field(tokens[4])?);
+    } else if tokens.len() > 3 {
         return Err(ServiceError::InvalidRequest(
-            "devices stats do not support grouping yet".into(),
+            "expected 'by <field>' after stats alias".into(),
         ));
     }
 
-    Ok(Some(DeviceStatsSpec { alias }))
+    Ok(Some(DeviceStatsSpec { alias, group_field }))
+}
+
+fn parse_group_field(raw: &str) -> Result<DeviceGroupField> {
+    DeviceGroupField::from_str(raw).ok_or_else(|| {
+        ServiceError::InvalidRequest(format!(
+            "unsupported stats group field '{}'. Supported fields: type, vendor_name, risk_level, is_available, gateway_id",
+            raw
+        ))
+    })
+}
+
+/// Builds a grouped stats query using raw SQL (Diesel doesn't support GROUP BY well)
+fn build_grouped_stats_query(
+    plan: &QueryPlan,
+    spec: &DeviceStatsSpec,
+) -> Result<DeviceGroupedStatsSql> {
+    let group_field = spec
+        .group_field
+        .ok_or_else(|| ServiceError::Internal(anyhow::anyhow!("group_field is required")))?;
+
+    let mut binds = Vec::new();
+    let mut clauses = Vec::new();
+
+    // Time range filter
+    if let Some(TimeRange { start, end }) = &plan.time_range {
+        clauses.push("last_seen_time >= ?".to_string());
+        binds.push(DeviceSqlBindValue::Timestamp(*start));
+        clauses.push("last_seen_time <= ?".to_string());
+        binds.push(DeviceSqlBindValue::Timestamp(*end));
+    }
+
+    // Apply filters
+    for filter in &plan.filters {
+        if let Some((clause, mut bind_values)) = build_grouped_stats_filter_clause(filter)? {
+            clauses.push(clause);
+            binds.append(&mut bind_values);
+        }
+    }
+
+    let column = group_field.column();
+    let response_key = group_field.response_key();
+
+    // Build SELECT with jsonb_build_object
+    let mut sql = format!(
+        "SELECT jsonb_build_object('{}', {}, '{}', COUNT(*)) AS payload",
+        response_key, column, spec.alias
+    );
+    sql.push_str("\nFROM ocsf_devices");
+
+    if !clauses.is_empty() {
+        sql.push_str("\nWHERE ");
+        sql.push_str(&clauses.join(" AND "));
+    }
+
+    sql.push_str(&format!("\nGROUP BY {column}"));
+
+    // Order by count descending by default
+    let order_sql = build_grouped_stats_order_clause(plan, &spec.alias, column);
+    sql.push_str(&order_sql);
+
+    // Apply limit (default 20 for distributions)
+    let limit = if plan.limit > 0 && plan.limit <= 100 {
+        plan.limit
+    } else {
+        20
+    };
+    sql.push_str(&format!("\nLIMIT {limit}"));
+
+    if plan.offset > 0 {
+        sql.push_str(&format!(" OFFSET {}", plan.offset));
+    }
+
+    Ok(DeviceGroupedStatsSql { sql, binds })
+}
+
+fn build_grouped_stats_order_clause(plan: &QueryPlan, alias: &str, group_column: &str) -> String {
+    if plan.order.is_empty() {
+        return "\nORDER BY COUNT(*) DESC".to_string();
+    }
+
+    let mut parts = Vec::new();
+    for clause in &plan.order {
+        let expr = if clause.field.eq_ignore_ascii_case(alias) || clause.field == "count" {
+            "COUNT(*)".to_string()
+        } else if clause.field.eq_ignore_ascii_case(group_column.split('(').next().unwrap_or("")) {
+            group_column.to_string()
+        } else {
+            continue;
+        };
+
+        let dir = match clause.direction {
+            OrderDirection::Asc => "ASC",
+            OrderDirection::Desc => "DESC",
+        };
+        parts.push(format!("{expr} {dir}"));
+    }
+
+    if parts.is_empty() {
+        "\nORDER BY COUNT(*) DESC".to_string()
+    } else {
+        format!("\nORDER BY {}", parts.join(", "))
+    }
+}
+
+fn build_grouped_stats_filter_clause(
+    filter: &Filter,
+) -> Result<Option<(String, Vec<DeviceSqlBindValue>)>> {
+    let mut binds = Vec::new();
+    let clause = match filter.field.as_str() {
+        "uid" => build_grouped_text_clause("uid", filter, &mut binds)?,
+        "hostname" => build_grouped_text_clause("hostname", filter, &mut binds)?,
+        "ip" => build_grouped_text_clause("ip", filter, &mut binds)?,
+        "mac" => build_grouped_text_clause("mac", filter, &mut binds)?,
+        "gateway_id" => build_grouped_text_clause("gateway_id", filter, &mut binds)?,
+        "agent_id" => build_grouped_text_clause("agent_id", filter, &mut binds)?,
+        "type" | "device_type" => build_grouped_text_clause("device_type", filter, &mut binds)?,
+        "type_id" => {
+            let type_id: i64 = filter
+                .value
+                .as_scalar()?
+                .parse()
+                .map_err(|_| ServiceError::InvalidRequest("type_id must be an integer".into()))?;
+            binds.push(DeviceSqlBindValue::Int(type_id));
+            match filter.op {
+                FilterOp::Eq => "type_id = ?".to_string(),
+                FilterOp::NotEq => "(type_id IS NULL OR type_id <> ?)".to_string(),
+                _ => {
+                    return Err(ServiceError::InvalidRequest(
+                        "type_id filter only supports equality".into(),
+                    ))
+                }
+            }
+        }
+        "vendor_name" => build_grouped_text_clause("vendor_name", filter, &mut binds)?,
+        "model" => build_grouped_text_clause("model", filter, &mut binds)?,
+        "risk_level" => build_grouped_text_clause("risk_level", filter, &mut binds)?,
+        "is_available" => {
+            let value = parse_bool(filter.value.as_scalar()?)?;
+            binds.push(DeviceSqlBindValue::Bool(value));
+            match filter.op {
+                FilterOp::Eq => "is_available = ?".to_string(),
+                FilterOp::NotEq => "(is_available IS NULL OR is_available <> ?)".to_string(),
+                _ => {
+                    return Err(ServiceError::InvalidRequest(
+                        "is_available filter only supports equality".into(),
+                    ))
+                }
+            }
+        }
+        "discovery_sources" => {
+            let values = match &filter.value {
+                FilterValue::Scalar(v) => vec![v.to_string()],
+                FilterValue::List(list) => list.clone(),
+            };
+            if values.is_empty() {
+                return Ok(None);
+            }
+            binds.push(DeviceSqlBindValue::TextArray(values));
+            match filter.op {
+                FilterOp::In | FilterOp::Eq => {
+                    "coalesce(discovery_sources, ARRAY[]::text[]) @> ?".to_string()
+                }
+                FilterOp::NotIn | FilterOp::NotEq => {
+                    "NOT (coalesce(discovery_sources, ARRAY[]::text[]) @> ?)".to_string()
+                }
+                _ => {
+                    return Err(ServiceError::InvalidRequest(
+                        "discovery_sources filter only supports equality and list filters".into(),
+                    ))
+                }
+            }
+        }
+        other => {
+            return Err(ServiceError::InvalidRequest(format!(
+                "unsupported filter field for device stats: '{other}'"
+            )));
+        }
+    };
+
+    Ok(Some((clause, binds)))
+}
+
+fn build_grouped_text_clause(
+    column: &str,
+    filter: &Filter,
+    binds: &mut Vec<DeviceSqlBindValue>,
+) -> Result<String> {
+    match filter.op {
+        FilterOp::Eq => {
+            binds.push(DeviceSqlBindValue::Text(
+                filter.value.as_scalar()?.to_string(),
+            ));
+            Ok(format!("{column} = ?"))
+        }
+        FilterOp::NotEq => {
+            binds.push(DeviceSqlBindValue::Text(
+                filter.value.as_scalar()?.to_string(),
+            ));
+            Ok(format!("({column} IS NULL OR {column} <> ?)"))
+        }
+        FilterOp::Like => {
+            binds.push(DeviceSqlBindValue::Text(
+                filter.value.as_scalar()?.to_string(),
+            ));
+            Ok(format!("{column} ILIKE ?"))
+        }
+        FilterOp::NotLike => {
+            binds.push(DeviceSqlBindValue::Text(
+                filter.value.as_scalar()?.to_string(),
+            ));
+            Ok(format!("({column} IS NULL OR {column} NOT ILIKE ?)"))
+        }
+        FilterOp::In => {
+            let values = filter.value.as_list()?.to_vec();
+            if values.is_empty() {
+                return Ok("1=1".to_string());
+            }
+            binds.push(DeviceSqlBindValue::TextArray(values));
+            Ok(format!("{column} = ANY(?)"))
+        }
+        FilterOp::NotIn => {
+            let values = filter.value.as_list()?.to_vec();
+            if values.is_empty() {
+                return Ok("1=1".to_string());
+            }
+            binds.push(DeviceSqlBindValue::TextArray(values));
+            Ok(format!("({column} IS NULL OR NOT ({column} = ANY(?)))"))
+        }
+        _ => Err(ServiceError::InvalidRequest(format!(
+            "unsupported operator for text filter: {:?}",
+            filter.op
+        ))),
+    }
+}
+
+/// Rewrites ? placeholders to $1, $2, etc. for PostgreSQL
+fn rewrite_placeholders(sql: &str) -> String {
+    let mut result = String::with_capacity(sql.len());
+    let mut index = 1;
+    for ch in sql.chars() {
+        if ch == '?' {
+            result.push('$');
+            result.push_str(&index.to_string());
+            index += 1;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 fn build_stats_query(

--- a/rust/srql/src/query/devices.rs
+++ b/rust/srql/src/query/devices.rs
@@ -53,7 +53,8 @@ impl DeviceGroupField {
 
     fn column(&self) -> &'static str {
         match self {
-            Self::Type => "COALESCE(device_type, 'Unknown')",
+            // Note: Diesel schema uses "device_type" but actual SQL column is "type"
+            Self::Type => "COALESCE(type, 'Unknown')",
             Self::VendorName => "COALESCE(vendor_name, 'Unknown')",
             Self::RiskLevel => "COALESCE(risk_level, 'Unknown')",
             Self::IsAvailable => "COALESCE(is_available, false)",

--- a/rust/srql/src/query/mod.rs
+++ b/rust/srql/src/query/mod.rs
@@ -967,6 +967,98 @@ mod tests {
             response.params
         );
     }
+
+    #[test]
+    fn devices_stats_group_by_type() {
+        let query = "in:devices stats:count() as count by type";
+        let plan = plan_for(query);
+
+        assert!(matches!(plan.entity, Entity::Devices));
+        assert!(plan.stats.is_some());
+
+        let (sql, params) = devices::to_sql_and_params(&plan).expect("should build grouped stats SQL");
+        let lower = sql.to_lowercase();
+        assert!(
+            lower.contains("group by"),
+            "expected GROUP BY in SQL, got: {sql}"
+        );
+        assert!(
+            lower.contains("jsonb_build_object"),
+            "expected jsonb_build_object in SQL, got: {sql}"
+        );
+        assert!(
+            lower.contains("device_type") || lower.contains("type"),
+            "expected type column in SQL, got: {sql}"
+        );
+        assert!(
+            lower.contains("count(*)"),
+            "expected COUNT(*) in SQL, got: {sql}"
+        );
+        assert!(params.is_empty(), "grouped stats without filters should have no params");
+    }
+
+    #[test]
+    fn devices_stats_group_by_vendor() {
+        let query = "in:devices stats:count() as count by vendor_name";
+        let plan = plan_for(query);
+
+        assert!(matches!(plan.entity, Entity::Devices));
+        let (sql, _) = devices::to_sql_and_params(&plan).expect("should build grouped stats SQL");
+        let lower = sql.to_lowercase();
+        assert!(
+            lower.contains("vendor_name"),
+            "expected vendor_name column in SQL, got: {sql}"
+        );
+        assert!(
+            lower.contains("order by count(*) desc"),
+            "expected ORDER BY COUNT(*) DESC in SQL, got: {sql}"
+        );
+    }
+
+    #[test]
+    fn devices_stats_group_by_availability() {
+        let query = "in:devices stats:count() as count by is_available";
+        let plan = plan_for(query);
+
+        let (sql, _) = devices::to_sql_and_params(&plan).expect("should build grouped stats SQL");
+        let lower = sql.to_lowercase();
+        assert!(
+            lower.contains("is_available"),
+            "expected is_available column in SQL, got: {sql}"
+        );
+    }
+
+    #[test]
+    fn devices_stats_group_by_with_filter() {
+        let query = "in:devices vendor_name:Cisco stats:count() as count by type";
+        let plan = plan_for(query);
+
+        let (sql, params) = devices::to_sql_and_params(&plan).expect("should build filtered grouped stats SQL");
+        let lower = sql.to_lowercase();
+        assert!(
+            lower.contains("where") && lower.contains("device_type"),
+            "expected WHERE clause with filter in SQL, got: {sql}"
+        );
+        assert!(
+            lower.contains("group by"),
+            "expected GROUP BY in SQL, got: {sql}"
+        );
+        assert_eq!(params.len(), 1, "should have one param for vendor_name filter");
+    }
+
+    #[test]
+    fn devices_stats_group_by_unsupported_field_returns_error() {
+        let query = "in:devices stats:count() as count by hostname";
+        let plan = plan_for(query);
+
+        let result = devices::to_sql_and_params(&plan);
+        assert!(result.is_err(), "grouping by hostname should fail");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported"),
+            "error should mention unsupported field, got: {err}"
+        );
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/rust/srql/src/query/mod.rs
+++ b/rust/srql/src/query/mod.rs
@@ -1036,12 +1036,12 @@ mod tests {
         let (sql, params) = devices::to_sql_and_params(&plan).expect("should build filtered grouped stats SQL");
         let lower = sql.to_lowercase();
         assert!(
-            lower.contains("where") && lower.contains("device_type"),
-            "expected WHERE clause with filter in SQL, got: {sql}"
+            lower.contains("where") && lower.contains("vendor_name"),
+            "expected WHERE clause with vendor_name filter in SQL, got: {sql}"
         );
         assert!(
-            lower.contains("group by"),
-            "expected GROUP BY in SQL, got: {sql}"
+            lower.contains("group by") && lower.contains("coalesce(type"),
+            "expected GROUP BY with type column in SQL, got: {sql}"
         );
         assert_eq!(params.len(), 1, "should have one param for vendor_name filter");
     }

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -5,6 +5,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   import Ash.Expr
 
   require Ash.Query
+  require Logger
 
   alias ServiceRadarWebNGWeb.SRQL.Page, as: SRQLPage
   alias ServiceRadar.Inventory.Device
@@ -1215,7 +1216,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
         <!-- Availability -->
         <.link
-          navigate={~p"/devices?q=in:devices is_available:false"}
+          navigate={~p"/devices?q=in:devices is_available:true"}
           class="block group"
         >
           <div class={[
@@ -1249,7 +1250,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
           title="By Type"
           items={@by_type}
           icon="hero-cpu-chip"
-          filter_field="type_id"
+          filter_field="type"
           empty_text="No type data"
         />
 
@@ -1277,11 +1278,20 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     top_item = List.first(items)
     other_count = items |> Enum.drop(1) |> Enum.reduce(0, fn %{count: c}, acc -> acc + c end)
 
+    # Build the link for the top item (skip "Unknown" since we can't filter NULL values)
+    top_item_link =
+      if top_item && top_item.name != "Unknown" do
+        "/devices?q=" <> URI.encode("in:devices #{assigns.filter_field}:\"#{top_item.name}\"")
+      else
+        nil
+      end
+
     assigns =
       assigns
       |> assign(:top_item, top_item)
       |> assign(:other_count, other_count)
       |> assign(:item_count, length(items))
+      |> assign(:top_item_link, top_item_link)
 
     ~H"""
     <div class="rounded-xl border border-base-200 bg-base-100 p-4 hover:shadow-md transition-shadow">
@@ -1290,19 +1300,37 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
           <.icon name={@icon} class="size-5 text-info" />
         </div>
         <div class="flex-1 min-w-0">
-          <div :if={@top_item} class="flex items-baseline gap-1">
-            <span class="text-lg font-bold text-base-content truncate max-w-[8rem]" title={@top_item.name}>
-              {@top_item.name}
-            </span>
-            <span class="text-sm text-base-content/60">({@top_item.count})</span>
+          <!-- Clickable top item (when not "Unknown") -->
+          <.link :if={@top_item && @top_item_link} navigate={@top_item_link} class="block group cursor-pointer">
+            <div class="flex items-baseline gap-1">
+              <span class="text-lg font-bold text-base-content truncate max-w-[8rem] group-hover:text-primary transition-colors" title={@top_item.name}>
+                {@top_item.name}
+              </span>
+              <span class="text-sm text-base-content/60">({@top_item.count})</span>
+            </div>
+            <div class="text-xs text-base-content/60">
+              {@title}
+              <span :if={@other_count > 0} class="text-base-content/40">
+                · +{@item_count - 1} more
+              </span>
+            </div>
+          </.link>
+          <!-- Non-clickable top item (for "Unknown" values) -->
+          <div :if={@top_item && @top_item_link == nil}>
+            <div class="flex items-baseline gap-1">
+              <span class="text-lg font-bold text-base-content truncate max-w-[8rem]" title={@top_item.name}>
+                {@top_item.name}
+              </span>
+              <span class="text-sm text-base-content/60">({@top_item.count})</span>
+            </div>
+            <div class="text-xs text-base-content/60">
+              {@title}
+              <span :if={@other_count > 0} class="text-base-content/40">
+                · +{@item_count - 1} more
+              </span>
+            </div>
           </div>
           <div :if={@top_item == nil} class="text-sm text-base-content/40">{@empty_text}</div>
-          <div class="text-xs text-base-content/60">
-            {@title}
-            <span :if={@other_count > 0} class="text-base-content/40">
-              · +{@item_count - 1} more
-            </span>
-          </div>
         </div>
         <div :if={@items != []} class="dropdown dropdown-end">
           <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-circle">
@@ -1311,13 +1339,20 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
           <ul tabindex="0" class="dropdown-content z-50 menu p-2 shadow-lg bg-base-100 rounded-lg w-52 border border-base-200">
             <%= for item <- Enum.take(@items, 10) do %>
               <li>
-                <.link
-                  navigate={"/devices?q=" <> URI.encode("in:devices #{@filter_field}:\"#{item.name}\"")}
-                  class="flex justify-between text-sm"
-                >
-                  <span class="truncate">{item.name}</span>
-                  <span class="badge badge-sm badge-ghost">{item.count}</span>
-                </.link>
+                <%= if item.name == "Unknown" do %>
+                  <span class="flex justify-between text-sm text-base-content/50 cursor-not-allowed">
+                    <span class="truncate">{item.name}</span>
+                    <span class="badge badge-sm badge-ghost">{item.count}</span>
+                  </span>
+                <% else %>
+                  <.link
+                    navigate={"/devices?q=" <> URI.encode("in:devices #{@filter_field}:\"#{item.name}\"")}
+                    class="flex justify-between text-sm"
+                  >
+                    <span class="truncate">{item.name}</span>
+                    <span class="badge badge-sm badge-ghost">{item.count}</span>
+                  </.link>
+                <% end %>
               </li>
             <% end %>
           </ul>
@@ -1951,21 +1986,39 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
         timeout: 10_000
       )
       |> Enum.reduce(%{}, fn
-        {:ok, {key, {:ok, result}}}, acc -> Map.put(acc, key, result)
-        {:ok, {key, result}}, acc -> Map.put(acc, key, result)
-        _, acc -> acc
+        {:ok, {key, {:ok, result}}}, acc ->
+          Map.put(acc, key, result)
+
+        {:ok, {key, {:error, reason}}}, acc ->
+          Logger.warning("Device stats query #{key} failed: #{inspect(reason)}")
+          acc
+
+        {:exit, reason}, acc ->
+          Logger.warning("Device stats query task exited: #{inspect(reason)}")
+          acc
+
+        other, acc ->
+          Logger.debug("Device stats unexpected result: #{inspect(other)}")
+          acc
       end)
 
-    %{
-      total: extract_stats_count(results[:total]),
-      available: extract_stats_count(results[:available]),
-      unavailable: extract_stats_count(results[:unavailable]),
+    Logger.debug("Device stats raw results: #{inspect(results, limit: 500)}")
+
+    stats = %{
+      total: extract_stats_count(results[:total], "total"),
+      available: extract_stats_count(results[:available], "count"),
+      unavailable: extract_stats_count(results[:unavailable], "count"),
       by_type: extract_grouped_stats(results[:by_type], "type"),
       by_vendor: extract_grouped_stats(results[:by_vendor], "vendor_name"),
       by_risk_level: extract_grouped_stats(results[:by_risk_level], "risk_level")
     }
+
+    Logger.debug("Device stats parsed: #{inspect(stats)}")
+    stats
   rescue
-    _ ->
+    e ->
+      Logger.error("Device stats loading failed: #{inspect(e)}")
+
       %{
         total: 0,
         available: 0,
@@ -1976,43 +2029,79 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
       }
   end
 
-  defp extract_stats_count({:ok, %{"results" => [%{"total" => count} | _]}})
-       when is_integer(count),
-       do: count
-
-  defp extract_stats_count({:ok, %{"results" => [%{"count" => count} | _]}})
-       when is_integer(count),
-       do: count
-
-  defp extract_stats_count(%{"results" => [%{"total" => count} | _]}) when is_integer(count),
-    do: count
-
-  defp extract_stats_count(%{"results" => [%{"count" => count} | _]}) when is_integer(count),
-    do: count
-
-  defp extract_stats_count(_), do: 0
-
-  defp extract_grouped_stats({:ok, %{"results" => results}}, field) when is_list(results) do
-    extract_grouped_stats_list(results, field)
+  # Handle map result (multiple columns): {"results": [{"total": 123}]}
+  defp extract_stats_count(%{"results" => [row | _]}, field) when is_map(row) do
+    value = Map.get(row, field) || Map.get(row, "count") || Map.get(row, "total")
+    to_stats_int(value)
   end
+
+  # Handle single value result (single column): {"results": [123]}
+  defp extract_stats_count(%{"results" => [value | _]}, _field) when not is_map(value) do
+    to_stats_int(value)
+  end
+
+  # Handle payload column (grouped stats): {"results": [%{"payload" => %{...}}]}
+  defp extract_stats_count(%{"results" => [%{"payload" => payload} | _]}, field)
+       when is_map(payload) do
+    value = Map.get(payload, field) || Map.get(payload, "count") || Map.get(payload, "total")
+    to_stats_int(value)
+  end
+
+  defp extract_stats_count(%{"results" => []}, _field), do: 0
+  defp extract_stats_count(nil, _field), do: 0
+  defp extract_stats_count(result, field) do
+    Logger.warning("Unexpected stats count result format: #{inspect(result)}, field: #{field}")
+    0
+  end
+
+  defp to_stats_int(nil), do: 0
+  defp to_stats_int(value) when is_integer(value), do: value
+  defp to_stats_int(value) when is_float(value), do: trunc(value)
+  defp to_stats_int(%Decimal{} = value), do: Decimal.to_integer(value)
+
+  defp to_stats_int(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {parsed, _} -> parsed
+      :error -> 0
+    end
+  end
+
+  defp to_stats_int(_), do: 0
 
   defp extract_grouped_stats(%{"results" => results}, field) when is_list(results) do
+    Logger.debug("Extracting grouped stats for field '#{field}' from #{inspect(results, limit: 200)}")
     extract_grouped_stats_list(results, field)
   end
 
-  defp extract_grouped_stats(_, _), do: []
+  defp extract_grouped_stats(nil, _field), do: []
+
+  defp extract_grouped_stats(result, field) do
+    Logger.warning("Unexpected grouped stats result format: #{inspect(result)}, field: #{field}")
+    []
+  end
 
   defp extract_grouped_stats_list(results, field) do
-    results
-    |> Enum.filter(&is_map/1)
-    |> Enum.map(fn row ->
-      %{
-        name: Map.get(row, field) || "Unknown",
-        count: Map.get(row, "count") || 0
-      }
-    end)
-    |> Enum.filter(fn %{count: count} -> count > 0 end)
-    |> Enum.sort_by(fn %{count: count} -> -count end)
+    items =
+      results
+      |> Enum.filter(&is_map/1)
+      |> Enum.map(fn row ->
+        # Handle both direct field and nested payload
+        data = Map.get(row, "payload", row)
+
+        %{
+          name: to_string(Map.get(data, field) || "Unknown"),
+          count: to_stats_int(Map.get(data, "count") || 0)
+        }
+      end)
+      |> Enum.filter(fn %{count: count} -> count > 0 end)
+
+    # Separate known values from "Unknown" - show known types first
+    {known, unknown} = Enum.split_with(items, fn %{name: name} -> name != "Unknown" end)
+
+    known_sorted = Enum.sort_by(known, fn %{count: count} -> -count end)
+    unknown_sorted = Enum.sort_by(unknown, fn %{count: count} -> -count end)
+
+    (known_sorted ++ unknown_sorted)
     |> Enum.take(10)
   end
 

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -36,6 +36,16 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
      |> assign(:limit, @default_limit)
      |> assign(:total_device_count, nil)
      |> assign(:current_page, 1)
+     # Device stats for cards
+     |> assign(:device_stats, %{
+       total: 0,
+       available: 0,
+       unavailable: 0,
+       by_type: [],
+       by_vendor: [],
+       by_risk_level: []
+     })
+     |> assign(:device_stats_loading, true)
      # Bulk selection
      |> assign(:selected_devices, MapSet.new())
      |> assign(:select_all_matching, false)
@@ -85,6 +95,9 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     # Track current page from URL params (default to 1 if not present or no cursor)
     current_page = parse_page_param(params)
 
+    # Load device stats for cards (async to not block page load)
+    device_stats = load_device_stats(srql_module(), scope)
+
     {:noreply,
      assign(socket,
        icmp_sparklines: icmp_sparklines,
@@ -94,7 +107,9 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
        sysmon_profiles_by_device: sysmon_profiles_by_device,
        default_sysmon_profile: default_sysmon_profile,
        total_device_count: total_device_count,
-       current_page: current_page
+       current_page: current_page,
+       device_stats: device_stats,
+       device_stats_loading: false
      )}
   end
 
@@ -550,7 +565,13 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
             </.link>
           </div>
         </div>
-        
+
+    <!-- Device Stats Cards -->
+        <.device_stats_cards
+          stats={@device_stats}
+          loading={@device_stats_loading}
+        />
+
     <!-- Quick Filters -->
         <div class="mb-4 flex flex-wrap items-center gap-2">
           <span class="text-xs font-medium text-base-content/60 mr-1">Quick filters:</span>
@@ -1127,6 +1148,200 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
       </form>
     </dialog>
     """
+  end
+
+  # Device Stats Cards Component
+  attr :stats, :map, required: true
+  attr :loading, :boolean, default: false
+
+  def device_stats_cards(assigns) do
+    stats = assigns.stats || %{}
+    total = Map.get(stats, :total, 0)
+    available = Map.get(stats, :available, 0)
+    unavailable = Map.get(stats, :unavailable, 0)
+    by_type = Map.get(stats, :by_type, [])
+    by_vendor = Map.get(stats, :by_vendor, [])
+    by_risk_level = Map.get(stats, :by_risk_level, [])
+
+    # Get top items for display
+    top_type = List.first(by_type)
+    top_vendor = List.first(by_vendor)
+
+    assigns =
+      assigns
+      |> assign(:total, total)
+      |> assign(:available, available)
+      |> assign(:unavailable, unavailable)
+      |> assign(:by_type, by_type)
+      |> assign(:by_vendor, by_vendor)
+      |> assign(:by_risk_level, by_risk_level)
+      |> assign(:top_type, top_type)
+      |> assign(:top_vendor, top_vendor)
+
+    ~H"""
+    <div class="mb-6">
+      <div :if={@loading} class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div class="rounded-xl border border-base-200 bg-base-100 p-4 h-24 animate-pulse">
+          <div class="h-4 bg-base-200 rounded w-1/2 mb-2" />
+          <div class="h-6 bg-base-200 rounded w-3/4" />
+        </div>
+        <div class="rounded-xl border border-base-200 bg-base-100 p-4 h-24 animate-pulse">
+          <div class="h-4 bg-base-200 rounded w-1/2 mb-2" />
+          <div class="h-6 bg-base-200 rounded w-3/4" />
+        </div>
+        <div class="rounded-xl border border-base-200 bg-base-100 p-4 h-24 animate-pulse">
+          <div class="h-4 bg-base-200 rounded w-1/2 mb-2" />
+          <div class="h-6 bg-base-200 rounded w-3/4" />
+        </div>
+        <div class="rounded-xl border border-base-200 bg-base-100 p-4 h-24 animate-pulse">
+          <div class="h-4 bg-base-200 rounded w-1/2 mb-2" />
+          <div class="h-6 bg-base-200 rounded w-3/4" />
+        </div>
+      </div>
+
+      <div :if={not @loading} class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <!-- Total Devices -->
+        <.link navigate={~p"/devices"} class="block group">
+          <div class="rounded-xl border border-base-200 bg-base-100 p-4 hover:shadow-md transition-shadow cursor-pointer flex items-center gap-3">
+            <div class="p-2.5 rounded-lg bg-primary/10">
+              <.icon name="hero-server" class="size-5 text-primary" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="text-xl font-bold text-base-content">{format_stat_number(@total)}</div>
+              <div class="text-xs text-base-content/60">Total Devices</div>
+            </div>
+          </div>
+        </.link>
+
+        <!-- Availability -->
+        <.link
+          navigate={~p"/devices?q=in:devices is_available:false"}
+          class="block group"
+        >
+          <div class={[
+            "rounded-xl border p-4 hover:shadow-md transition-shadow cursor-pointer flex items-center gap-3",
+            if(@unavailable > 0, do: "border-error/30 bg-error/5", else: "border-success/30 bg-success/5")
+          ]}>
+            <div class={["p-2.5 rounded-lg", if(@unavailable > 0, do: "bg-error/10", else: "bg-success/10")]}>
+              <.icon
+                name={if(@unavailable > 0, do: "hero-signal-slash", else: "hero-signal")}
+                class={["size-5", if(@unavailable > 0, do: "text-error", else: "text-success")]}
+              />
+            </div>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-1">
+                <span class={["text-xl font-bold", if(@unavailable > 0, do: "text-error", else: "text-success")]}>
+                  {format_stat_number(@available)}
+                </span>
+                <span :if={@unavailable > 0} class="text-sm text-error/80">
+                  / {format_stat_number(@unavailable)} offline
+                </span>
+              </div>
+              <div class="text-xs text-base-content/60">
+                {if @unavailable == 0, do: "All Online", else: "Available"}
+              </div>
+            </div>
+          </div>
+        </.link>
+
+        <!-- Top Device Type -->
+        <.device_breakdown_card
+          title="By Type"
+          items={@by_type}
+          icon="hero-cpu-chip"
+          filter_field="type_id"
+          empty_text="No type data"
+        />
+
+        <!-- Top Vendor -->
+        <.device_breakdown_card
+          title="By Vendor"
+          items={@by_vendor}
+          icon="hero-building-office"
+          filter_field="vendor_name"
+          empty_text="No vendor data"
+        />
+      </div>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :items, :list, required: true
+  attr :icon, :string, required: true
+  attr :filter_field, :string, required: true
+  attr :empty_text, :string, default: "No data"
+
+  defp device_breakdown_card(assigns) do
+    items = assigns.items || []
+    top_item = List.first(items)
+    other_count = items |> Enum.drop(1) |> Enum.reduce(0, fn %{count: c}, acc -> acc + c end)
+
+    assigns =
+      assigns
+      |> assign(:top_item, top_item)
+      |> assign(:other_count, other_count)
+      |> assign(:item_count, length(items))
+
+    ~H"""
+    <div class="rounded-xl border border-base-200 bg-base-100 p-4 hover:shadow-md transition-shadow">
+      <div class="flex items-center gap-3">
+        <div class="p-2.5 rounded-lg bg-info/10">
+          <.icon name={@icon} class="size-5 text-info" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <div :if={@top_item} class="flex items-baseline gap-1">
+            <span class="text-lg font-bold text-base-content truncate max-w-[8rem]" title={@top_item.name}>
+              {@top_item.name}
+            </span>
+            <span class="text-sm text-base-content/60">({@top_item.count})</span>
+          </div>
+          <div :if={@top_item == nil} class="text-sm text-base-content/40">{@empty_text}</div>
+          <div class="text-xs text-base-content/60">
+            {@title}
+            <span :if={@other_count > 0} class="text-base-content/40">
+              · +{@item_count - 1} more
+            </span>
+          </div>
+        </div>
+        <div :if={@items != []} class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-circle">
+            <.icon name="hero-chevron-down" class="size-3" />
+          </div>
+          <ul tabindex="0" class="dropdown-content z-50 menu p-2 shadow-lg bg-base-100 rounded-lg w-52 border border-base-200">
+            <%= for item <- Enum.take(@items, 10) do %>
+              <li>
+                <.link
+                  navigate={"/devices?q=" <> URI.encode("in:devices #{@filter_field}:\"#{item.name}\"")}
+                  class="flex justify-between text-sm"
+                >
+                  <span class="truncate">{item.name}</span>
+                  <span class="badge badge-sm badge-ghost">{item.count}</span>
+                </.link>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp format_stat_number(n) when is_integer(n) and n >= 1000 do
+    n |> Integer.to_string() |> add_stat_commas()
+  end
+
+  defp format_stat_number(n) when is_integer(n), do: Integer.to_string(n)
+  defp format_stat_number(n) when is_float(n), do: n |> trunc() |> format_stat_number()
+  defp format_stat_number(_), do: "0"
+
+  defp add_stat_commas(str) do
+    str
+    |> String.reverse()
+    |> String.graphemes()
+    |> Enum.chunk_every(3)
+    |> Enum.join(",")
+    |> String.reverse()
   end
 
   attr :available, :any, default: nil
@@ -1715,6 +1930,90 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
   defp srql_module do
     Application.get_env(:serviceradar_web_ng, :srql_module, ServiceRadarWebNG.SRQL)
+  end
+
+  # Load device stats for cards using SRQL GROUP BY queries
+  defp load_device_stats(srql_module, scope) do
+    queries = %{
+      total: ~s|in:devices stats:"count() as total"|,
+      available: ~s|in:devices is_available:true stats:"count() as count"|,
+      unavailable: ~s|in:devices is_available:false stats:"count() as count"|,
+      by_type: ~s|in:devices stats:count() as count by type|,
+      by_vendor: ~s|in:devices stats:count() as count by vendor_name|,
+      by_risk_level: ~s|in:devices stats:count() as count by risk_level|
+    }
+
+    results =
+      queries
+      |> Task.async_stream(
+        fn {key, query} -> {key, srql_module.query(query, %{scope: scope})} end,
+        ordered: false,
+        timeout: 10_000
+      )
+      |> Enum.reduce(%{}, fn
+        {:ok, {key, {:ok, result}}}, acc -> Map.put(acc, key, result)
+        {:ok, {key, result}}, acc -> Map.put(acc, key, result)
+        _, acc -> acc
+      end)
+
+    %{
+      total: extract_stats_count(results[:total]),
+      available: extract_stats_count(results[:available]),
+      unavailable: extract_stats_count(results[:unavailable]),
+      by_type: extract_grouped_stats(results[:by_type], "type"),
+      by_vendor: extract_grouped_stats(results[:by_vendor], "vendor_name"),
+      by_risk_level: extract_grouped_stats(results[:by_risk_level], "risk_level")
+    }
+  rescue
+    _ ->
+      %{
+        total: 0,
+        available: 0,
+        unavailable: 0,
+        by_type: [],
+        by_vendor: [],
+        by_risk_level: []
+      }
+  end
+
+  defp extract_stats_count({:ok, %{"results" => [%{"total" => count} | _]}})
+       when is_integer(count),
+       do: count
+
+  defp extract_stats_count({:ok, %{"results" => [%{"count" => count} | _]}})
+       when is_integer(count),
+       do: count
+
+  defp extract_stats_count(%{"results" => [%{"total" => count} | _]}) when is_integer(count),
+    do: count
+
+  defp extract_stats_count(%{"results" => [%{"count" => count} | _]}) when is_integer(count),
+    do: count
+
+  defp extract_stats_count(_), do: 0
+
+  defp extract_grouped_stats({:ok, %{"results" => results}}, field) when is_list(results) do
+    extract_grouped_stats_list(results, field)
+  end
+
+  defp extract_grouped_stats(%{"results" => results}, field) when is_list(results) do
+    extract_grouped_stats_list(results, field)
+  end
+
+  defp extract_grouped_stats(_, _), do: []
+
+  defp extract_grouped_stats_list(results, field) do
+    results
+    |> Enum.filter(&is_map/1)
+    |> Enum.map(fn row ->
+      %{
+        name: Map.get(row, field) || "Unknown",
+        count: Map.get(row, "count") || 0
+      }
+    end)
+    |> Enum.filter(fn %{count: count} -> count > 0 end)
+    |> Enum.sort_by(fn %{count: count} -> -count end)
+    |> Enum.take(10)
   end
 
   defp get_total_matching_count(scope, query) do

--- a/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
@@ -21,6 +21,8 @@ defmodule ServiceRadarWebNGWeb.SRQL.Catalog do
         "is_compliant",
         "is_trusted",
         "type_id",
+        "type",
+        "vendor_name",
         "discovery_sources",
         "tags"
       ],

--- a/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
@@ -25,6 +25,8 @@ defmodule ServiceRadarWebNGWeb.SRQL.Catalog do
         "tags"
       ],
       boolean_fields: ["is_available", "is_managed", "is_compliant", "is_trusted"],
+      # Fields that support GROUP BY in stats queries (stats:count() as count by <field>)
+      stats_fields: ["type", "vendor_name", "risk_level", "is_available", "gateway_id"],
       downsample: false
     },
     %{


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add SRQL GROUP BY support for device stats queries (type, vendor_name, risk_level, is_available, gateway_id)

- Implement device stats cards component displaying total, available, unavailable, and distribution metrics

- Load stats asynchronously via parallel SRQL queries with skeleton loading state

- Make stats cards clickable to filter devices table by availability and other dimensions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Parser["SRQL Parser<br/>Handle 'by field' syntax"]
  DeviceRS["devices.rs<br/>Build grouped stats SQL"]
  Catalog["SRQL Catalog<br/>Define stats_fields"]
  LiveView["Device LiveView<br/>Load stats async"]
  Component["Stats Cards<br/>Display & filter"]
  
  Parser -->|Parse GROUP BY| DeviceRS
  DeviceRS -->|Execute queries| Catalog
  Catalog -->|Query via NIF| LiveView
  LiveView -->|Render component| Component
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>parser.rs</strong><dd><code>Add GROUP BY clause parsing to stats syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-b2edf55d1721185349ecddb2f4eacc42e0dfcae19b6c2bc638602f187da67e66">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>devices.rs</strong><dd><code>Implement grouped stats queries with raw SQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-3202f22fff6863ed7848a129c49e2323322462b379d896d3fca2e59aa6f7b4c5">+384/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ex</strong><dd><code>Add stats cards component and async loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-261a01f4876e5984e1d9e9b38a3540675dfb0272abc30e6bdb2a4fa610353cc7">+301/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Add tests for devices GROUP BY queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-393e3fa3d0e41741834cd7cd398a06111ab7b141ae6caca7a5dcc0e036172491">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>catalog.ex</strong><dd><code>Define stats_fields for device grouping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-80c07c25c17e48bf86860ec91db10256b7700a863d5371798e1893e741dc0e15">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>proposal.md</strong><dd><code>Document feature proposal and scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-fcf6422f2f4757f42bed94091e829e40f000a45e471408b95cfffdd95a33c371">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong><dd><code>Detail implementation decisions and patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-155ffcba16864987c78fe6550405a60a8cbb7711b64019777c006e575e92484b">+181/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Define device dashboard stats requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-5e129a20a595879416ca99e82ef323a4fd8acac347d23f9debab246eae446e59">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Define SRQL GROUP BY query requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-57d87294b315fcff9ecd45bc2b643a0dd7e898a4520364f7d3dbe5ea5dbff9dd">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong><dd><code>Track implementation tasks and checklist</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2352/files#diff-7ab7b48288c3779b58840375cfd7ab35eaf0a8b82ba61d86197143e8b5e96b2f">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

