### PR TITLE
sorting by is_available

### DIFF
--- a/rust/srql/src/query/devices.rs
+++ b/rust/srql/src/query/devices.rs
@@ -18,7 +18,7 @@ use diesel::dsl::{not, sql};
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::{AsQuery, BoxedSelectStatement, BoxedSqlQuery, FromClause, SqlQuery};
-use diesel::sql_types::{Array, BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
+use diesel::sql_types::{Array, BigInt, Bool, Inet, Jsonb, Nullable, Text, Timestamptz};
 use diesel::PgTextExpressionMethods;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde_json::Value;
@@ -1092,55 +1092,154 @@ fn parse_ip_range(value: &str) -> Result<Option<(String, String)>> {
 
 fn apply_ordering<'a>(mut query: DeviceQuery<'a>, order: &[OrderClause]) -> DeviceQuery<'a> {
     let mut applied = false;
+    let mut saw_is_available = false;
+    let mut saw_ip = false;
+
     for clause in order {
-        query = if !applied {
-            applied = true;
-            match clause.field.as_str() {
-                "uid" => match clause.direction {
-                    OrderDirection::Asc => query.order(col_uid.asc()),
-                    OrderDirection::Desc => query.order(col_uid.desc()),
-                },
-                // Support both OCSF and legacy time field names
-                "first_seen_time" | "first_seen" => match clause.direction {
-                    OrderDirection::Asc => query.order(col_first_seen_time.asc()),
-                    OrderDirection::Desc => query.order(col_first_seen_time.desc()),
-                },
-                "last_seen_time" | "last_seen" => match clause.direction {
-                    OrderDirection::Asc => query.order(col_last_seen_time.asc()),
-                    OrderDirection::Desc => query.order(col_last_seen_time.desc()),
-                },
-                "type_id" => match clause.direction {
-                    OrderDirection::Asc => query.order(col_type_id.asc()),
-                    OrderDirection::Desc => query.order(col_type_id.desc()),
-                },
-                _ => query,
-            }
+        let (updated, did_apply) = if applied {
+            apply_secondary_order(query, clause)
         } else {
-            match clause.field.as_str() {
-                "uid" => match clause.direction {
-                    OrderDirection::Asc => query.then_order_by(col_uid.asc()),
-                    OrderDirection::Desc => query.then_order_by(col_uid.desc()),
-                },
-                "first_seen_time" | "first_seen" => match clause.direction {
-                    OrderDirection::Asc => query.then_order_by(col_first_seen_time.asc()),
-                    OrderDirection::Desc => query.then_order_by(col_first_seen_time.desc()),
-                },
-                "last_seen_time" | "last_seen" => match clause.direction {
-                    OrderDirection::Asc => query.then_order_by(col_last_seen_time.asc()),
-                    OrderDirection::Desc => query.then_order_by(col_last_seen_time.desc()),
-                },
-                _ => query,
-            }
+            apply_primary_order(query, clause)
         };
+
+        query = updated;
+        if did_apply {
+            applied = true;
+        }
+
+        match clause.field.as_str() {
+            "is_available" => saw_is_available = true,
+            "ip" => saw_ip = true,
+            _ => {}
+        }
     }
 
     if !applied {
         query = query
-            .order(col_last_seen_time.desc())
-            .then_order_by(col_uid.desc());
+            .order(sql::<Bool>("coalesce(is_available, false)").desc())
+            .then_order_by(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").asc())
+            .then_order_by(col_uid.asc());
+    } else if saw_is_available && !saw_ip {
+        query = query
+            .then_order_by(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").asc())
+            .then_order_by(col_uid.asc());
+    } else {
+        query = query.then_order_by(col_uid.asc());
     }
 
     query
+}
+
+fn apply_primary_order<'a>(
+    query: DeviceQuery<'a>,
+    clause: &OrderClause,
+) -> (DeviceQuery<'a>, bool) {
+    match clause.field.as_str() {
+        "is_available" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(sql::<Bool>("coalesce(is_available, false)").asc()),
+                OrderDirection::Desc => query.order(sql::<Bool>("coalesce(is_available, false)").desc()),
+            },
+            true,
+        ),
+        "ip" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").asc()),
+                OrderDirection::Desc => query.order(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").desc()),
+            },
+            true,
+        ),
+        "uid" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(col_uid.asc()),
+                OrderDirection::Desc => query.order(col_uid.desc()),
+            },
+            true,
+        ),
+        // Support both OCSF and legacy time field names
+        "first_seen_time" | "first_seen" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(col_first_seen_time.asc()),
+                OrderDirection::Desc => query.order(col_first_seen_time.desc()),
+            },
+            true,
+        ),
+        "last_seen_time" | "last_seen" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(col_last_seen_time.asc()),
+                OrderDirection::Desc => query.order(col_last_seen_time.desc()),
+            },
+            true,
+        ),
+        "type_id" => (
+            match clause.direction {
+                OrderDirection::Asc => query.order(col_type_id.asc()),
+                OrderDirection::Desc => query.order(col_type_id.desc()),
+            },
+            true,
+        ),
+        _ => (query, false),
+    }
+}
+
+fn apply_secondary_order<'a>(
+    query: DeviceQuery<'a>,
+    clause: &OrderClause,
+) -> (DeviceQuery<'a>, bool) {
+    match clause.field.as_str() {
+        "is_available" => (
+            match clause.direction {
+                OrderDirection::Asc => {
+                    query.then_order_by(sql::<Bool>("coalesce(is_available, false)").asc())
+                }
+                OrderDirection::Desc => {
+                    query.then_order_by(sql::<Bool>("coalesce(is_available, false)").desc())
+                }
+            },
+            true,
+        ),
+        "ip" => (
+            match clause.direction {
+                OrderDirection::Asc => {
+                    query.then_order_by(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").asc())
+                }
+                OrderDirection::Desc => {
+                    query.then_order_by(sql::<Nullable<Inet>>("NULLIF(ip, '')::inet").desc())
+                }
+            },
+            true,
+        ),
+        "uid" => (
+            match clause.direction {
+                OrderDirection::Asc => query.then_order_by(col_uid.asc()),
+                OrderDirection::Desc => query.then_order_by(col_uid.desc()),
+            },
+            true,
+        ),
+        // Support both OCSF and legacy time field names
+        "first_seen_time" | "first_seen" => (
+            match clause.direction {
+                OrderDirection::Asc => query.then_order_by(col_first_seen_time.asc()),
+                OrderDirection::Desc => query.then_order_by(col_first_seen_time.desc()),
+            },
+            true,
+        ),
+        "last_seen_time" | "last_seen" => (
+            match clause.direction {
+                OrderDirection::Asc => query.then_order_by(col_last_seen_time.asc()),
+                OrderDirection::Desc => query.then_order_by(col_last_seen_time.desc()),
+            },
+            true,
+        ),
+        "type_id" => (
+            match clause.direction {
+                OrderDirection::Asc => query.then_order_by(col_type_id.asc()),
+                OrderDirection::Desc => query.then_order_by(col_type_id.desc()),
+            },
+            true,
+        ),
+        _ => (query, false),
+    }
 }
 
 fn parse_bool(raw: &str) -> Result<bool> {

--- a/web-ng/lib/serviceradar_web_ng_web/srql/builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/srql/builder.ex
@@ -201,7 +201,6 @@ defmodule ServiceRadarWebNGWeb.SRQL.Builder do
 
   defp normalize_sort_field(entity, field) when is_binary(field) do
     field = String.trim(field)
-
     allowed = allowed_sort_fields(entity)
 
     cond do
@@ -230,7 +229,7 @@ defmodule ServiceRadarWebNGWeb.SRQL.Builder do
         if id == "gateways" do
           ["last_seen", "gateway_id", "status", "agent_count", "checker_count"]
         else
-          ["last_seen", "hostname", "ip", "uid"]
+          ["last_seen", "hostname", "ip", "uid", "is_available"]
         end
 
       _ ->

--- a/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex
@@ -7,7 +7,7 @@ defmodule ServiceRadarWebNGWeb.SRQL.Catalog do
       label: "Devices",
       route: "/devices",
       default_time: "",
-      default_sort_field: "last_seen",
+      default_sort_field: "is_available",
       default_sort_dir: "desc",
       default_filter_field: "hostname",
       filter_fields: [


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Enhancement


___

### **Description**
- Add `is_available` as sortable field for devices in SRQL

- Change default device sort from `last_seen` to `is_available`

- Refactor ordering logic to support primary and secondary sort fields

- Implement intelligent default ordering: `is_available` desc, then `ip` asc, then `uid` asc


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Sorting Request"] --> B["SRQL Builder"]
  B --> C["Allowed Sort Fields"]
  C --> D["is_available Added"]
  D --> E["Rust Query Builder"]
  E --> F["Primary Order Function"]
  E --> G["Secondary Order Function"]
  F --> H["Default: is_available desc"]
  G --> I["Then: ip asc, uid asc"]
  H --> J["Ordered Results"]
  I --> J
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>catalog.ex</strong><dd><code>Change default device sort field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/srql/catalog.ex

<ul><li>Changed default sort field for devices from <code>last_seen</code> to <code>is_available</code><br> <li> Maintains backward compatibility with existing catalog structure</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2661/files#diff-80c07c25c17e48bf86860ec91db10256b7700a863d5371798e1893e741dc0e15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>builder.ex</strong><dd><code>Add is_available to allowed sort fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/srql/builder.ex

<ul><li>Added <code>is_available</code> to allowed sort fields for devices<br> <li> Removed unnecessary blank line in <code>normalize_sort_field</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2661/files#diff-0eed4282479f6f8c4f3ed9ae60280a2acdd5ff9d52db06dde050ed49d3b6da20">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>devices.rs</strong><dd><code>Refactor ordering logic and add is_available support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/devices.rs

<ul><li>Added <code>Inet</code> type import for IP address handling<br> <li> Refactored <code>apply_ordering</code> function to support multiple sort clauses <br>with primary and secondary ordering<br> <li> Extracted ordering logic into <code>apply_primary_order</code> and <br><code>apply_secondary_order</code> helper functions<br> <li> Implemented intelligent default ordering: <code>is_available</code> (desc), then <code>ip</code> <br>(asc), then <code>uid</code> (asc)<br> <li> Added support for <code>is_available</code> and <code>ip</code> fields with proper SQL type <br>casting<br> <li> Track which fields have been applied to avoid duplicate ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2661/files#diff-3202f22fff6863ed7848a129c49e2323322462b379d896d3fca2e59aa6f7b4c5">+139/-40</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

