### PR TITLE
fix: Netflow tweaks to collector conversions and bump 0.8.4 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,9 +2953,9 @@ dependencies = [
 
 [[package]]
 name = "netflow_parser"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b7e846ffa75e940825f1654f2ab046cdbaea25f8707b3dcb529f4990dff4e0"
+checksum = "c4eadda211d974b3b249e9dc18636e37873dada453647fd1f4dece1d1e435ffe"
 dependencies = [
  "byteorder 1.5.0",
  "lru",

--- a/packaging/zen/rules/netflow_to_ocsf.json
+++ b/packaging/zen/rules/netflow_to_ocsf.json
@@ -66,7 +66,7 @@
           {
             "id": "connection_info",
             "key": "connection_info",
-            "value": "{ protocol_num: proto, protocol_name: proto == 1 ? 'ICMP' : proto == 6 ? 'TCP' : proto == 17 ? 'UDP' : proto == 47 ? 'GRE' : proto == 50 ? 'ESP' : proto == 58 ? 'ICMPv6' : 'Unknown', tcp_flags: tcp_flags, direction_id: 0, boundary_id: 0 }"
+            "value": "{ protocol_num: proto, protocol_name: protocol_name != '' ? protocol_name : (proto == 1 ? 'ICMP' : proto == 6 ? 'TCP' : proto == 17 ? 'UDP' : proto == 47 ? 'GRE' : proto == 50 ? 'ESP' : proto == 58 ? 'ICMPv6' : 'Unknown'), tcp_flags: tcp_flags, direction_id: 0, boundary_id: 0 }"
           },
           {
             "id": "traffic",

--- a/proto/flow/flow.proto
+++ b/proto/flow/flow.proto
@@ -120,4 +120,7 @@ message FlowMessage {
   repeated bytes ipv6_routing_header_addresses = 105; // SRv6
   uint32 ipv6_routing_header_seg_left = 106; // SRv6
 
+  // Human-readable protocol name (e.g., "TCP", "UDP", "ICMP")
+  string protocol_name = 107;
+
 }

--- a/rust/netflow-collector/Cargo.toml
+++ b/rust/netflow-collector/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-netflow_parser = { version = "0.8.1", features = ["parse_unknown_fields"] }
+netflow_parser = { version = "0.8.4", features = ["parse_unknown_fields"] }
 prost = "0.13"
 async-nats = "0.42"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }

--- a/rust/netflow-collector/data/flows/netflow_to_ocsf.json
+++ b/rust/netflow-collector/data/flows/netflow_to_ocsf.json
@@ -66,7 +66,7 @@
           {
             "id": "connection_info",
             "key": "connection_info",
-            "value": "{ protocol_num: proto, protocol_name: proto == 1 ? 'ICMP' : proto == 6 ? 'TCP' : proto == 17 ? 'UDP' : proto == 47 ? 'GRE' : proto == 50 ? 'ESP' : proto == 58 ? 'ICMPv6' : 'Unknown', tcp_flags: tcp_flags, direction_id: 0, boundary_id: 0 }"
+            "value": "{ protocol_num: proto, protocol_name: protocol_name != '' ? protocol_name : (proto == 1 ? 'ICMP' : proto == 6 ? 'TCP' : proto == 17 ? 'UDP' : proto == 47 ? 'GRE' : proto == 50 ? 'ESP' : proto == 58 ? 'ICMPv6' : 'Unknown'), tcp_flags: tcp_flags, direction_id: 0, boundary_id: 0 }"
           },
           {
             "id": "traffic",

--- a/rust/netflow-collector/src/converter.rs
+++ b/rust/netflow-collector/src/converter.rs
@@ -2,8 +2,9 @@ use crate::error::ConversionError;
 use anyhow::Result;
 use log::debug;
 use netflow_parser::NetflowPacket;
+use netflow_parser::protocol::ProtocolTypes;
 use netflow_parser::static_versions::v5::V5;
-use netflow_parser::variable_versions::data_number::FieldValue;
+use netflow_parser::variable_versions::data_number::{DataNumber, FieldValue};
 use netflow_parser::variable_versions::ipfix_lookup::{IANAIPFixField, IPFixField};
 use netflow_parser::variable_versions::v9_lookup::V9Field;
 use std::net::{IpAddr, SocketAddr};
@@ -50,6 +51,7 @@ impl Converter {
 
             // Protocol
             msg.proto = u32::from(flow.protocol_number);
+            msg.protocol_name = protocol_type_name(ProtocolTypes::from(flow.protocol_number));
 
             // Bytes and packets
             msg.bytes = u64::from(flow.d_octets);
@@ -143,7 +145,10 @@ impl Converter {
                             V9Field::L4DstPort => msg.dst_port = field_value_to_u32(field_value),
 
                             // Protocol
-                            V9Field::Protocol => msg.proto = field_value_to_u32(field_value),
+                            V9Field::Protocol => {
+                                msg.proto = field_value_to_u32(field_value);
+                                msg.protocol_name = field_value_to_protocol_name(field_value);
+                            }
 
                             // Volume
                             V9Field::InBytes => msg.bytes = field_value_to_u64(field_value),
@@ -303,7 +308,8 @@ impl Converter {
 
                             // Protocol
                             IPFixField::IANA(IANAIPFixField::ProtocolIdentifier) => {
-                                msg.proto = field_value_to_u32(field_value)
+                                msg.proto = field_value_to_u32(field_value);
+                                msg.protocol_name = field_value_to_protocol_name(field_value);
                             }
 
                             // Volume - prefer Delta counts
@@ -526,12 +532,56 @@ fn field_value_to_ip_bytes(value: &FieldValue) -> Vec<u8> {
     }
 }
 
+fn data_number_to_u32(dn: &DataNumber) -> u32 {
+    match *dn {
+        DataNumber::U8(v) => u32::from(v),
+        DataNumber::I8(v) => v.max(0) as u32,
+        DataNumber::U16(v) => u32::from(v),
+        DataNumber::I16(v) => v.max(0) as u32,
+        DataNumber::U24(v) => v,
+        DataNumber::I24(v) => v.max(0) as u32,
+        DataNumber::U32(v) => v,
+        DataNumber::I32(v) => v.max(0) as u32,
+        DataNumber::U64(v) => v.min(u64::from(u32::MAX)) as u32,
+        DataNumber::I64(v) => v.max(0).min(i64::from(u32::MAX)) as u32,
+        DataNumber::U128(v) => v.min(u128::from(u32::MAX)) as u32,
+        DataNumber::I128(v) => v.max(0).min(i128::from(u32::MAX)) as u32,
+    }
+}
+
+fn data_number_to_u64(dn: &DataNumber) -> u64 {
+    match *dn {
+        DataNumber::U8(v) => u64::from(v),
+        DataNumber::I8(v) => v.max(0) as u64,
+        DataNumber::U16(v) => u64::from(v),
+        DataNumber::I16(v) => v.max(0) as u64,
+        DataNumber::U24(v) => u64::from(v),
+        DataNumber::I24(v) => v.max(0) as u64,
+        DataNumber::U32(v) => u64::from(v),
+        DataNumber::I32(v) => v.max(0) as u64,
+        DataNumber::U64(v) => v,
+        DataNumber::I64(v) => v.max(0) as u64,
+        DataNumber::U128(v) => v.min(u128::from(u64::MAX)) as u64,
+        DataNumber::I128(v) => v.max(0).min(i128::from(u64::MAX)) as u64,
+    }
+}
+
 fn field_value_to_u32(value: &FieldValue) -> u32 {
-    value.try_into().unwrap_or_default()
+    match value {
+        FieldValue::DataNumber(dn) => data_number_to_u32(dn),
+        FieldValue::ProtocolType(pt) => u32::from(u8::from(*pt)),
+        FieldValue::Float64(f) => f.max(0.0).min(f64::from(u32::MAX)) as u32,
+        _ => 0,
+    }
 }
 
 fn field_value_to_u64(value: &FieldValue) -> u64 {
-    value.try_into().unwrap_or_default()
+    match value {
+        FieldValue::DataNumber(dn) => data_number_to_u64(dn),
+        FieldValue::ProtocolType(pt) => u64::from(u8::from(*pt)),
+        FieldValue::Float64(f) => f.max(0.0).min(u64::MAX as f64) as u64,
+        _ => 0,
+    }
 }
 
 fn field_value_to_mac_u64(value: &FieldValue) -> u64 {
@@ -548,9 +598,25 @@ fn field_value_to_mac_u64(value: &FieldValue) -> u64 {
     }
 }
 
+fn protocol_type_name(pt: ProtocolTypes) -> String {
+    format!("{pt:?}").to_uppercase()
+}
+
+fn field_value_to_protocol_name(value: &FieldValue) -> String {
+    match value {
+        FieldValue::ProtocolType(pt) => protocol_type_name(*pt),
+        FieldValue::DataNumber(dn) => {
+            let n = data_number_to_u32(dn) as u8;
+            protocol_type_name(ProtocolTypes::from(n))
+        }
+        _ => String::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use netflow_parser::protocol::ProtocolTypes;
 
     #[test]
     fn test_mac_to_u64() {
@@ -575,5 +641,194 @@ mod tests {
         let ip = IpAddr::V4([192, 168, 1, 1].into());
         let bytes = ip_to_bytes(&ip);
         assert_eq!(bytes, vec![192, 168, 1, 1]);
+    }
+
+    // --- data_number_to_u32 tests ---
+
+    #[test]
+    fn test_data_number_to_u32_unsigned_widening() {
+        assert_eq!(data_number_to_u32(&DataNumber::U8(255)), 255);
+        assert_eq!(data_number_to_u32(&DataNumber::U16(65535)), 65535);
+        assert_eq!(data_number_to_u32(&DataNumber::U24(16_777_215)), 16_777_215);
+        assert_eq!(data_number_to_u32(&DataNumber::U32(42)), 42);
+    }
+
+    #[test]
+    fn test_data_number_to_u32_saturates_large() {
+        assert_eq!(
+            data_number_to_u32(&DataNumber::U64(u64::from(u32::MAX) + 1)),
+            u32::MAX
+        );
+        assert_eq!(
+            data_number_to_u32(&DataNumber::U128(u128::from(u32::MAX) + 100)),
+            u32::MAX
+        );
+    }
+
+    #[test]
+    fn test_data_number_to_u32_signed_negative_clamps_to_zero() {
+        assert_eq!(data_number_to_u32(&DataNumber::I8(-1)), 0);
+        assert_eq!(data_number_to_u32(&DataNumber::I16(-500)), 0);
+        assert_eq!(data_number_to_u32(&DataNumber::I32(-1)), 0);
+        assert_eq!(data_number_to_u32(&DataNumber::I64(-1)), 0);
+        assert_eq!(data_number_to_u32(&DataNumber::I128(-1)), 0);
+        assert_eq!(data_number_to_u32(&DataNumber::I24(-1)), 0);
+    }
+
+    #[test]
+    fn test_data_number_to_u32_signed_positive() {
+        assert_eq!(data_number_to_u32(&DataNumber::I8(127)), 127);
+        assert_eq!(data_number_to_u32(&DataNumber::I16(1000)), 1000);
+        assert_eq!(data_number_to_u32(&DataNumber::I32(35000)), 35000);
+        assert_eq!(data_number_to_u32(&DataNumber::I64(100)), 100);
+    }
+
+    // --- data_number_to_u64 tests ---
+
+    #[test]
+    fn test_data_number_to_u64_unsigned_widening() {
+        assert_eq!(data_number_to_u64(&DataNumber::U8(200)), 200);
+        assert_eq!(data_number_to_u64(&DataNumber::U16(50000)), 50000);
+        assert_eq!(data_number_to_u64(&DataNumber::U32(35000)), 35000);
+        assert_eq!(data_number_to_u64(&DataNumber::U64(99999)), 99999);
+    }
+
+    #[test]
+    fn test_data_number_to_u64_saturates_u128() {
+        assert_eq!(
+            data_number_to_u64(&DataNumber::U128(u128::from(u64::MAX) + 1)),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn test_data_number_to_u64_signed_negative_clamps_to_zero() {
+        assert_eq!(data_number_to_u64(&DataNumber::I8(-10)), 0);
+        assert_eq!(data_number_to_u64(&DataNumber::I64(-999)), 0);
+        assert_eq!(data_number_to_u64(&DataNumber::I128(-1)), 0);
+    }
+
+    // --- field_value_to_u32 tests ---
+
+    #[test]
+    fn test_field_value_to_u32_data_number() {
+        let fv = FieldValue::DataNumber(DataNumber::U8(6));
+        assert_eq!(field_value_to_u32(&fv), 6);
+
+        let fv = FieldValue::DataNumber(DataNumber::U32(35000));
+        assert_eq!(field_value_to_u32(&fv), 35000);
+    }
+
+    #[test]
+    fn test_field_value_to_u32_protocol_type() {
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Tcp);
+        assert_eq!(field_value_to_u32(&fv), 6);
+
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Udp);
+        assert_eq!(field_value_to_u32(&fv), 17);
+
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Icmp);
+        assert_eq!(field_value_to_u32(&fv), 1);
+    }
+
+    #[test]
+    fn test_field_value_to_u32_float64() {
+        let fv = FieldValue::Float64(42.7);
+        assert_eq!(field_value_to_u32(&fv), 42);
+    }
+
+    #[test]
+    fn test_field_value_to_u32_non_numeric_returns_zero() {
+        let fv = FieldValue::String("hello".to_string());
+        assert_eq!(field_value_to_u32(&fv), 0);
+
+        let fv = FieldValue::Ip4Addr([10, 0, 0, 1].into());
+        assert_eq!(field_value_to_u32(&fv), 0);
+
+        let fv = FieldValue::Vec(vec![1, 2, 3]);
+        assert_eq!(field_value_to_u32(&fv), 0);
+    }
+
+    // --- field_value_to_u64 tests ---
+
+    #[test]
+    fn test_field_value_to_u64_data_number() {
+        // The key bug scenario: IN_BYTES sent as 4-byte field -> DataNumber::U32
+        let fv = FieldValue::DataNumber(DataNumber::U32(35000));
+        assert_eq!(field_value_to_u64(&fv), 35000);
+
+        let fv = FieldValue::DataNumber(DataNumber::U64(999999));
+        assert_eq!(field_value_to_u64(&fv), 999999);
+    }
+
+    #[test]
+    fn test_field_value_to_u64_protocol_type() {
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Tcp);
+        assert_eq!(field_value_to_u64(&fv), 6);
+    }
+
+    #[test]
+    fn test_field_value_to_u64_non_numeric_returns_zero() {
+        let fv = FieldValue::String("test".to_string());
+        assert_eq!(field_value_to_u64(&fv), 0);
+
+        let fv = FieldValue::MacAddr("00:11:22:33:44:55".to_string());
+        assert_eq!(field_value_to_u64(&fv), 0);
+    }
+
+    // --- protocol_type_name tests ---
+
+    #[test]
+    fn test_protocol_type_name_common_protocols() {
+        assert_eq!(protocol_type_name(ProtocolTypes::Tcp), "TCP");
+        assert_eq!(protocol_type_name(ProtocolTypes::Udp), "UDP");
+        assert_eq!(protocol_type_name(ProtocolTypes::Icmp), "ICMP");
+        assert_eq!(protocol_type_name(ProtocolTypes::Gre), "GRE");
+        assert_eq!(protocol_type_name(ProtocolTypes::Esp), "ESP");
+    }
+
+    #[test]
+    fn test_protocol_type_name_ipv6_icmp() {
+        assert_eq!(protocol_type_name(ProtocolTypes::Ipv6Icmp), "IPV6ICMP");
+    }
+
+    #[test]
+    fn test_protocol_type_name_unknown() {
+        assert_eq!(protocol_type_name(ProtocolTypes::Unknown), "UNKNOWN");
+    }
+
+    // --- field_value_to_protocol_name tests ---
+
+    #[test]
+    fn test_field_value_to_protocol_name_protocol_type() {
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Tcp);
+        assert_eq!(field_value_to_protocol_name(&fv), "TCP");
+
+        let fv = FieldValue::ProtocolType(ProtocolTypes::Udp);
+        assert_eq!(field_value_to_protocol_name(&fv), "UDP");
+    }
+
+    #[test]
+    fn test_field_value_to_protocol_name_data_number() {
+        // Protocol number 6 = TCP
+        let fv = FieldValue::DataNumber(DataNumber::U8(6));
+        assert_eq!(field_value_to_protocol_name(&fv), "TCP");
+
+        // Protocol number 17 = UDP
+        let fv = FieldValue::DataNumber(DataNumber::U16(17));
+        assert_eq!(field_value_to_protocol_name(&fv), "UDP");
+
+        // Protocol number 1 = ICMP
+        let fv = FieldValue::DataNumber(DataNumber::U32(1));
+        assert_eq!(field_value_to_protocol_name(&fv), "ICMP");
+    }
+
+    #[test]
+    fn test_field_value_to_protocol_name_non_numeric_returns_empty() {
+        let fv = FieldValue::String("hello".to_string());
+        assert_eq!(field_value_to_protocol_name(&fv), "");
+
+        let fv = FieldValue::Ip4Addr([10, 0, 0, 1].into());
+        assert_eq!(field_value_to_protocol_name(&fv), "");
     }
 }

--- a/rust/netflow-collector/src/converter.rs
+++ b/rust/netflow-collector/src/converter.rs
@@ -598,6 +598,13 @@ fn field_value_to_mac_u64(value: &FieldValue) -> u64 {
     }
 }
 
+/// Returns true if the flow message contains meaningful traffic data.
+/// Flows with 0 bytes AND 0 packets are degenerate records (e.g. options templates,
+/// metadata records, or incomplete template data) and should be filtered out.
+pub fn is_valid_flow(msg: &flowpb::FlowMessage) -> bool {
+    msg.bytes > 0 || msg.packets > 0
+}
+
 fn protocol_type_name(pt: ProtocolTypes) -> String {
     format!("{pt:?}").to_uppercase()
 }
@@ -830,5 +837,47 @@ mod tests {
 
         let fv = FieldValue::Ip4Addr([10, 0, 0, 1].into());
         assert_eq!(field_value_to_protocol_name(&fv), "");
+    }
+
+    // --- is_valid_flow tests ---
+
+    #[test]
+    fn test_is_valid_flow_zero_bytes_zero_packets_is_invalid() {
+        let msg = flowpb::FlowMessage {
+            bytes: 0,
+            packets: 0,
+            ..Default::default()
+        };
+        assert!(!is_valid_flow(&msg));
+    }
+
+    #[test]
+    fn test_is_valid_flow_with_bytes_is_valid() {
+        let msg = flowpb::FlowMessage {
+            bytes: 100,
+            packets: 0,
+            ..Default::default()
+        };
+        assert!(is_valid_flow(&msg));
+    }
+
+    #[test]
+    fn test_is_valid_flow_with_packets_is_valid() {
+        let msg = flowpb::FlowMessage {
+            bytes: 0,
+            packets: 1,
+            ..Default::default()
+        };
+        assert!(is_valid_flow(&msg));
+    }
+
+    #[test]
+    fn test_is_valid_flow_with_both_is_valid() {
+        let msg = flowpb::FlowMessage {
+            bytes: 1500,
+            packets: 3,
+            ..Default::default()
+        };
+        assert!(is_valid_flow(&msg));
     }
 }

--- a/rust/netflow-collector/src/listener.rs
+++ b/rust/netflow-collector/src/listener.rs
@@ -12,11 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
-type CacheStatsVec = Vec<(
-    String,
-    netflow_parser::CacheStats,
-    netflow_parser::CacheStats,
-)>;
+type CacheStatsVec = Vec<(String, netflow_parser::ParserCacheStats)>;
 
 fn template_event_callback(event: &TemplateEvent) {
     use TemplateEvent::*;
@@ -183,24 +179,12 @@ impl Listener {
         let v9_stats: Vec<_> = parser
             .v9_stats()
             .iter()
-            .map(|(key, template_stats, data_stats)| {
-                (
-                    format!("{:?}", key),
-                    template_stats.clone(),
-                    data_stats.clone(),
-                )
-            })
+            .map(|(key, stats)| (format!("{:?}", key), stats.clone()))
             .collect();
         let ipfix_stats: Vec<_> = parser
             .ipfix_stats()
             .iter()
-            .map(|(key, template_stats, data_stats)| {
-                (
-                    format!("{:?}", key),
-                    template_stats.clone(),
-                    data_stats.clone(),
-                )
-            })
+            .map(|(key, stats)| (format!("{:?}", key), stats.clone()))
             .collect();
         (v9_stats, ipfix_stats)
     }

--- a/rust/netflow-collector/src/listener.rs
+++ b/rust/netflow-collector/src/listener.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::converter::Converter;
+use crate::converter::{Converter, is_valid_flow};
 use crate::converter::flowpb;
 use crate::error::GetCurrentTimeError;
 use anyhow::Result;
@@ -146,10 +146,36 @@ impl Listener {
                     }
                 };
 
-            debug!("Converted {} flow records", flow_messages.len());
+            // Filter out degenerate flow records (0 bytes, 0 packets)
+            let (valid, invalid): (Vec<_>, Vec<_>) =
+                flow_messages.into_iter().partition(is_valid_flow);
 
-            // Encode and send each flow message to the publisher channel
-            for flow_msg in flow_messages {
+            if !invalid.is_empty() {
+                warn!(
+                    "Dropped {} degenerate flow record(s) from {} \
+                     (0 bytes, 0 packets - likely options template or metadata)",
+                    invalid.len(),
+                    peer_addr
+                );
+                for dropped in &invalid {
+                    debug!(
+                        "Dropped flow: proto={} protocol_name={:?} src_addr={:?} dst_addr={:?} \
+                         src_port={} dst_port={} type={:?}",
+                        dropped.proto,
+                        dropped.protocol_name,
+                        dropped.src_addr,
+                        dropped.dst_addr,
+                        dropped.src_port,
+                        dropped.dst_port,
+                        dropped.r#type,
+                    );
+                }
+            }
+
+            debug!("Converted {} flow records ({} dropped)", valid.len(), invalid.len());
+
+            // Encode and send each valid flow message to the publisher channel
+            for flow_msg in valid {
                 let mut buf = Vec::new();
                 if let Err(e) = flow_msg.encode(&mut buf) {
                     error!("Failed to encode protobuf: {}", e);

--- a/rust/netflow-collector/src/metrics.rs
+++ b/rust/netflow-collector/src/metrics.rs
@@ -31,34 +31,34 @@ impl MetricsReporter {
             let (v9_stats, ipfix_stats) = listener.get_cache_stats();
 
             // Log V9 cache stats per source
-            for (source, template_stats, data_stats) in &v9_stats {
+            for (source, stats) in &v9_stats {
                 info!(
-                    "V9 Template Cache [{}] - Templates: {}/{}, Data: {}/{}, Template Hits/Misses: {}/{}, Data Hits/Misses: {}/{}",
+                    "V9 Template Cache [{}] - V9: {}/{}, IPFIX: {}/{}, V9 Hits/Misses: {}/{}, IPFIX Hits/Misses: {}/{}",
                     source,
-                    template_stats.current_size,
-                    template_stats.max_size,
-                    data_stats.current_size,
-                    data_stats.max_size,
-                    template_stats.metrics.hits,
-                    template_stats.metrics.misses,
-                    data_stats.metrics.hits,
-                    data_stats.metrics.misses
+                    stats.v9.current_size,
+                    stats.v9.max_size,
+                    stats.ipfix.current_size,
+                    stats.ipfix.max_size,
+                    stats.v9.metrics.hits,
+                    stats.v9.metrics.misses,
+                    stats.ipfix.metrics.hits,
+                    stats.ipfix.metrics.misses
                 );
             }
 
             // Log IPFIX cache stats per source
-            for (source, template_stats, data_stats) in &ipfix_stats {
+            for (source, stats) in &ipfix_stats {
                 info!(
-                    "IPFIX Template Cache [{}] - Templates: {}/{}, Data: {}/{}, Template Hits/Misses: {}/{}, Data Hits/Misses: {}/{}",
+                    "IPFIX Template Cache [{}] - V9: {}/{}, IPFIX: {}/{}, V9 Hits/Misses: {}/{}, IPFIX Hits/Misses: {}/{}",
                     source,
-                    template_stats.current_size,
-                    template_stats.max_size,
-                    data_stats.current_size,
-                    data_stats.max_size,
-                    template_stats.metrics.hits,
-                    template_stats.metrics.misses,
-                    data_stats.metrics.hits,
-                    data_stats.metrics.misses
+                    stats.v9.current_size,
+                    stats.v9.max_size,
+                    stats.ipfix.current_size,
+                    stats.ipfix.max_size,
+                    stats.v9.metrics.hits,
+                    stats.v9.metrics.misses,
+                    stats.ipfix.metrics.hits,
+                    stats.ipfix.metrics.misses
                 );
             }
 

--- a/rust/netflow-collector/src/publisher.rs
+++ b/rust/netflow-collector/src/publisher.rs
@@ -234,6 +234,7 @@ mod tests {
             drop_policy: crate::config::DropPolicy::DropOldest,
             security: None,
             metrics_addr: None,
+            nats_creds_file: None,
         });
 
         let (_tx, rx) = mpsc::channel(1000);

--- a/web-ng/lib/serviceradar_web_ng_web/live/netflow_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/netflow_live/index.ex
@@ -42,6 +42,7 @@ defmodule ServiceRadarWebNGWeb.NetflowLive.Index do
       src_endpoint_port as src_port,
       dst_endpoint_port as dst_port,
       protocol_num as protocol,
+      protocol_name,
       packets_total as packets,
       bytes_total as octets,
       COALESCE(ocsf_payload->'unmapped'->>'flow_type', ocsf_payload->>'flow_type') as flow_type
@@ -233,7 +234,7 @@ defmodule ServiceRadarWebNGWeb.NetflowLive.Index do
                   else: ""}
               </td>
               <td class="p-2">
-                <.protocol_badge protocol={flow["protocol"]} />
+                <.protocol_badge protocol={flow["protocol"]} protocol_name={flow["protocol_name"]} />
               </td>
               <td class="p-2">
                 <.flow_type_badge flow_type={flow["flow_type"]} />
@@ -257,15 +258,20 @@ defmodule ServiceRadarWebNGWeb.NetflowLive.Index do
   end
 
   defp protocol_badge(assigns) do
+    protocol_name = Map.get(assigns, :protocol_name)
     protocol = assigns.protocol
 
     {label, variant} =
-      case protocol do
-        6 -> {"TCP", "success"}
-        17 -> {"UDP", "info"}
-        1 -> {"ICMP", "ghost"}
-        nil -> {"Unknown", "ghost"}
-        other -> {to_string(other), "ghost"}
+      if is_binary(protocol_name) and protocol_name != "" do
+        {String.upcase(protocol_name), protocol_variant(protocol_name)}
+      else
+        case protocol do
+          6 -> {"TCP", "success"}
+          17 -> {"UDP", "info"}
+          1 -> {"ICMP", "ghost"}
+          nil -> {"Unknown", "ghost"}
+          other -> {to_string(other), "ghost"}
+        end
       end
 
     assigns = assign(assigns, label: label, variant: variant)
@@ -273,6 +279,22 @@ defmodule ServiceRadarWebNGWeb.NetflowLive.Index do
     ~H"""
     <.ui_badge variant={@variant}>{@label}</.ui_badge>
     """
+  end
+
+  defp protocol_variant(name) when is_binary(name) do
+    case String.downcase(name) do
+      "tcp" -> "success"
+      "udp" -> "info"
+      "icmp" -> "ghost"
+      "sctp" -> "success"
+      "gre" -> "warning"
+      "esp" -> "warning"
+      "ah" -> "warning"
+      "ospf" -> "info"
+      "igmp" -> "info"
+      "ipv6-icmp" -> "ghost"
+      _ -> "ghost"
+    end
   end
 
   defp flow_type_badge(assigns) do


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add protocol name field to NetFlow data collection and display
  - Capture `protocol_name` from NetFlow packets in Rust collector
  - Display protocol names in web UI with intelligent fallback logic

- Improve field value conversion robustness in NetFlow parser
  - Handle `DataNumber` and `ProtocolType` variants explicitly
  - Add comprehensive conversion functions with proper type handling

- Refactor cache statistics structure for simplified reporting
  - Update `CacheStatsVec` type to use unified `ParserCacheStats`
  - Simplify metrics logging to use consolidated stats object

- Update dependencies and add comprehensive test coverage
  - Bump `netflow_parser` from 0.8.1 to 0.8.4
  - Add 30+ tests for data conversion and protocol name handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NetFlow Packet"] -->|"Extract protocol_name"| B["Rust Converter"]
  B -->|"Store in FlowMessage"| C["Protocol Field"]
  C -->|"Query from DB"| D["Web UI"]
  D -->|"Display with variant"| E["Protocol Badge"]
  F["Field Value"] -->|"Convert DataNumber/ProtocolType"| G["Robust Conversion"]
  G -->|"Handle edge cases"| H["u32/u64 Output"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>index.ex</strong><dd><code>Add protocol name display with intelligent fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-7ec566a3a20e36d101f72bb9ee19620be76b397c1d88a1edc6d9a88e8da6909e">+29/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>converter.rs</strong><dd><code>Implement protocol name extraction and robust field conversions</code></dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-873d955c2362720f0772872c1dfaba79c512b09dc5c794009ea466ba73cbaae4">+260/-5</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>listener.rs</strong><dd><code>Refactor cache statistics to unified structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-3ec4d0175a1f407a9c9246268da3491d1fdfacd2e8c00d536fde36357e993999">+3/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics.rs</strong><dd><code>Update metrics logging for consolidated cache stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-d3fef810bfa2a5b985b71300423ec1d9c6eea321fee261710cd3257b521ad7e2">+20/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>netflow_to_ocsf.json</strong><dd><code>Use protocol_name field with fallback to numeric mapping</code>&nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-f1817cc1d98f34d2d27d99bcc8471124179fd5ed61860e45b87d397ff3e08d9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>netflow_to_ocsf.json</strong><dd><code>Use protocol_name field with fallback to numeric mapping</code>&nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-1de8bfcc6c483d7eebbf49223ced7377d1647d5ac71069b4ef49c705caa164e3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flow.proto</strong><dd><code>Add protocol_name string field to FlowMessage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-81ddfbe717075dc4000bbe1aca2ffdbf0b81b11b5f6103c235af6aba0ec9600e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>publisher.rs</strong><dd><code>Add missing nats_creds_file field to test config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-10dec5866b4bc416c62590bdf2d3ded6c234b8d423ec4aebc70eac891ff0c07d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump netflow_parser dependency to 0.8.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2658/files#diff-03c9bd143b73f35c01bd56390e03d9bde76065f53473ed6a70aa49c6dd1d67b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

