### PR TITLE
2675 bug cant create event rule   invalid request unsupported filter field for logs timestamp

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1753,7 +1753,7 @@
         "bzlTransitiveDigest": "qATCXoRXiE4t2IhaFrGaKqtvL9i+mgfVSeAFstpB2/Q=",
         "usagesDigest": "nBE61dnm18OtQXTyg7JmEHbvLyMbE7WBDjiibYOo1aE=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "4ec613effd6c42c726b654e84c8f6ca34a1c936ef2fbb66cb3899d8609d8c62a",
+          "@@//Cargo.lock": "4c79422db16c60962a787489bd46934cdee28237fda56be7d4c077a074c50a65",
           "@@//Cargo.toml": "b1ddcdaef53ae1ac1fc8475d101096af3eec67e3a15b3284fb1436c561815a65",
           "@@//cmd/checkers/rperf-client/Cargo.toml": "a0c791977332d5ab34a589b105b63f9723372480bdc7d789fa1eed70e239ce35",
           "@@//cmd/consumers/zen/Cargo.toml": "13b21f7d75c3ca22aeb560efa80fc6c1317596ec59060c2139dc81bb0f1aaaec",

--- a/openspec/changes/fix-log-rule-preview-time-filter/proposal.md
+++ b/openspec/changes/fix-log-rule-preview-time-filter/proposal.md
@@ -1,0 +1,12 @@
+# Change: Fix log rule preview time filter token
+
+## Why
+The log promotion rule preview currently builds `timestamp:>now-1h`, which SRQL treats as a normal filter field and rejects for logs. This causes the "Test Rule" preview to fail with "unsupported filter field for logs: 'timestamp'" and blocks rule creation workflows.
+
+## What Changes
+- Use the SRQL `time:` filter token (e.g. `time:last_1h`) when building preview queries for log promotion rules.
+- Update preview query tests to assert the correct time filter token.
+
+## Impact
+- Affected specs: observability-rule-management
+- Affected code: web-ng rule builder preview query assembly

--- a/openspec/changes/fix-log-rule-preview-time-filter/specs/observability-rule-management/spec.md
+++ b/openspec/changes/fix-log-rule-preview-time-filter/specs/observability-rule-management/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+### Requirement: Rule Testing and Preview
+The system SHALL allow users to test promotion rule match conditions against recent logs before saving the rule.
+
+#### Scenario: Test rule against recent logs
+- **GIVEN** the user has configured match conditions in the rule builder
+- **WHEN** the user clicks "Test Rule"
+- **THEN** the system SHALL query logs from the last hour using the configured conditions and an SRQL `time:last_1h` filter
+- **AND** the system SHALL display the count of matching logs
+- **AND** the system SHALL display a sample of up to 10 matching log entries
+
+#### Scenario: No matching logs found
+- **GIVEN** the user has configured match conditions that don't match any recent logs
+- **WHEN** the user clicks "Test Rule"
+- **THEN** the system SHALL display a message indicating no logs would match
+- **AND** the user SHALL still be able to save the rule
+
+#### Scenario: Preview updates as conditions change
+- **GIVEN** the user has tested a rule and sees matching results
+- **WHEN** the user modifies a match condition
+- **THEN** the system SHALL update the preview after a short delay (debounced)
+- **AND** the new match count and samples SHALL reflect the updated conditions

--- a/openspec/changes/fix-log-rule-preview-time-filter/tasks.md
+++ b/openspec/changes/fix-log-rule-preview-time-filter/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update the log promotion rule preview query to use `time:last_1h` instead of a `timestamp:` filter
+- [x] 1.2 Update rule preview query tests to assert the new time filter token
+- [ ] 1.3 Manually verify the rule preview works without SRQL filter errors

--- a/rust/srql/src/query/logs.rs
+++ b/rust/srql/src/query/logs.rs
@@ -219,7 +219,7 @@ fn collect_filter_params(params: &mut Vec<BindParam>, filter: &Filter) -> Result
         }
         "trace_id" | "span_id" | "service_name" | "service_version" | "service_instance"
         | "source" | "scope_name" | "scope_version" | "severity_text" | "severity" | "level"
-        | "body" => {
+        | "body" | "message" => {
             collect_text_params(params, filter)
         }
         "severity_number" => match filter.op {
@@ -468,7 +468,7 @@ fn apply_filter<'a>(mut query: LogsQuery<'a>, filter: &Filter) -> Result<LogsQue
         "severity_text" | "severity" | "level" => {
             query = apply_text_filter!(query, filter, col_severity_text)?;
         }
-        "body" => {
+        "body" | "message" => {
             query = apply_text_filter!(query, filter, col_body)?;
         }
         "severity_number" => match filter.op {
@@ -695,7 +695,7 @@ fn resolve_group_field(field: &str) -> Result<&'static str> {
         "severity_text" | "severity" | "level" => Ok("severity_text"),
         "trace_id" => Ok("trace_id"),
         "span_id" => Ok("span_id"),
-        "body" => Ok("body"),
+        "body" | "message" => Ok("body"),
         other => Err(ServiceError::InvalidRequest(format!(
             "unsupported field '{other}' for group_uniq_array"
         ))),
@@ -713,7 +713,7 @@ fn build_stats_filter_clause(filter: &Filter) -> Result<Option<(String, Vec<SqlB
         "scope_name" => build_text_clause("scope_name", filter),
         "scope_version" => build_text_clause("scope_version", filter),
         "severity_text" | "severity" | "level" => build_text_clause("severity_text", filter),
-        "body" => build_text_clause("body", filter),
+        "body" | "message" => build_text_clause("body", filter),
         "severity_number" => build_numeric_clause("severity_number", filter),
         other => Err(ServiceError::InvalidRequest(format!(
             "unsupported filter field for logs stats: '{other}'"
@@ -929,6 +929,66 @@ mod tests {
             }
             Ok(_) => panic!("expected error for unknown filter field"),
         }
+    }
+
+    #[test]
+    fn message_filter_is_supported() {
+        let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let end = start + ChronoDuration::hours(24);
+        let plan = QueryPlan {
+            entity: Entity::Logs,
+            filters: vec![Filter {
+                field: "message".into(),
+                op: FilterOp::Like,
+                value: FilterValue::Scalar("%earlyoom%".to_string()),
+            }],
+            order: Vec::new(),
+            limit: 100,
+            offset: 0,
+            time_range: Some(TimeRange { start, end }),
+            stats: None,
+            downsample: None,
+            rollup_stats: None,
+            include_deleted: false,
+        };
+
+        let result = build_query(&plan);
+        assert!(result.is_ok(), "message filter should be supported");
+    }
+
+    #[test]
+    fn stats_query_accepts_message_filter() {
+        let start = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+        let end = start + ChronoDuration::hours(24);
+        let plan = QueryPlan {
+            entity: Entity::Logs,
+            filters: vec![Filter {
+                field: "message".into(),
+                op: FilterOp::Like,
+                value: FilterValue::Scalar("%earlyoom%".to_string()),
+            }],
+            order: Vec::new(),
+            limit: 100,
+            offset: 0,
+            time_range: Some(TimeRange { start, end }),
+            stats: Some(crate::parser::StatsSpec::from_raw("count() as total")),
+            downsample: None,
+            rollup_stats: None,
+            include_deleted: false,
+        };
+
+        let stats_sql = build_stats_query(&plan).expect("stats query should parse");
+        let stats_sql = stats_sql.expect("stats SQL expected");
+        assert!(
+            stats_sql.sql.to_lowercase().contains("body ilike"),
+            "message filter should map to body: {}",
+            stats_sql.sql
+        );
+        assert_eq!(
+            stats_sql.binds.len(),
+            3,
+            "time range + message filter binds expected"
+        );
     }
 
     #[test]

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -767,7 +767,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
       end
 
     base = "in:logs"
-    time_filter = "timestamp:>now-1h"
+    time_filter = "time:last_1h"
 
     [base, time_filter | filters]
     |> Enum.join(" ")

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -689,7 +689,9 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
 
     scope = socket.assigns.current_scope
 
-    case Ash.create(EventRule, attrs, scope: scope) do
+    changeset = Ash.Changeset.for_create(EventRule, :create, attrs, scope: scope)
+
+    case Ash.create(changeset) do
       {:ok, rule} ->
         send(self(), {:rule_created, rule})
         {:noreply, assign(socket, :saving, false)}

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -755,7 +755,8 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
 
     filters =
       if form[:severity_enabled].value and String.trim(form[:severity_text].value || "") != "" do
-        ["severity_text:\"#{form[:severity_text].value}\"" | filters]
+        escaped = escape_srql_value(form[:severity_text].value)
+        ["severity_text:\"%#{escaped}%\"" | filters]
       else
         filters
       end

--- a/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex
@@ -748,7 +748,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilder do
       if form[:body_contains_enabled].value and
            String.trim(form[:body_contains].value || "") != "" do
         escaped = escape_srql_value(form[:body_contains].value)
-        ["body:\"*#{escaped}*\"" | filters]
+        ["body:\"%#{escaped}%\"" | filters]
       else
         filters
       end

--- a/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex
@@ -71,10 +71,8 @@ defmodule ServiceRadarWebNGWeb.LogLive.Show do
     {:noreply,
      socket
      |> assign(:show_rule_builder, false)
-     |> put_flash(
-       :info,
-       "Rule \"#{rule.name}\" created successfully. View it in Settings > Rules."
-     )}
+     |> put_flash(:info, "Rule \"#{rule.name}\" created successfully.")
+     |> push_navigate(to: ~p"/settings/rules?#{%{tab: "events"}}")}
   end
 
   def handle_info({:rule_creation_failed, reason}, socket) do

--- a/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
@@ -204,7 +204,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
 
       query = build_preview_query(form)
 
-      assert query =~ ~s(severity_text:"error")
+      assert query =~ ~s(severity_text:"%error%")
     end
 
     test "builds query with service name filter" do
@@ -247,7 +247,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
 
       assert query =~ "in:logs"
       assert query =~ ~s(body:"%timeout%")
-      assert query =~ ~s(severity_text:"error")
+      assert query =~ ~s(severity_text:"%error%")
       assert query =~ ~s(service_name:"api-gateway")
     end
   end

--- a/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
@@ -192,7 +192,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
 
       query = build_preview_query(form)
 
-      assert query =~ ~s(body:"*connection error*")
+      assert query =~ ~s(body:"%connection error%")
     end
 
     test "builds query with severity filter" do
@@ -229,7 +229,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
       query = build_preview_query(form)
 
       # Should escape the quotes
-      assert query =~ ~s(body:"*error with \\"quotes\\"*)
+      assert query =~ ~s(body:"%error with \\"quotes\\"%")
     end
 
     test "builds query with multiple filters" do
@@ -246,7 +246,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
       query = build_preview_query(form)
 
       assert query =~ "in:logs"
-      assert query =~ ~s(body:"*timeout*")
+      assert query =~ ~s(body:"%timeout%")
       assert query =~ ~s(severity_text:"error")
       assert query =~ ~s(service_name:"api-gateway")
     end

--- a/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs
@@ -179,7 +179,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
       query = build_preview_query(form)
 
       assert query =~ "in:logs"
-      assert query =~ "timestamp:>now-1h"
+      assert query =~ "time:last_1h"
       assert query =~ "limit:10"
     end
 
@@ -482,7 +482,7 @@ defmodule ServiceRadarWebNGWeb.Components.PromotionRuleBuilderTest do
       end
 
     base = "in:logs"
-    time_filter = "timestamp:>now-1h"
+    time_filter = "time:last_1h"
 
     [base, time_filter | filters]
     |> Enum.join(" ")

--- a/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
+++ b/web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs
@@ -155,7 +155,7 @@ defmodule ServiceRadarWebNGWeb.LogLive.ShowTest do
       })
       |> render_submit()
 
-      refute has_element?(lv, "#rule_builder_modal")
+      assert_redirect(lv, ~p"/settings/rules?#{%{tab: "events"}}")
 
       rules = unwrap_page(Ash.read(ServiceRadar.Observability.LogPromotionRule, scope: scope))
       rule = Enum.find(rules, &(&1.name == rule_name))


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix event rule creation by using Ash.Changeset for proper validation

- Replace unsupported `timestamp:` filter with SRQL `time:last_1h` token

- Add support for `message` field alias in log query filters

- Navigate to rules page after successful rule creation

- Apply consistent SRQL wildcard syntax with percent signs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Rule Creation"] -->|Use Changeset| B["Proper Validation"]
  C["SRQL Query Building"] -->|Replace timestamp| D["Use time:last_1h"]
  E["Log Filters"] -->|Add message alias| F["Support message field"]
  G["Rule Creation Success"] -->|Navigate| H["Settings Rules Page"]
  I["Preview Filters"] -->|Escape & Format| J["Percent wildcard syntax"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder.ex</strong><dd><code>Fix event rule creation and SRQL query syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/components/promotion_rule_builder.ex

<ul><li>Use <code>Ash.Changeset.for_create</code> before <code>Ash.create</code> for proper validation<br> <li> Replace <code>timestamp:>now-1h</code> with <code>time:last_1h</code> in preview queries<br> <li> Apply percent-sign wildcards to body and severity filters<br> <li> Escape SRQL values consistently for all filter types</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-0226580d3777904915943339ececa4e0e314a03a7c43a0e9afec64fe2a8f9354">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Navigate to rules after rule creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/log_live/show.ex

<ul><li>Navigate to settings rules page after successful rule creation<br> <li> Simplify success flash message<br> <li> Redirect to rules with events tab selected</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-4f9769353c55928a0d382cd7510379444445aea116e1ecdf7b8eb892d249ff26">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logs.rs</strong><dd><code>Add message field alias support for logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/srql/src/query/logs.rs

<ul><li>Add <code>message</code> as supported field alias for <code>body</code> in filter collection<br> <li> Add <code>message</code> field support in text filter application<br> <li> Add <code>message</code> field support in group field resolution<br> <li> Add <code>message</code> field support in stats filter clause building<br> <li> Add test cases for message filter support in regular and stats queries</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-f4d3b33667f2e79a6ebe4cfff931f93c728d9a81c305ac13586e623850a504db">+64/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>promotion_rule_builder_test.exs</strong><dd><code>Update preview query test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/components/promotion_rule_builder_test.exs

<ul><li>Update time filter assertions from <code>timestamp:>now-1h</code> to <code>time:last_1h</code><br> <li> Update body filter assertions to use percent wildcards instead of <br>asterisks<br> <li> Update severity filter assertions to use percent wildcards and <br>escaping<br> <li> Verify multiple filter combinations with new syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-4ff7f672a7acd6834d3e7eba25af462a2535e6ee010b511de8e57d12693703d4">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show_test.exs</strong><dd><code>Update rule creation success assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/test/serviceradar_web_ng_web/live/log_live/show_test.exs

<ul><li>Assert redirect to settings rules page instead of modal closure<br> <li> Verify navigation includes events tab parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-2d62472b3e212a4da643a2f66d2a07d358795602e680f31249a162b71fa0ea3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Add change proposal documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-rule-preview-time-filter/proposal.md

<ul><li>Document the issue with <code>timestamp:>now-1h</code> filter rejection<br> <li> Specify use of SRQL <code>time:last_1h</code> token as solution<br> <li> List affected specs and code components</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-a9154afa019d66a662e2d3dd92480888ead5f77e0ac7890e32d4827305cc20c7">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Add rule preview specification requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-rule-preview-time-filter/specs/observability-rule-management/spec.md

<ul><li>Define requirement for rule testing and preview functionality<br> <li> Specify SRQL <code>time:last_1h</code> filter usage in scenarios<br> <li> Document preview update behavior on condition changes</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-b4180adcaf3fd0524deb151c47a9faf9beab40b8e3243b7caa063e7c386434e7">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Add implementation task tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/fix-log-rule-preview-time-filter/tasks.md

<ul><li>Track implementation tasks for time filter fix<br> <li> Mark query update and test updates as complete<br> <li> Note manual verification task pending</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2679/files#diff-b68695dcb9f576e88870b0c4aa3cbc4ccd6aa859f71581b01849ce2f5bbed0b5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

