### PR TITLE
2339 buglogs lost otel log formatschema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,4 @@ When you're done executing code, try to compile the code, and check the logs or 
 
 ## Tools
 
-Use Tidewave MCP tools, as they let you interrogate the running application in various useful ways.
-- Use the `project_eval` tool to execute code in the running instance of the application. Eval `h Module.fun` to get documentation for a module or function.
-- Always use `search_package_docs` to find relevant documentation before beginning work.
+Tidewave MCP tools are optional and may not always be available. Use them when present for deeper inspection, but proceed without them when unavailable.

--- a/cmd/consumers/zen/src/integration_tests.rs
+++ b/cmd/consumers/zen/src/integration_tests.rs
@@ -130,11 +130,14 @@ mod tests {
         assert_eq!(result["severity_number"], 13);
         assert_eq!(result["severity_text"], "WARN");
         assert_eq!(result["body"], "This is a warning message from OTEL");
-        assert_eq!(result["scope"], "my-instrumentation");
+        assert_eq!(result["scope_name"], "my-instrumentation");
+        assert_eq!(result["scope_version"], "1.0.0");
 
         // Check resource attributes
-        assert_eq!(result["resource"]["service.name"], "my-service");
-        assert_eq!(result["resource"]["service.version"], "1.0.0");
+        assert_eq!(result["resource_attributes"]["service.name"], "my-service");
+        assert_eq!(result["resource_attributes"]["service.version"], "1.0.0");
+        assert_eq!(result["service_name"], "my-service");
+        assert_eq!(result["service_version"], "1.0.0");
 
         // Check log attributes
         assert_eq!(result["attributes"]["http.method"], "GET");

--- a/cmd/consumers/zen/src/otel_logs.rs
+++ b/cmd/consumers/zen/src/otel_logs.rs
@@ -1,5 +1,6 @@
 use prost::Message;
 use serde_json::{json, Value};
+use std::fmt::Write;
 
 // Include the generated protobuf code
 pub mod opentelemetry {
@@ -43,21 +44,62 @@ pub fn otel_logs_to_json(data: &[u8]) -> anyhow::Result<Value> {
             .map(|r| attributes_to_json(&r.attributes))
             .unwrap_or_default();
 
+        let service_name = get_attr_string(&resource_attrs, "service.name");
+        let service_version = get_attr_string(&resource_attrs, "service.version");
+        let service_instance = get_attr_string(&resource_attrs, "service.instance.id");
+
         for scope_logs in resource_logs.scope_logs {
             let scope_name = scope_logs
                 .scope
                 .as_ref()
                 .map(|s| s.name.clone())
                 .unwrap_or_default();
+            let scope_version = scope_logs
+                .scope
+                .as_ref()
+                .map(|s| s.version.clone())
+                .unwrap_or_default();
 
             for log_record in scope_logs.log_records {
+                let timestamp = if log_record.time_unix_nano > 0 {
+                    log_record.time_unix_nano
+                } else {
+                    log_record.observed_time_unix_nano
+                };
+
                 let mut log_json = json!({
-                    "timestamp": log_record.time_unix_nano,
+                    "timestamp": timestamp,
                     "severity_number": log_record.severity_number,
                     "severity_text": log_record.severity_text,
-                    "resource": resource_attrs.clone(),
-                    "scope": scope_name.clone(),
+                    "resource_attributes": resource_attrs.clone(),
                 });
+
+                log_json["resource"] = resource_attrs.clone();
+
+                if !service_name.is_empty() {
+                    log_json["service_name"] = json!(service_name);
+                }
+                if !service_version.is_empty() {
+                    log_json["service_version"] = json!(service_version);
+                }
+                if !service_instance.is_empty() {
+                    log_json["service_instance"] = json!(service_instance);
+                }
+
+                if !scope_name.is_empty() {
+                    log_json["scope_name"] = json!(scope_name);
+                    log_json["scope"] = json!(scope_name);
+                }
+                if !scope_version.is_empty() {
+                    log_json["scope_version"] = json!(scope_version);
+                }
+
+                if let Some(trace_id) = bytes_to_hex(&log_record.trace_id) {
+                    log_json["trace_id"] = json!(trace_id);
+                }
+                if let Some(span_id) = bytes_to_hex(&log_record.span_id) {
+                    log_json["span_id"] = json!(span_id);
+                }
 
                 if let Some(body) = log_record.body {
                     log_json["body"] = any_value_to_json(&body);
@@ -88,6 +130,29 @@ fn attributes_to_json(attrs: &[opentelemetry::proto::common::v1::KeyValue]) -> V
         }
     }
     Value::Object(map)
+}
+
+fn get_attr_string(attrs: &Value, key: &str) -> String {
+    match attrs {
+        Value::Object(map) => map
+            .get(key)
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{:02x}", byte);
+    }
+    Some(out)
 }
 
 fn any_value_to_json(value: &opentelemetry::proto::common::v1::AnyValue) -> Value {
@@ -199,8 +264,13 @@ mod tests {
         assert_eq!(result["severity_number"], 9);
         assert_eq!(result["severity_text"], "INFO");
         assert_eq!(result["body"], "Test log message");
-        assert_eq!(result["scope"], "test-scope");
-        assert_eq!(result["resource"]["service.name"], "test-service");
+        assert_eq!(result["scope_name"], "test-scope");
+        assert_eq!(result["scope_version"], "1.0.0");
+        assert_eq!(
+            result["resource_attributes"]["service.name"],
+            "test-service"
+        );
+        assert_eq!(result["service_name"], "test-service");
         assert_eq!(result["attributes"]["service.name"], "test-service");
         assert_eq!(result["attributes"]["log.level"], "info");
     }

--- a/elixir/serviceradar_core/lib/serviceradar/event_writer/processors/logs.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/event_writer/processors/logs.ex
@@ -86,6 +86,10 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
     resource_attributes =
       json
       |> FieldParser.get_field("resource_attributes", "resourceAttributes")
+      |> case do
+        nil -> json["resource"]
+        value -> value
+      end
       |> FieldParser.encode_jsonb()
       |> case do
         nil -> %{}
@@ -93,6 +97,7 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
       end
 
     resource_lookup = resource_attributes
+    {scope_name, scope_version} = parse_scope_fields(json)
 
     %{
       id: log_id,
@@ -111,8 +116,8 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
       service_instance:
         FieldParser.get_field(json, "service_instance", "serviceInstance") ||
           resource_lookup["service.instance.id"],
-      scope_name: FieldParser.get_field(json, "scope_name", "scopeName"),
-      scope_version: FieldParser.get_field(json, "scope_version", "scopeVersion"),
+      scope_name: scope_name,
+      scope_version: scope_version,
       attributes: attributes,
       resource_attributes: resource_attributes,
       created_at: DateTime.utc_now()
@@ -120,6 +125,34 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
   end
 
   defp parse_json_log(_json, _metadata), do: nil
+
+  defp parse_scope_fields(json) when is_map(json) do
+    scope_name = FieldParser.get_field(json, "scope_name", "scopeName")
+    scope_version = FieldParser.get_field(json, "scope_version", "scopeVersion")
+
+    case json["scope"] do
+      %{} = scope_map ->
+        scope_name =
+          scope_name ||
+            FieldParser.get_field(scope_map, "name", "scopeName") ||
+            FieldParser.get_field(scope_map, "scope_name", "scopeName")
+
+        scope_version =
+          scope_version ||
+            FieldParser.get_field(scope_map, "version", "scopeVersion") ||
+            FieldParser.get_field(scope_map, "scope_version", "scopeVersion")
+
+        {scope_name, scope_version}
+
+      scope when is_binary(scope) and scope != "" ->
+        {scope_name || scope, scope_version}
+
+      _ ->
+        {scope_name, scope_version}
+    end
+  end
+
+  defp parse_scope_fields(_), do: {nil, nil}
 
   defp parse_protobuf_log(data, metadata) do
     case decode_export_logs(data) do

--- a/elixir/serviceradar_core/lib/serviceradar/event_writer/processors/logs.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/event_writer/processors/logs.ex
@@ -83,20 +83,7 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
     log_id = Ash.UUID.generate()
     attributes = FieldParser.encode_jsonb(json["attributes"]) || %{}
     attributes = attach_ingest_metadata(attributes, metadata)
-    resource_attributes =
-      json
-      |> FieldParser.get_field("resource_attributes", "resourceAttributes")
-      |> case do
-        nil -> json["resource"]
-        value -> value
-      end
-      |> FieldParser.encode_jsonb()
-      |> case do
-        nil -> %{}
-        value -> value
-      end
-
-    resource_lookup = resource_attributes
+    resource_attributes = normalize_resource_attributes(json)
     {scope_name, scope_version} = parse_scope_fields(json)
 
     %{
@@ -105,17 +92,22 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
       trace_id: FieldParser.get_field(json, "trace_id", "traceId"),
       span_id: FieldParser.get_field(json, "span_id", "spanId"),
       severity_text: FieldParser.get_field(json, "severity_text", "severityText") || json["level"],
-      severity_number: FieldParser.safe_bigint(FieldParser.get_field(json, "severity_number", "severityNumber")),
+      severity_number:
+        json
+        |> FieldParser.get_field("severity_number", "severityNumber")
+        |> FieldParser.safe_bigint(),
       body: extract_body(json),
-      service_name:
-        FieldParser.get_field(json, "service_name", "serviceName") ||
-          resource_lookup["service.name"],
+      service_name: service_field(json, resource_attributes, "service_name", "serviceName", "service.name"),
       service_version:
-        FieldParser.get_field(json, "service_version", "serviceVersion") ||
-          resource_lookup["service.version"],
+        service_field(json, resource_attributes, "service_version", "serviceVersion", "service.version"),
       service_instance:
-        FieldParser.get_field(json, "service_instance", "serviceInstance") ||
-          resource_lookup["service.instance.id"],
+        service_field(
+          json,
+          resource_attributes,
+          "service_instance",
+          "serviceInstance",
+          "service.instance.id"
+        ),
       scope_name: scope_name,
       scope_version: scope_version,
       attributes: attributes,
@@ -130,29 +122,49 @@ defmodule ServiceRadar.EventWriter.Processors.Logs do
     scope_name = FieldParser.get_field(json, "scope_name", "scopeName")
     scope_version = FieldParser.get_field(json, "scope_version", "scopeVersion")
 
-    case json["scope"] do
-      %{} = scope_map ->
-        scope_name =
-          scope_name ||
-            FieldParser.get_field(scope_map, "name", "scopeName") ||
-            FieldParser.get_field(scope_map, "scope_name", "scopeName")
-
-        scope_version =
-          scope_version ||
-            FieldParser.get_field(scope_map, "version", "scopeVersion") ||
-            FieldParser.get_field(scope_map, "scope_version", "scopeVersion")
-
-        {scope_name, scope_version}
-
-      scope when is_binary(scope) and scope != "" ->
-        {scope_name || scope, scope_version}
-
-      _ ->
-        {scope_name, scope_version}
-    end
+    json["scope"]
+    |> merge_scope_fields(scope_name, scope_version)
   end
 
   defp parse_scope_fields(_), do: {nil, nil}
+
+  defp normalize_resource_attributes(json) do
+    json
+    |> resource_attributes_source()
+    |> FieldParser.encode_jsonb()
+    |> case do
+      nil -> %{}
+      value -> value
+    end
+  end
+
+  defp resource_attributes_source(json) do
+    FieldParser.get_field(json, "resource_attributes", "resourceAttributes") || json["resource"]
+  end
+
+  defp service_field(json, resource_attributes, snake_key, camel_key, resource_key) do
+    FieldParser.get_field(json, snake_key, camel_key) || resource_attributes[resource_key]
+  end
+
+  defp merge_scope_fields(%{} = scope_map, scope_name, scope_version) do
+    scope_name =
+      scope_name ||
+        FieldParser.get_field(scope_map, "name", "scopeName") ||
+        FieldParser.get_field(scope_map, "scope_name", "scopeName")
+
+    scope_version =
+      scope_version ||
+        FieldParser.get_field(scope_map, "version", "scopeVersion") ||
+        FieldParser.get_field(scope_map, "scope_version", "scopeVersion")
+
+    {scope_name, scope_version}
+  end
+
+  defp merge_scope_fields(scope, scope_name, scope_version) when is_binary(scope) and scope != "" do
+    {scope_name || scope, scope_version}
+  end
+
+  defp merge_scope_fields(_, scope_name, scope_version), do: {scope_name, scope_version}
 
   defp parse_protobuf_log(data, metadata) do
     case decode_export_logs(data) do

--- a/openspec/changes/restore-otel-log-schema/design.md
+++ b/openspec/changes/restore-otel-log-schema/design.md
@@ -1,0 +1,27 @@
+## Context
+The Logs UI currently presents only a reduced set of fields (Time, Level, Service, Message) and OTEL-specific metadata (resource, scope, attributes, trace/span identifiers) appears missing. This creates inconsistency with OTEL metrics/traces and reduces operator visibility.
+
+## Goals / Non-Goals
+- Goals:
+  - Preserve OTEL log record fields end-to-end for OTEL sources.
+  - Normalize non-OTEL sources into OTEL log records so the UI and queries are consistent.
+  - Surface OTEL fields in the Logs UI detail view.
+- Non-Goals:
+  - Redesigning OCSF event promotion or alerting behavior.
+  - Changing log retention policies.
+
+## Decisions
+- Decision: Treat the OTEL log record schema as the canonical storage/query shape for all log sources.
+- Alternatives considered: Keep source-native schemas and only map in the UI (rejected due to fragmented queries and inconsistent metadata availability).
+
+## Risks / Trade-offs
+- Mapping fidelity: Non-OTEL sources may not have direct equivalents for all OTEL fields; mitigated by explicit mapping rules and preserving raw payload as attributes.
+- UI performance: Showing additional metadata could increase payload size; mitigate with lazy detail loading and selective columns in list views.
+
+## Migration Plan
+- Backfill is optional; prioritize restoring schema for new ingests first.
+- If feasible, provide a one-time backfill job to populate OTEL fields for recent log records.
+
+## Open Questions
+- Should syslog/GELF raw payloads be preserved as OTEL log attributes or retained in a dedicated raw field?
+- Do we require backfill for existing log records to restore UI parity?

--- a/openspec/changes/restore-otel-log-schema/proposal.md
+++ b/openspec/changes/restore-otel-log-schema/proposal.md
@@ -1,0 +1,14 @@
+# Change: Restore OpenTelemetry log schema in observability logs
+
+## Why
+The observability Logs UI no longer shows the expected OTEL log schema/fields and appears to surface only a reduced column set, which breaks troubleshooting workflows and obscures resource/scope metadata.
+
+## What Changes
+- Normalize all ingested log sources (OTEL, syslog, SNMP traps, GELF) into the OTEL log record schema and retain OTEL fields in storage and query results.
+- Restore OTEL log fields in the Logs UI detail view, including resource/scope/attributes and timestamp/severity/body fields.
+- Clarify how non-OTEL sources are mapped into OTEL records for consistency across logs, metrics, and traces.
+
+## Impact
+- Affected specs: observability-signals
+- Affected code: log ingestion pipeline, SRQL/log queries, Logs UI (web-ng)
+- Notes: This is a behavior change to persist and display OTEL schema fields consistently across all log sources.

--- a/openspec/changes/restore-otel-log-schema/specs/observability-signals/spec.md
+++ b/openspec/changes/restore-otel-log-schema/specs/observability-signals/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+### Requirement: Raw logs ingestion
+The system SHALL ingest syslog, SNMP traps, GELF logs, and OTEL logs as OTEL log records with source metadata and tenant scoping. OTEL fields (timestamp, severity, body, resource, scope, attributes, and trace/span identifiers when present) SHALL be preserved in storage and query results.
+
+#### Scenario: SNMP trap stored as OTEL log
+- **WHEN** an SNMP trap is received
+- **THEN** the system SHALL persist the log as an OTEL log record
+- **AND** it SHALL include source metadata and a normalized severity/body
+
+#### Scenario: OTEL log attributes preserved
+- **WHEN** an OTEL log record is ingested
+- **THEN** the system SHALL retain resource attributes, scope attributes, and log attributes
+- **AND** trace/span identifiers SHALL be queryable when present
+
+## ADDED Requirements
+### Requirement: OTEL log schema visibility in the UI
+The Logs UI SHALL surface OTEL log fields in the detail view, including resource attributes, scope information, attributes, and trace/span identifiers when present.
+
+#### Scenario: Log detail shows OTEL metadata
+- **GIVEN** a user opens a log detail view
+- **WHEN** the log record includes OTEL resource/scope/attributes
+- **THEN** the UI SHALL display those OTEL fields alongside time, severity, service, and body

--- a/openspec/changes/restore-otel-log-schema/tasks.md
+++ b/openspec/changes/restore-otel-log-schema/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+- [ ] 1.1 Audit current log ingestion/storage for OTEL schema retention and identify where fields are dropped.
+- [ ] 1.2 Define and implement mapping for syslog/SNMP/GELF into OTEL log record fields (severity, body, resource/scope/attributes).
+- [ ] 1.3 Update log query/SRQL paths to return OTEL fields required by the UI.
+- [ ] 1.4 Update Logs UI to render OTEL schema fields in list/detail views.
+- [ ] 1.5 Add coverage (unit/integration) to verify OTEL fields persist from ingest through UI.

--- a/pkg/consumers/db-event-writer/json_logs.go
+++ b/pkg/consumers/db-event-writer/json_logs.go
@@ -3,7 +3,6 @@ package dbeventwriter
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -22,43 +21,50 @@ const (
 
 //nolint:gochecknoglobals // package-level lookup table for performance
 var jsonLogReservedKeys = map[string]struct{}{
-	"@timestamp":           {},
-	"body":                 {},
-	"event":                {},
-	"host":                 {},
-	"hostname":             {},
-	"ip":                   {},
-	"ip_address":           {},
-	"level":                {},
-	"log":                  {},
-	"message":              {},
-	"msg":                  {},
-	"remote_addr":          {},
-	"scope.name":           {},
-	"scope.version":        {},
-	"scope_name":           {},
-	"scope_version":        {},
-	"service.instance":     {},
-	"service.instance.id":  {},
-	"service.name":         {},
-	"service.version":      {},
-	"service_instance":     {},
-	"service_instance_id":  {},
-	"service_name":         {},
-	"service_version":      {},
-	"severity":             {},
-	"severity_number":      {},
-	"severity_text":        {},
-	"short_message":        {},
-	"source":               {},
-	"span_id":              {},
-	"spanId":               {},
-	"summary":              {},
-	"time":                 {},
-	"timestamp":            {},
-	"trace_id":             {},
-	"traceId":              {},
-	"ts":                   {},
+	"@timestamp":          {},
+	"body":                {},
+	"attributes":          {},
+	"event":               {},
+	"host":                {},
+	"hostname":            {},
+	"ip":                  {},
+	"ip_address":          {},
+	"level":               {},
+	"log":                 {},
+	"message":             {},
+	"msg":                 {},
+	"remote_addr":         {},
+	"resource":            {},
+	"resource_attributes": {},
+	"resourceAttributes":  {},
+	"scope":               {},
+	"scope.name":          {},
+	"scope.version":       {},
+	"scopeName":           {},
+	"scopeVersion":        {},
+	"scope_name":          {},
+	"scope_version":       {},
+	"service.instance":    {},
+	"service.instance.id": {},
+	"service.name":        {},
+	"service.version":     {},
+	"service_instance":    {},
+	"service_instance_id": {},
+	"service_name":        {},
+	"service_version":     {},
+	"severity":            {},
+	"severity_number":     {},
+	"severity_text":       {},
+	"short_message":       {},
+	"source":              {},
+	"span_id":             {},
+	"spanId":              {},
+	"summary":             {},
+	"time":                {},
+	"timestamp":           {},
+	"trace_id":            {},
+	"traceId":             {},
+	"ts":                  {},
 }
 
 func parseJSONLogs(payload []byte, subject string) ([]models.OTELLogRow, bool) {
@@ -105,19 +111,48 @@ func buildJSONLogRow(entry map[string]interface{}, subject string) models.OTELLo
 
 	severityText, severityNumber := normalizeSeverity(entry)
 
-	serviceName := firstString(entry, "service.name", "service_name", "service")
+	resourceMap := extractAttributesMap(entry, "resource_attributes", "resourceAttributes", "resource")
+	resourceAttribs := resourceMap
+	if len(resourceAttribs) == 0 {
+		resourceAttribs = buildResourceAttributesMap(entry)
+	}
+
+	attributesMap := extractAttributesMap(entry, "attributes")
+	extraAttributes := buildAttributesMap(entry, jsonLogReservedKeys)
+	attributesMap = mergeAttributeMaps(attributesMap, extraAttributes)
+
+	serviceName := firstString(entry, "service.name", "service_name", "service", "serviceName")
 	host := firstString(entry, "host", "hostname")
 	if serviceName == "" {
 		serviceName = host
 	}
+	if serviceName == "" {
+		serviceName = firstStringFromMap(resourceAttribs, "service.name", "service_name", "serviceName")
+	}
 
-	serviceVersion := firstString(entry, "service.version", "service_version")
-	serviceInstance := firstString(entry, "service.instance.id", "service_instance", "service_instance_id")
-	scopeName := firstString(entry, "scope.name", "scope_name")
-	scopeVersion := firstString(entry, "scope.version", "scope_version")
+	serviceVersion := firstString(entry, "service.version", "service_version", "serviceVersion")
+	if serviceVersion == "" {
+		serviceVersion = firstStringFromMap(resourceAttribs, "service.version", "service_version", "serviceVersion")
+	}
 
-	attributes := buildAttributes(entry, jsonLogReservedKeys)
-	resourceAttributes := buildResourceAttributes(entry)
+	serviceInstance := firstString(entry, "service.instance.id", "service_instance", "service_instance_id", "serviceInstance")
+	if serviceInstance == "" {
+		serviceInstance = firstStringFromMap(
+			resourceAttribs,
+			"service.instance.id",
+			"service.instance",
+			"service_instance",
+			"service_instance_id",
+			"serviceInstance",
+		)
+	}
+
+	scopeName := firstString(entry, "scope.name", "scope_name", "scopeName")
+	scopeVersion := firstString(entry, "scope.version", "scope_version", "scopeVersion")
+	scopeName, scopeVersion = applyScopeFallbacks(entry, scopeName, scopeVersion)
+
+	attributes := encodeAttributes(attributesMap)
+	resourceAttributes := encodeAttributes(resourceAttribs)
 
 	return models.OTELLogRow{
 		Timestamp:          timestamp,
@@ -136,38 +171,36 @@ func buildJSONLogRow(entry map[string]interface{}, subject string) models.OTELLo
 	}
 }
 
-func buildResourceAttributes(entry map[string]interface{}) string {
+func buildResourceAttributesMap(entry map[string]interface{}) map[string]interface{} {
 	keys := []string{"host", "hostname", "remote_addr", "source", "ip", "ip_address"}
-	pairs := make([]string, 0, len(keys))
+	resource := make(map[string]interface{})
 	for _, key := range keys {
 		value := firstString(entry, key)
 		if value == "" {
 			continue
 		}
 
-		pairs = append(pairs, fmt.Sprintf("%s=%s", key, value))
+		resource[key] = value
 	}
 
-	return strings.Join(pairs, ",")
+	return resource
 }
 
-func buildAttributes(entry map[string]interface{}, reserved map[string]struct{}) string {
-	pairs := make([]string, 0, len(entry))
+func buildAttributesMap(entry map[string]interface{}, reserved map[string]struct{}) map[string]interface{} {
+	attributes := make(map[string]interface{})
 	for key, value := range entry {
 		if _, skip := reserved[key]; skip {
 			continue
 		}
 
-		strValue := stringifyValue(value)
-		if strValue == "" {
+		if isEmptyAttributeValue(value) {
 			continue
 		}
 
-		pairs = append(pairs, fmt.Sprintf("%s=%s", key, strValue))
+		attributes[key] = value
 	}
 
-	sort.Strings(pairs)
-	return strings.Join(pairs, ",")
+	return attributes
 }
 
 func normalizeSeverity(entry map[string]interface{}) (string, int32) {
@@ -388,4 +421,168 @@ func stringifyValue(value interface{}) string {
 		}
 		return string(encoded)
 	}
+}
+
+func extractAttributesMap(entry map[string]interface{}, keys ...string) map[string]interface{} {
+	for _, key := range keys {
+		if value, ok := entry[key]; ok {
+			if parsed := parseAttributeValue(value); len(parsed) > 0 {
+				return parsed
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseAttributeValue(value interface{}) map[string]interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return typed
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return nil
+		}
+
+		var decoded map[string]interface{}
+		if err := json.Unmarshal([]byte(text), &decoded); err == nil {
+			return decoded
+		}
+
+		return parseKeyValueMap(text)
+	default:
+		return nil
+	}
+}
+
+func parseKeyValueMap(text string) map[string]interface{} {
+	parts := strings.Split(text, ",")
+	attributes := make(map[string]interface{})
+	for _, part := range parts {
+		segment := strings.TrimSpace(part)
+		if segment == "" {
+			continue
+		}
+
+		kv := strings.SplitN(segment, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+		if key == "" || value == "" {
+			continue
+		}
+
+		if strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[") {
+			var decoded interface{}
+			if err := json.Unmarshal([]byte(value), &decoded); err == nil {
+				attributes[key] = decoded
+				continue
+			}
+		}
+
+		attributes[key] = value
+	}
+
+	if len(attributes) == 0 {
+		return nil
+	}
+
+	return attributes
+}
+
+func encodeAttributes(attributes map[string]interface{}) string {
+	if len(attributes) == 0 {
+		return ""
+	}
+
+	encoded, err := json.Marshal(attributes)
+	if err != nil {
+		return ""
+	}
+
+	return string(encoded)
+}
+
+func mergeAttributeMaps(base, extra map[string]interface{}) map[string]interface{} {
+	if len(base) == 0 && len(extra) == 0 {
+		return nil
+	}
+
+	merged := make(map[string]interface{})
+	for key, value := range base {
+		merged[key] = value
+	}
+
+	for key, value := range extra {
+		if _, exists := merged[key]; exists {
+			continue
+		}
+		merged[key] = value
+	}
+
+	return merged
+}
+
+func isEmptyAttributeValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(typed) == ""
+	default:
+		return false
+	}
+}
+
+func firstStringFromMap(values map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			if text := stringFromValue(value); text != "" {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func stringFromValue(value interface{}) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func applyScopeFallbacks(entry map[string]interface{}, scopeName, scopeVersion string) (string, string) {
+	if scopeName != "" && scopeVersion != "" {
+		return scopeName, scopeVersion
+	}
+
+	scopeValue, ok := entry["scope"]
+	if !ok {
+		return scopeName, scopeVersion
+	}
+
+	switch typed := scopeValue.(type) {
+	case map[string]interface{}:
+		if scopeName == "" {
+			scopeName = firstStringFromMap(typed, "name", "scope_name", "scopeName")
+		}
+		if scopeVersion == "" {
+			scopeVersion = firstStringFromMap(typed, "version", "scope_version", "scopeVersion")
+		}
+	case string:
+		if scopeName == "" {
+			scopeName = strings.TrimSpace(typed)
+		}
+	}
+
+	return scopeName, scopeVersion
 }

--- a/pkg/consumers/db-event-writer/json_logs.go
+++ b/pkg/consumers/db-event-writer/json_logs.go
@@ -402,27 +402,6 @@ func parseNumeric(value interface{}) (float64, bool) {
 	return 0, false
 }
 
-func stringifyValue(value interface{}) string {
-	switch typed := value.(type) {
-	case nil:
-		return ""
-	case string:
-		return strings.TrimSpace(typed)
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	case json.Number:
-		return typed.String()
-	case bool:
-		return strconv.FormatBool(typed)
-	default:
-		encoded, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Sprint(typed)
-		}
-		return string(encoded)
-	}
-}
-
 func extractAttributesMap(entry map[string]interface{}, keys ...string) map[string]interface{} {
 	for _, key := range keys {
 		if value, ok := entry[key]; ok {

--- a/rust/srql/src/query/alerts.rs
+++ b/rust/srql/src/query/alerts.rs
@@ -86,11 +86,7 @@ fn build_query(plan: &QueryPlan) -> Result<AlertsQuery<'static>> {
 
     // Use triggered_at for time-based filtering (primary timestamp for alerts)
     if let Some(TimeRange { start, end }) = &plan.time_range {
-        query = query.filter(
-            col_triggered_at
-                .ge(*start)
-                .and(col_triggered_at.le(*end)),
-        );
+        query = query.filter(col_triggered_at.ge(*start).and(col_triggered_at.le(*end)));
     }
 
     for filter in &plan.filters {
@@ -105,9 +101,8 @@ fn apply_filter<'a>(mut query: AlertsQuery<'a>, filter: &Filter) -> Result<Alert
     match filter.field.as_str() {
         "id" => {
             let value = filter.value.as_scalar()?;
-            let uuid = Uuid::parse_str(value).map_err(|_| {
-                ServiceError::InvalidRequest("id must be a valid UUID".into())
-            })?;
+            let uuid = Uuid::parse_str(value)
+                .map_err(|_| ServiceError::InvalidRequest("id must be a valid UUID".into()))?;
             query = match filter.op {
                 crate::parser::FilterOp::Eq => query.filter(col_id.eq(uuid)),
                 crate::parser::FilterOp::NotEq => query.filter(col_id.ne(uuid)),

--- a/rust/srql/src/query/logs.rs
+++ b/rust/srql/src/query/logs.rs
@@ -202,9 +202,8 @@ fn collect_filter_params(params: &mut Vec<BindParam>, filter: &Filter) -> Result
     match filter.field.as_str() {
         "id" => {
             let value = filter.value.as_scalar()?;
-            let uuid = Uuid::parse_str(value).map_err(|_| {
-                ServiceError::InvalidRequest("id must be a valid UUID".into())
-            })?;
+            let uuid = Uuid::parse_str(value)
+                .map_err(|_| ServiceError::InvalidRequest("id must be a valid UUID".into()))?;
             params.push(BindParam::Uuid(uuid));
             Ok(())
         }
@@ -419,9 +418,8 @@ fn apply_filter<'a>(mut query: LogsQuery<'a>, filter: &Filter) -> Result<LogsQue
     match filter.field.as_str() {
         "id" => {
             let value = filter.value.as_scalar()?;
-            let uuid = Uuid::parse_str(value).map_err(|_| {
-                ServiceError::InvalidRequest("id must be a valid UUID".into())
-            })?;
+            let uuid = Uuid::parse_str(value)
+                .map_err(|_| ServiceError::InvalidRequest("id must be a valid UUID".into()))?;
             query = match filter.op {
                 FilterOp::Eq => query.filter(col_id.eq(uuid)),
                 FilterOp::NotEq => query.filter(col_id.ne(uuid)),

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
@@ -229,13 +229,15 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
       |> Enum.reject(&(&1 in summary_fields))
       |> Enum.sort()
 
-    # Parse attributes field if present for structured display
+    # Parse attributes fields if present for structured display
     parsed_attributes = parse_attributes(Map.get(assigns.log, "attributes"))
+    parsed_resource_attributes = parse_attributes(Map.get(assigns.log, "resource_attributes"))
 
     assigns =
       assigns
       |> assign(:detail_fields, detail_fields)
       |> assign(:parsed_attributes, parsed_attributes)
+      |> assign(:parsed_resource_attributes, parsed_resource_attributes)
 
     ~H"""
     <div :if={@detail_fields != []} class="rounded-xl border border-base-200 bg-base-100 shadow-sm">
@@ -246,16 +248,23 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
       <div class="divide-y divide-base-200">
         <%= for field <- @detail_fields do %>
           <%= if field == "attributes" and is_map(@parsed_attributes) do %>
-            <.parsed_attributes_section attributes={@parsed_attributes} />
+            <.parsed_attributes_section attributes={@parsed_attributes} title="Attributes" />
           <% else %>
-            <div class="px-4 py-3 flex items-start gap-4">
-              <span class="text-xs text-base-content/50 w-36 shrink-0 pt-0.5">
-                {humanize_field(field)}
-              </span>
-              <span class="text-sm flex-1 break-all">
-                <.format_value value={Map.get(@log, field)} />
-              </span>
-            </div>
+            <%= if field == "resource_attributes" and is_map(@parsed_resource_attributes) do %>
+              <.parsed_attributes_section
+                attributes={@parsed_resource_attributes}
+                title="Resource Attributes"
+              />
+            <% else %>
+              <div class="px-4 py-3 flex items-start gap-4">
+                <span class="text-xs text-base-content/50 w-36 shrink-0 pt-0.5">
+                  {humanize_field(field)}
+                </span>
+                <span class="text-sm flex-1 break-all">
+                  <.format_value value={Map.get(@log, field)} />
+                </span>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       </div>
@@ -264,11 +273,12 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
   end
 
   attr :attributes, :map, required: true
+  attr :title, :string, default: "Attributes"
 
   defp parsed_attributes_section(assigns) do
     ~H"""
     <div class="px-4 py-3">
-      <span class="text-xs text-base-content/50 uppercase tracking-wider">Attributes</span>
+      <span class="text-xs text-base-content/50 uppercase tracking-wider">{@title}</span>
       <div class="mt-2 space-y-2">
         <%= for {section, values} <- @attributes do %>
           <div class="pl-2 border-l-2 border-base-300">

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/networks_live/index.ex
@@ -1285,7 +1285,7 @@ defmodule ServiceRadarWebNGWeb.Settings.NetworksLive.Index do
           <div class="text-xs text-base-content/60">
             <span class="text-success">{@hosts_available}</span>
             <span :if={@hosts_failed > 0} class="text-error ml-1">/ {@hosts_failed} failed</span>
-            <span> of   {@hosts_processed} hosts</span>
+            <span> of    {@hosts_processed} hosts</span>
           </div>
           <div :if={@batch_info} class="text-xs text-base-content/40 mt-0.5">
             {@batch_info}

--- a/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
@@ -195,6 +195,24 @@ defmodule ServiceRadarWebNGWeb.LogLive.ShowTest do
     end
   end
 
+  describe "log detail metadata rendering" do
+    test "renders resource attributes section when present", %{conn: conn} do
+      user = operator_user_fixture()
+      conn = log_in_user(conn, user)
+
+      Application.put_env(:serviceradar_web_ng, :srql_module, MockSRQLWithLog)
+
+      log_id = "550e8400-e29b-41d4-a716-446655440000"
+      {:ok, lv, _html} = live(conn, ~p"/observability/logs/#{log_id}")
+
+      assert has_element?(lv, "span", "Resource Attributes")
+      assert has_element?(lv, "span", "service.name")
+      assert has_element?(lv, "span", "service.version")
+    after
+      Application.delete_env(:serviceradar_web_ng, :srql_module)
+    end
+  end
+
   describe "can_create_rules? helper" do
     test "returns true for operator role" do
       scope = %{user: %{role: :operator}}
@@ -249,8 +267,14 @@ defmodule MockSRQLWithLog do
              "body" => "Test error message",
              "severity_text" => "ERROR",
              "service_name" => "test-service",
+             "scope_name" => "test-scope",
+             "scope_version" => "1.0.0",
              "timestamp" => "2024-01-15T10:30:00Z",
-             "attributes" => %{"error" => "connection failed"}
+             "attributes" => %{"error" => "connection failed"},
+             "resource_attributes" => %{
+               "service.name" => "test-service",
+               "service.version" => "1.0.0"
+             }
            }
          ],
          "total_count" => 1

--- a/web-ng/test/serviceradar_web_ng_web/live/settings/rules_live_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/settings/rules_live_test.exs
@@ -169,7 +169,9 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
             enabled: true,
             priority: 100,
             match: %{"body_contains" => "original error"}
-          }, scope: scope)
+          },
+          scope: scope
+        )
 
       {:ok, lv, _html} = live(conn, ~p"/settings/rules?tab=events")
 
@@ -210,7 +212,9 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
             enabled: true,
             priority: 100,
             match: %{"body_contains" => "test"}
-          }, scope: scope)
+          },
+          scope: scope
+        )
 
       {:ok, lv, _html} = live(conn, ~p"/settings/rules?tab=events")
 
@@ -239,7 +243,9 @@ defmodule ServiceRadarWebNGWeb.Settings.RulesLiveTest do
               "severity_text" => "error",
               "service_name" => "test-service"
             }
-          }, scope: scope)
+          },
+          scope: scope
+        )
 
       {:ok, _lv, html} = live(conn, ~p"/settings/rules?tab=events")
 


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore OTEL log schema fields (resource_attributes, scope_name, scope_version) across ingestion and UI

- Normalize non-OTEL log sources into OTEL record format with proper field mapping

- Enhance log detail view to display resource attributes and scope metadata

- Refactor log parsing to extract and preserve OTEL-specific fields from multiple source formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Log Ingestion<br/>OTEL/Syslog/GELF"] -->|"Parse & Normalize"| B["OTEL Log Record<br/>with Schema Fields"]
  B -->|"Extract Fields"| C["resource_attributes<br/>scope_name/version<br/>service metadata"]
  C -->|"Store & Query"| D["Database<br/>OTEL Schema"]
  D -->|"Return Fields"| E["Logs UI Detail View<br/>Display Metadata"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>logs.ex</strong><dd><code>Refactor log parsing to extract OTEL schema fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-60c56675b539f19f1cce7702a571d883df17ce5c20a32bdc95afcd329b0b0efd">+65/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>show.ex</strong><dd><code>Display resource attributes in log detail view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-4f9769353c55928a0d382cd7510379444445aea116e1ecdf7b8eb892d249ff26">+21/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>json_logs.go</strong><dd><code>Refactor JSON log parsing to preserve OTEL fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-c16044ec608122e3cb559e6e21779d3b25753581b58ff01da701cec5d19a2d42">+243/-67</a></td>

</tr>

<tr>
  <td><strong>otel_logs.rs</strong><dd><code>Extract and normalize OTEL log record fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-4542ace311c2de0c5f9389169b9b4b3429e972dde67ea1c6efb9dff04ec1c725">+75/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>show_test.exs</strong><dd><code>Add tests for resource attributes rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-2d62472b3e212a4da643a2f66d2a07d358795602e680f31249a162b71fa0ea3b">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration_tests.rs</strong><dd><code>Update tests for OTEL field extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-8f8472cec653bcfc677523f13262b63dbf7ea390d52249db1e52c670fe0ce60f">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>rules_live_test.exs</strong><dd><code>Fix formatting in test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-dddd0d747bd725738a10e74770d765ed98fb22cdd5cd702bcbe98cc47c5af5d0">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ex</strong><dd><code>Minor spacing adjustment in UI text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-b2127e71582033bc6dfd2d7397f56bf43c1f7c613defffc504b3d8ee1e7406c4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>alerts.rs</strong><dd><code>Reformat query filter code for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-b7cd072de79e393d78f338a0fd97a15798bf38372fe58cc1349636d049733f27">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>logs.rs</strong><dd><code>Reformat UUID parsing error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-f4d3b33667f2e79a6ebe4cfff931f93c728d9a81c305ac13586e623850a504db">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Update documentation on MCP tools usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>proposal.md</strong><dd><code>Add change proposal for OTEL log schema restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-e2ec43171daa2c2aba7382d9bcd3a39f10f102f019ac8b2c718ef8e1209e8011">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>design.md</strong><dd><code>Add design document for OTEL schema changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-636ed5005c5553d21f7fdfaf0334c56c6e49dfe3dcf2368fb83001cc51a26b82">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec.md</strong><dd><code>Add requirements for OTEL log schema visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-6f6a749ea2ab57cb2d0f4768d4b4817aff93d4c353779af296e9f2b8564734e3">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong><dd><code>Add implementation tasks for OTEL schema restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2354/files#diff-d39d8463ab316bb79b9898a5225d03269d05bc29f59d8fc6e86bb45ddb56258d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

