### PR TITLE
helm updates for flowgger and netflow

### DIFF
--- a/helm/serviceradar/templates/flowgger.yaml
+++ b/helm/serviceradar/templates/flowgger.yaml
@@ -190,6 +190,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.flowgger.externalService.type | default "LoadBalancer" }}
+  {{- with .Values.flowgger.externalService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   {{- if .Values.flowgger.externalService.loadBalancerIP }}
   loadBalancerIP: {{ .Values.flowgger.externalService.loadBalancerIP }}
   {{- end }}

--- a/helm/serviceradar/templates/netflow-collector.yaml
+++ b/helm/serviceradar/templates/netflow-collector.yaml
@@ -144,6 +144,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.netflowCollector.service.type | default "ClusterIP" }}
+  {{- with .Values.netflowCollector.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   {{- if .Values.netflowCollector.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.netflowCollector.service.loadBalancerIP | quote }}
   {{- end }}

--- a/helm/serviceradar/values-demo.yaml
+++ b/helm/serviceradar/values-demo.yaml
@@ -91,8 +91,9 @@ flowgger:
   externalService:
     enabled: true
     annotations:
-      metallb.universe.tf/address-pool: k3s-lan-pool
-    loadBalancerIP: "192.168.6.81"
+      metallb.universe.tf/address-pool: k3s-pool
+    loadBalancerIP: "23.138.124.24"
+    externalTrafficPolicy: Local
 
 netflowCollector:
   enabled: true
@@ -101,5 +102,6 @@ netflowCollector:
   service:
     type: LoadBalancer
     annotations:
-      metallb.universe.tf/address-pool: k3s-lan-pool
-    loadBalancerIP: "192.168.6.82"
+      metallb.universe.tf/address-pool: k3s-pool
+    loadBalancerIP: "23.138.124.25"
+    externalTrafficPolicy: Local

--- a/helm/serviceradar/values.yaml
+++ b/helm/serviceradar/values.yaml
@@ -252,6 +252,8 @@ flowgger:
     enabled: false
     # Service type: LoadBalancer, NodePort, or ClusterIP
     type: LoadBalancer
+    # Only advertise from nodes with local endpoints (required for Calico BGP)
+    externalTrafficPolicy: Cluster
     # Annotations for load balancer configuration (MetalLB, cloud providers, etc.)
     # Example for MetalLB: metallb.universe.tf/address-pool: k3s-pool
     # Example for AWS NLB: service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -304,6 +306,8 @@ netflowCollector:
     type: ClusterIP
     annotations: {}
     loadBalancerIP: ""
+    # Only advertise from nodes with local endpoints (required for Calico BGP)
+    externalTrafficPolicy: Cluster
     ports:
       netflow:
         enabled: true

--- a/k8s/demo/base/serviceradar-netflow-collector.yaml
+++ b/k8s/demo/base/serviceradar-netflow-collector.yaml
@@ -154,6 +154,7 @@ metadata:
 spec:
   selector:
     app: serviceradar-netflow-collector
+  externalTrafficPolicy: Local
   ports:
   - name: netflow
     port: 2055

--- a/k8s/demo/prod/serviceradar-flowgger-external.yaml
+++ b/k8s/demo/prod/serviceradar-flowgger-external.yaml
@@ -8,6 +8,7 @@ metadata:
     metallb.universe.tf/address-pool: k3s-pool
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     app: serviceradar-flowgger
     app.kubernetes.io/part-of: serviceradar


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add `externalTrafficPolicy` configuration to Helm templates for flowgger and netflow services

- Update demo values with new IP addresses and pool names for MetalLB

- Set `externalTrafficPolicy: Local` in demo and production Kubernetes manifests

- Add documentation comments explaining Calico BGP requirement for traffic policy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Helm Templates"] -->|Add externalTrafficPolicy| B["flowgger.yaml & netflow-collector.yaml"]
  C["Values Files"] -->|Update IPs & pool names| D["values-demo.yaml & values.yaml"]
  E["K8s Manifests"] -->|Set Local policy| F["Demo & Prod Services"]
  B --> G["Enhanced Service Configuration"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flowgger.yaml</strong><dd><code>Add externalTrafficPolicy to flowgger service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/flowgger.yaml

<ul><li>Add conditional <code>externalTrafficPolicy</code> field to flowgger external <br>service spec<br> <li> Allow configuration via <br><code>Values.flowgger.externalService.externalTrafficPolicy</code><br> <li> Maintain backward compatibility with conditional rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-511cfbfe42e0c41cd2fddf67a04911b48724ca9ea9f6d1ddc1f4bb7bf07086ab">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>netflow-collector.yaml</strong><dd><code>Add externalTrafficPolicy to netflow service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/templates/netflow-collector.yaml

<ul><li>Add conditional <code>externalTrafficPolicy</code> field to netflow collector <br>service spec<br> <li> Allow configuration via <br><code>Values.netflowCollector.service.externalTrafficPolicy</code><br> <li> Maintain backward compatibility with conditional rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-2caca5e6b4a9d567d04bd326125e554b1f571be0f7746fb6f9144e0a33f65b07">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-netflow-collector.yaml</strong><dd><code>Add externalTrafficPolicy to netflow service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/base/serviceradar-netflow-collector.yaml

<ul><li>Add <code>externalTrafficPolicy: Local</code> to netflow collector service spec</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-c29757a23e5f4021c9cd4d6d35a261edf9b56c706188bb24855fafa84454b797">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serviceradar-flowgger-external.yaml</strong><dd><code>Add externalTrafficPolicy to flowgger service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/demo/prod/serviceradar-flowgger-external.yaml

<ul><li>Add <code>externalTrafficPolicy: Local</code> to flowgger external service spec</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-0e3d242dcaf4f3a83adc9de3f7183db6299c50bca47b9cd544ee02dfec263dcf">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add externalTrafficPolicy defaults with documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/values.yaml

<ul><li>Add <code>externalTrafficPolicy: Cluster</code> default for flowgger external <br>service<br> <li> Add <code>externalTrafficPolicy: Cluster</code> default for netflow collector <br>service<br> <li> Add documentation comments explaining Calico BGP requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-d4449c7cb70362554b274f81eae5a4b81a8e81df494282e383d1b7ea3871c452">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values-demo.yaml</strong><dd><code>Update demo IPs, pools, and traffic policies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

helm/serviceradar/values-demo.yaml

<ul><li>Update flowgger loadBalancerIP from <code>192.168.6.81</code> to <code>23.138.124.24</code><br> <li> Update netflow loadBalancerIP from <code>192.168.6.82</code> to <code>23.138.124.25</code><br> <li> Change MetalLB address pool from <code>k3s-lan-pool</code> to <code>k3s-pool</code> for both <br>services<br> <li> Set <code>externalTrafficPolicy: Local</code> for both flowgger and netflow <br>services</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2654/files#diff-3a2c6c76ca4d5e8a336cd917d39b1704c03ea94a5cba4da1eb20629c63a5b914">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

