### PR TITLE
fix: Caching flows with no template

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -8,6 +8,7 @@ elixir/datasvc/deps
 elixir/serviceradar_core/deps
 elixir/serviceradar_core_elx/deps
 elixir/serviceradar_poller/deps
+elixir/protobuf/deps
 node_modules
 dist
 target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
+
+[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if 1.0.4",
+ "memchr",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,12 +1172,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1162,11 +1220,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.114",
 ]
@@ -1223,6 +1292,37 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1298,6 +1398,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "direct-cargo-bazel-deps"
+version = "0.0.1"
+dependencies = [
+ "libzetta",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,7 +1448,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -1482,6 +1589,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde 1.0.228",
+]
 
 [[package]]
 name = "errno"
@@ -1855,6 +1971,18 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2621,6 +2749,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libnv"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4fecff624ba832137c82123e6fc332d8fa94018e84055c02d84ba09705df850"
+dependencies = [
+ "libc",
+ "nvpair-sys",
+ "quick-error 2.0.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +2768,45 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
+]
+
+[[package]]
+name = "libzetta"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b445f50ec6fb16c8e5029827f72cfd4617cd18a732aec4a22ec76397bb30a4ed"
+dependencies = [
+ "bitflags 1.2.1",
+ "chrono",
+ "cmake",
+ "cstr-argument",
+ "derive_builder",
+ "getset",
+ "lazy_static",
+ "libc",
+ "libnv",
+ "libzetta-zfs-core-sys",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "quick-error 1.2.3",
+ "regex",
+ "slog",
+ "slog-stdlog",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "libzetta-zfs-core-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5839d503d2c731dd8dd2366f8dbf6c3cfeaa65c2c8e5fe752ce51bd3bdbfd4c8"
+dependencies = [
+ "build-env",
+ "libc",
+ "nvpair-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3215,6 +3393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvpair-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81222a842a50a0929c9d8411f839475cec320f3cb41e97735b2746524f6eb75a"
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,6 +3607,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -3734,6 +3961,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4051,6 +4300,18 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5230,7 +5491,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5526,6 +5787,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b76cf645c92e7850d5a1c9205ebf2864bd32c0ab3e978e6daad51fedf7ef54"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
+dependencies = [
+ "log 0.4.29",
+ "slog",
+ "slog-scope",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5699,9 +5994,21 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
@@ -5709,7 +6016,20 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6597,6 +6917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,7 +7731,7 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "sha2",
- "strum",
+ "strum 0.27.2",
  "thiserror 1.0.69",
  "tokio",
  "zen-expression",
@@ -7436,8 +7762,8 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "strsim 0.11.1",
- "strum",
- "strum_macros",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "thiserror 1.0.69",
  "zen-macros",
  "zen-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,15 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,12 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,15 +888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,16 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if 1.0.4",
- "memchr",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,36 +1138,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1220,22 +1162,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.114",
 ]
@@ -1292,37 +1223,6 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1398,13 +1298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "direct-cargo-bazel-deps"
-version = "0.0.1"
-dependencies = [
- "libzetta",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,7 +1341,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -1589,15 +1482,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde 1.0.228",
-]
 
 [[package]]
 name = "errno"
@@ -1971,18 +1855,6 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2749,17 +2621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libnv"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4fecff624ba832137c82123e6fc332d8fa94018e84055c02d84ba09705df850"
-dependencies = [
- "libc",
- "nvpair-sys",
- "quick-error 2.0.1",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,45 +2629,6 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
-]
-
-[[package]]
-name = "libzetta"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b445f50ec6fb16c8e5029827f72cfd4617cd18a732aec4a22ec76397bb30a4ed"
-dependencies = [
- "bitflags 1.2.1",
- "chrono",
- "cmake",
- "cstr-argument",
- "derive_builder",
- "getset",
- "lazy_static",
- "libc",
- "libnv",
- "libzetta-zfs-core-sys",
- "once_cell",
- "pest",
- "pest_derive",
- "quick-error 1.2.3",
- "regex",
- "slog",
- "slog-stdlog",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "libzetta-zfs-core-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5839d503d2c731dd8dd2366f8dbf6c3cfeaa65c2c8e5fe752ce51bd3bdbfd4c8"
-dependencies = [
- "build-env",
- "libc",
- "nvpair-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -3393,12 +3215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nvpair-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81222a842a50a0929c9d8411f839475cec320f3cb41e97735b2746524f6eb75a"
-
-[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,49 +3423,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -3961,28 +3734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -4300,18 +4051,6 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5491,7 +5230,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -5787,40 +5526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slog"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
-dependencies = [
- "anyhow",
- "erased-serde",
- "rustversion",
- "serde_core",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b76cf645c92e7850d5a1c9205ebf2864bd32c0ab3e978e6daad51fedf7ef54"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog-stdlog"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
-dependencies = [
- "log 0.4.29",
- "slog",
- "slog-scope",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5994,21 +5699,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
@@ -6016,20 +5709,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -6917,12 +6597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,7 +7405,7 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "sha2",
- "strum 0.27.2",
+ "strum",
  "thiserror 1.0.69",
  "tokio",
  "zen-expression",
@@ -7762,8 +7436,8 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "strsim 0.11.1",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum",
+ "strum_macros",
  "thiserror 1.0.69",
  "zen-macros",
  "zen-types",

--- a/rust/netflow-collector/src/config.rs
+++ b/rust/netflow-collector/src/config.rs
@@ -43,6 +43,12 @@ pub struct Config {
     // Security
     pub security: Option<SecurityConfig>,
 
+    // Pending packet buffer
+    #[serde(default = "default_pending_packet_ttl_secs")]
+    pub pending_packet_ttl_secs: u64,
+    #[serde(default = "default_max_pending_packets")]
+    pub max_pending_packets: usize,
+
     // Observability
     pub metrics_addr: Option<String>,
 }
@@ -134,6 +140,14 @@ fn default_partition() -> String {
 
 fn default_stream_max_bytes() -> i64 {
     10 * 1024 * 1024 * 1024
+}
+
+fn default_pending_packet_ttl_secs() -> u64 {
+    60
+}
+
+fn default_max_pending_packets() -> usize {
+    100
 }
 
 impl Config {

--- a/rust/netflow-collector/src/listener.rs
+++ b/rust/netflow-collector/src/listener.rs
@@ -2,13 +2,15 @@ use crate::config::Config;
 use crate::converter::{Converter, is_valid_flow};
 use crate::converter::flowpb;
 use crate::error::GetCurrentTimeError;
+use crate::pending_buffer::PendingPacketBuffer;
 use anyhow::Result;
 use log::{debug, error, info, warn};
-use netflow_parser::{AutoScopedParser, NetflowParserBuilder, TemplateEvent};
+use netflow_parser::{AutoScopedParser, NetflowPacket, NetflowParserBuilder, TemplateEvent};
 use prost::Message;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
@@ -71,6 +73,8 @@ pub struct Listener {
     socket: Arc<UdpSocket>,
     parser: Mutex<AutoScopedParser>,
     tx: mpsc::Sender<Vec<u8>>,
+    pending_buffer: Mutex<PendingPacketBuffer>,
+    templates_learned: Arc<AtomicBool>,
 }
 
 impl Listener {
@@ -78,17 +82,32 @@ impl Listener {
         let socket = UdpSocket::bind(&config.listen_addr).await?;
         info!("NetFlow collector listening on {}", config.listen_addr);
 
+        let templates_learned = Arc::new(AtomicBool::new(false));
+        let tl_clone = templates_learned.clone();
+
         let builder = NetflowParserBuilder::default()
             .with_cache_size(config.max_templates)
-            .on_template_event(template_event_callback);
+            .on_template_event(move |event: &TemplateEvent| {
+                template_event_callback(event);
+                if matches!(event, TemplateEvent::Learned { .. }) {
+                    tl_clone.store(true, Ordering::Relaxed);
+                }
+            });
 
         let parser = AutoScopedParser::with_builder(builder);
+
+        let pending_buffer = PendingPacketBuffer::new(
+            Duration::from_secs(config.pending_packet_ttl_secs),
+            config.max_pending_packets,
+        );
 
         Ok(Self {
             config,
             socket: Arc::new(socket),
             parser: Mutex::new(parser),
             tx,
+            pending_buffer: Mutex::new(pending_buffer),
+            templates_learned,
         })
     }
 
@@ -116,6 +135,79 @@ impl Listener {
         u64::try_from(duration.as_nanos()).map_err(GetCurrentTimeError::TryFromIntError)
     }
 
+    /// Process a single parsed NetFlow packet: convert, filter, encode, and send.
+    /// Returns (valid_count, dropped_count).
+    fn process_parsed_packet(
+        &self,
+        packet: NetflowPacket,
+        peer_addr: SocketAddr,
+        receive_time_ns: u64,
+    ) -> Result<(usize, usize)> {
+        debug!("Parsed NetFlow packet {:?}", packet);
+
+        let flow_messages: Vec<flowpb::FlowMessage> =
+            match Converter::new(packet, peer_addr, receive_time_ns).try_into() {
+                Ok(messages) => messages,
+                Err(e) => {
+                    warn!("Failed to convert NetFlow packet to protobuf: {:?}", e);
+                    return Ok((0, 0));
+                }
+            };
+
+        // Filter out degenerate flow records (0 bytes, 0 packets)
+        let (valid, invalid): (Vec<_>, Vec<_>) =
+            flow_messages.into_iter().partition(is_valid_flow);
+
+        if !invalid.is_empty() {
+            warn!(
+                "Dropped {} degenerate flow record(s) from {} \
+                 (0 bytes, 0 packets - likely options template or metadata)",
+                invalid.len(),
+                peer_addr
+            );
+            for dropped in &invalid {
+                debug!(
+                    "Dropped flow: proto={} protocol_name={:?} src_addr={:?} dst_addr={:?} \
+                     src_port={} dst_port={} type={:?}",
+                    dropped.proto,
+                    dropped.protocol_name,
+                    dropped.src_addr,
+                    dropped.dst_addr,
+                    dropped.src_port,
+                    dropped.dst_port,
+                    dropped.r#type,
+                );
+            }
+        }
+
+        let valid_count = valid.len();
+        let dropped_count = invalid.len();
+        debug!("Converted {} flow records ({} dropped)", valid_count, dropped_count);
+
+        // Encode and send each valid flow message to the publisher channel
+        for flow_msg in valid {
+            let mut buf = Vec::new();
+            if let Err(e) = flow_msg.encode(&mut buf) {
+                error!("Failed to encode protobuf: {}", e);
+                continue;
+            }
+
+            // Send to publisher channel (non-blocking with backpressure handling)
+            match self.tx.try_send(buf) {
+                Ok(_) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!("Publisher channel full, dropping flow message");
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    error!("Publisher channel closed, stopping listener");
+                    return Err(anyhow::anyhow!("Publisher channel closed"));
+                }
+            }
+        }
+
+        Ok((valid_count, dropped_count))
+    }
+
     async fn process_packet(&self, data: &[u8], peer_addr: SocketAddr) -> Result<()> {
         let receive_time_ns = Self::get_current_time_ns()?;
 
@@ -127,77 +219,110 @@ impl Listener {
             parser.iter_packets_from_source(peer_addr, data).collect()
         };
 
+        // Check if templates were learned during this parse (swap to false)
+        let templates_were_learned = self.templates_learned.swap(false, Ordering::Relaxed);
+
+        let mut had_errors = false;
         for packet_result in packets {
-            let packet = match packet_result {
-                Ok(p) => p,
+            match packet_result {
+                Ok(packet) => {
+                    self.process_parsed_packet(packet, peer_addr, receive_time_ns)?;
+                }
                 Err(e) => {
                     warn!("Failed to parse NetFlow packet from {}: {:?}", peer_addr, e);
-                    continue;
-                }
-            };
-            debug!("Parsed NetFlow packet {:?}", packet);
-
-            let flow_messages: Vec<flowpb::FlowMessage> =
-                match Converter::new(packet, peer_addr, receive_time_ns).try_into() {
-                    Ok(messages) => messages,
-                    Err(e) => {
-                        warn!("Failed to convert NetFlow packet to protobuf: {:?}", e);
-                        continue; // Skip this packet and continue with the next
-                    }
-                };
-
-            // Filter out degenerate flow records (0 bytes, 0 packets)
-            let (valid, invalid): (Vec<_>, Vec<_>) =
-                flow_messages.into_iter().partition(is_valid_flow);
-
-            if !invalid.is_empty() {
-                warn!(
-                    "Dropped {} degenerate flow record(s) from {} \
-                     (0 bytes, 0 packets - likely options template or metadata)",
-                    invalid.len(),
-                    peer_addr
-                );
-                for dropped in &invalid {
-                    debug!(
-                        "Dropped flow: proto={} protocol_name={:?} src_addr={:?} dst_addr={:?} \
-                         src_port={} dst_port={} type={:?}",
-                        dropped.proto,
-                        dropped.protocol_name,
-                        dropped.src_addr,
-                        dropped.dst_addr,
-                        dropped.src_port,
-                        dropped.dst_port,
-                        dropped.r#type,
-                    );
-                }
-            }
-
-            debug!("Converted {} flow records ({} dropped)", valid.len(), invalid.len());
-
-            // Encode and send each valid flow message to the publisher channel
-            for flow_msg in valid {
-                let mut buf = Vec::new();
-                if let Err(e) = flow_msg.encode(&mut buf) {
-                    error!("Failed to encode protobuf: {}", e);
-                    continue;
-                }
-
-                // Send to publisher channel (non-blocking with backpressure handling)
-                match self.tx.try_send(buf) {
-                    Ok(_) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        warn!("Publisher channel full, dropping flow message");
-                        // TODO: Increment metrics counter for drops
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        error!("Publisher channel closed, stopping listener");
-                        return Err(anyhow::anyhow!("Publisher channel closed"));
-                    }
+                    had_errors = true;
                 }
             }
         }
 
+        // If there were parse errors, buffer the raw packet for later retry
+        if had_errors {
+            let mut pending = self.pending_buffer.lock().unwrap();
+            pending.add(peer_addr, data.to_vec(), receive_time_ns);
+            info!(
+                "Buffered pending packet from {} ({} bytes)",
+                peer_addr,
+                data.len()
+            );
+        }
+
+        // If new templates were learned, retry any pending packets for this source
+        if templates_were_learned && self.pending_buffer.lock().unwrap().has_pending(&peer_addr) {
+            self.retry_pending_packets(peer_addr)?;
+        }
+
         Ok(())
+    }
+
+    fn retry_pending_packets(&self, peer_addr: SocketAddr) -> Result<()> {
+        let pending_packets = self.pending_buffer.lock().unwrap().take_all(&peer_addr);
+        let count = pending_packets.len();
+        if count == 0 {
+            return Ok(());
+        }
+
+        info!("Retrying {} pending packet(s) for {}", count, peer_addr);
+
+        let mut recovered = 0usize;
+        let mut still_pending = 0usize;
+
+        for pkt in pending_packets {
+            // Check if this packet has expired
+            if self.pending_buffer.lock().unwrap().is_expired(&pkt) {
+                debug!(
+                    "Dropping expired pending packet from {} ({} bytes)",
+                    peer_addr,
+                    pkt.data.len()
+                );
+                continue;
+            }
+
+            // Re-parse with current template state
+            let packets: Vec<_> = {
+                let mut parser = self.parser.lock().unwrap();
+                parser
+                    .iter_packets_from_source(peer_addr, &pkt.data)
+                    .collect()
+            };
+
+            let mut had_errors = false;
+            for packet_result in packets {
+                match packet_result {
+                    Ok(packet) => {
+                        self.process_parsed_packet(packet, peer_addr, pkt.receive_time_ns)?;
+                        recovered += 1;
+                    }
+                    Err(e) => {
+                        debug!(
+                            "Still failing to parse pending packet from {}: {:?}",
+                            peer_addr, e
+                        );
+                        had_errors = true;
+                    }
+                }
+            }
+
+            // If still has errors, re-buffer
+            if had_errors {
+                self.pending_buffer.lock().unwrap().re_add(peer_addr, pkt);
+                still_pending += 1;
+            }
+        }
+
+        info!(
+            "Pending retry for {}: {} recovered, {} still pending",
+            peer_addr, recovered, still_pending
+        );
+
+        Ok(())
+    }
+
+    pub fn sweep_pending_buffer(&self) {
+        self.pending_buffer.lock().unwrap().sweep_expired();
+    }
+
+    pub fn get_pending_stats(&self) -> (usize, usize) {
+        self.pending_buffer.lock().unwrap().stats()
     }
 
     pub fn get_cache_stats(&self) -> (CacheStatsVec, CacheStatsVec) {

--- a/rust/netflow-collector/src/listener.rs
+++ b/rust/netflow-collector/src/listener.rs
@@ -16,6 +16,12 @@ use tokio::sync::mpsc;
 
 type CacheStatsVec = Vec<(String, netflow_parser::ParserCacheStats)>;
 
+#[derive(Debug, Default)]
+struct ProcessedPacketStats {
+    valid: usize,
+    dropped: usize,
+}
+
 fn template_event_callback(event: &TemplateEvent) {
     use TemplateEvent::*;
     match event {
@@ -136,13 +142,12 @@ impl Listener {
     }
 
     /// Process a single parsed NetFlow packet: convert, filter, encode, and send.
-    /// Returns (valid_count, dropped_count).
     fn process_parsed_packet(
         &self,
         packet: NetflowPacket,
         peer_addr: SocketAddr,
         receive_time_ns: u64,
-    ) -> Result<(usize, usize)> {
+    ) -> Result<ProcessedPacketStats> {
         debug!("Parsed NetFlow packet {:?}", packet);
 
         let flow_messages: Vec<flowpb::FlowMessage> =
@@ -150,7 +155,7 @@ impl Listener {
                 Ok(messages) => messages,
                 Err(e) => {
                     warn!("Failed to convert NetFlow packet to protobuf: {:?}", e);
-                    return Ok((0, 0));
+                    return Ok(ProcessedPacketStats::default());
                 }
             };
 
@@ -180,9 +185,11 @@ impl Listener {
             }
         }
 
-        let valid_count = valid.len();
-        let dropped_count = invalid.len();
-        debug!("Converted {} flow records ({} dropped)", valid_count, dropped_count);
+        let stats = ProcessedPacketStats {
+            valid: valid.len(),
+            dropped: invalid.len(),
+        };
+        debug!("Converted {} flow records ({} dropped)", stats.valid, stats.dropped);
 
         // Encode and send each valid flow message to the publisher channel
         for flow_msg in valid {
@@ -205,7 +212,7 @@ impl Listener {
             }
         }
 
-        Ok((valid_count, dropped_count))
+        Ok(stats)
     }
 
     async fn process_packet(&self, data: &[u8], peer_addr: SocketAddr) -> Result<()> {
@@ -237,7 +244,9 @@ impl Listener {
 
         // If there were parse errors, buffer the raw packet for later retry
         if had_errors {
-            let mut pending = self.pending_buffer.lock().unwrap();
+            let mut pending = self.pending_buffer
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pending buffer lock poisoned: {e}"))?;
             pending.add(peer_addr, data.to_vec(), receive_time_ns);
             info!(
                 "Buffered pending packet from {} ({} bytes)",
@@ -247,7 +256,12 @@ impl Listener {
         }
 
         // If new templates were learned, retry any pending packets for this source
-        if templates_were_learned && self.pending_buffer.lock().unwrap().has_pending(&peer_addr) {
+        let has_pending = self
+            .pending_buffer
+            .lock()
+            .map_err(|e| anyhow::anyhow!("pending buffer lock poisoned: {e}"))?
+            .has_pending(&peer_addr);
+        if templates_were_learned && has_pending {
             self.retry_pending_packets(peer_addr)?;
         }
 
@@ -255,7 +269,11 @@ impl Listener {
     }
 
     fn retry_pending_packets(&self, peer_addr: SocketAddr) -> Result<()> {
-        let pending_packets = self.pending_buffer.lock().unwrap().take_all(&peer_addr);
+        let pending_packets = self
+            .pending_buffer
+            .lock()
+            .map_err(|e| anyhow::anyhow!("pending buffer lock poisoned: {e}"))?
+            .take_all(&peer_addr);
         let count = pending_packets.len();
         if count == 0 {
             return Ok(());
@@ -268,7 +286,12 @@ impl Listener {
 
         for pkt in pending_packets {
             // Check if this packet has expired
-            if self.pending_buffer.lock().unwrap().is_expired(&pkt) {
+            let expired = self
+                .pending_buffer
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pending buffer lock poisoned: {e}"))?
+                .is_expired(&pkt);
+            if expired {
                 debug!(
                     "Dropping expired pending packet from {} ({} bytes)",
                     peer_addr,
@@ -304,7 +327,10 @@ impl Listener {
 
             // If still has errors, re-buffer
             if had_errors {
-                self.pending_buffer.lock().unwrap().re_add(peer_addr, pkt);
+                self.pending_buffer
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("pending buffer lock poisoned: {e}"))?
+                    .re_add(peer_addr, pkt);
                 still_pending += 1;
             }
         }
@@ -318,11 +344,20 @@ impl Listener {
     }
 
     pub fn sweep_pending_buffer(&self) {
-        self.pending_buffer.lock().unwrap().sweep_expired();
+        match self.pending_buffer.lock() {
+            Ok(mut buf) => buf.sweep_expired(),
+            Err(e) => warn!("Failed to lock pending buffer for sweep: {e}"),
+        }
     }
 
     pub fn get_pending_stats(&self) -> (usize, usize) {
-        self.pending_buffer.lock().unwrap().stats()
+        match self.pending_buffer.lock() {
+            Ok(buf) => buf.stats(),
+            Err(e) => {
+                warn!("Failed to lock pending buffer for stats: {e}");
+                (0, 0)
+            }
+        }
     }
 
     pub fn get_cache_stats(&self) -> (CacheStatsVec, CacheStatsVec) {

--- a/rust/netflow-collector/src/main.rs
+++ b/rust/netflow-collector/src/main.rs
@@ -3,6 +3,7 @@ mod converter;
 mod error;
 mod listener;
 mod metrics;
+mod pending_buffer;
 mod publisher;
 
 use anyhow::Result;

--- a/rust/netflow-collector/src/metrics.rs
+++ b/rust/netflow-collector/src/metrics.rs
@@ -66,6 +66,16 @@ impl MetricsReporter {
                 info!("Template Cache - No sources active yet");
             }
 
+            // Sweep expired pending packets and report stats
+            listener.sweep_pending_buffer();
+            let (pending_packets, pending_sources) = listener.get_pending_stats();
+            if pending_packets > 0 {
+                info!(
+                    "Pending packet buffer: {} packet(s) across {} source(s)",
+                    pending_packets, pending_sources
+                );
+            }
+
             // TODO: Expose via Prometheus metrics endpoint on port 50046
             // The current implementation logs metrics, but the structure is ready
             // for Prometheus integration when needed. Example:

--- a/rust/netflow-collector/src/pending_buffer.rs
+++ b/rust/netflow-collector/src/pending_buffer.rs
@@ -1,0 +1,162 @@
+use std::collections::{HashMap, VecDeque};
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+pub struct PendingPacket {
+    pub data: Vec<u8>,
+    pub receive_time_ns: u64,
+    pub received_at: Instant,
+}
+
+pub struct PendingPacketBuffer {
+    buffer: HashMap<SocketAddr, VecDeque<PendingPacket>>,
+    ttl: Duration,
+    max_packets_per_source: usize,
+}
+
+impl PendingPacketBuffer {
+    pub fn new(ttl: Duration, max_per_source: usize) -> Self {
+        Self {
+            buffer: HashMap::new(),
+            ttl,
+            max_packets_per_source: max_per_source,
+        }
+    }
+
+    pub fn add(&mut self, source: SocketAddr, data: Vec<u8>, receive_time_ns: u64) {
+        let queue = self.buffer.entry(source).or_default();
+
+        // Evict oldest if at capacity
+        while queue.len() >= self.max_packets_per_source {
+            queue.pop_front();
+        }
+
+        queue.push_back(PendingPacket {
+            data,
+            receive_time_ns,
+            received_at: Instant::now(),
+        });
+    }
+
+    pub fn take_all(&mut self, source: &SocketAddr) -> Vec<PendingPacket> {
+        self.buffer
+            .remove(source)
+            .map(Vec::from)
+            .unwrap_or_default()
+    }
+
+    pub fn has_pending(&self, source: &SocketAddr) -> bool {
+        self.buffer
+            .get(source)
+            .is_some_and(|q| !q.is_empty())
+    }
+
+    pub fn is_expired(&self, packet: &PendingPacket) -> bool {
+        packet.received_at.elapsed() >= self.ttl
+    }
+
+    pub fn re_add(&mut self, source: SocketAddr, packet: PendingPacket) {
+        let queue = self.buffer.entry(source).or_default();
+        while queue.len() >= self.max_packets_per_source {
+            queue.pop_front();
+        }
+        queue.push_back(packet);
+    }
+
+    pub fn sweep_expired(&mut self) {
+        let ttl = self.ttl;
+        self.buffer.retain(|_, queue| {
+            queue.retain(|pkt| pkt.received_at.elapsed() < ttl);
+            !queue.is_empty()
+        });
+    }
+
+    pub fn stats(&self) -> (usize, usize) {
+        let total_packets: usize = self.buffer.values().map(|q| q.len()).sum();
+        let total_sources = self.buffer.len();
+        (total_packets, total_sources)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::thread::sleep;
+
+    fn test_addr(port: u16) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), port)
+    }
+
+    #[test]
+    fn test_add_and_take_all() {
+        let mut buf = PendingPacketBuffer::new(Duration::from_secs(60), 10);
+        let addr = test_addr(9000);
+
+        buf.add(addr, vec![1, 2, 3], 1000);
+        buf.add(addr, vec![4, 5, 6], 2000);
+
+        assert!(buf.has_pending(&addr));
+
+        let packets = buf.take_all(&addr);
+        assert_eq!(packets.len(), 2);
+        assert_eq!(packets[0].data, vec![1, 2, 3]);
+        assert_eq!(packets[1].data, vec![4, 5, 6]);
+        assert!(!buf.has_pending(&addr));
+    }
+
+    #[test]
+    fn test_eviction_at_capacity() {
+        let mut buf = PendingPacketBuffer::new(Duration::from_secs(60), 2);
+        let addr = test_addr(9000);
+
+        buf.add(addr, vec![1], 1000);
+        buf.add(addr, vec![2], 2000);
+        buf.add(addr, vec![3], 3000);
+
+        let packets = buf.take_all(&addr);
+        assert_eq!(packets.len(), 2);
+        assert_eq!(packets[0].data, vec![2]);
+        assert_eq!(packets[1].data, vec![3]);
+    }
+
+    #[test]
+    fn test_sweep_expired() {
+        let mut buf = PendingPacketBuffer::new(Duration::from_millis(50), 10);
+        let addr = test_addr(9000);
+
+        buf.add(addr, vec![1], 1000);
+        sleep(Duration::from_millis(100));
+
+        buf.sweep_expired();
+        assert!(!buf.has_pending(&addr));
+        let (packets, sources) = buf.stats();
+        assert_eq!(packets, 0);
+        assert_eq!(sources, 0);
+    }
+
+    #[test]
+    fn test_stats() {
+        let mut buf = PendingPacketBuffer::new(Duration::from_secs(60), 10);
+        let addr1 = test_addr(9000);
+        let addr2 = test_addr(9001);
+
+        buf.add(addr1, vec![1], 1000);
+        buf.add(addr1, vec![2], 2000);
+        buf.add(addr2, vec![3], 3000);
+
+        let (packets, sources) = buf.stats();
+        assert_eq!(packets, 3);
+        assert_eq!(sources, 2);
+    }
+
+    #[test]
+    fn test_take_all_empty() {
+        let mut buf = PendingPacketBuffer::new(Duration::from_secs(60), 10);
+        let addr = test_addr(9000);
+
+        let packets = buf.take_all(&addr);
+        assert!(packets.is_empty());
+        assert!(!buf.has_pending(&addr));
+    }
+}

--- a/rust/netflow-collector/src/publisher.rs
+++ b/rust/netflow-collector/src/publisher.rs
@@ -234,8 +234,9 @@ mod tests {
             publish_timeout_ms: 5000,
             drop_policy: crate::config::DropPolicy::DropOldest,
             security: None,
+            pending_packet_ttl_secs: 60,
+            max_pending_packets: 100,
             metrics_addr: None,
-            nats_creds_file: None,
         });
 
         let (_tx, rx) = mpsc::channel(1000);


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add pending packet buffer to handle flows with missing templates

- Implement template learning detection and packet retry mechanism

- Add configurable TTL and max packet limits for pending buffer

- Extract packet processing logic into reusable method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NetFlow Packet Received"] --> B["Parse with Current Templates"]
  B --> C{Parse Successful?}
  C -->|Yes| D["Process & Send Flows"]
  C -->|No| E["Buffer Packet"]
  F["New Template Learned"] --> G["Retry Pending Packets"]
  G --> B
  E --> H["Sweep Expired Packets"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add pending packet buffer configuration options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/netflow-collector/src/config.rs

<ul><li>Add <code>pending_packet_ttl_secs</code> configuration with default 60 seconds<br> <li> Add <code>max_pending_packets</code> configuration with default 100 packets<br> <li> Add corresponding default value functions for serde deserialization</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-ea8fb7fc6e55836ada19b9c1ca26f2a88575289a3fee3005183916a8454d0fc9">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>listener.rs</strong><dd><code>Implement pending packet buffer with template-triggered retry</code></dd></summary>
<hr>

rust/netflow-collector/src/listener.rs

<ul><li>Add <code>PendingPacketBuffer</code> field to store packets awaiting templates<br> <li> Add <code>templates_learned</code> atomic flag to track template learning events<br> <li> Extract packet processing logic into <code>process_parsed_packet()</code> method<br> <li> Implement <code>retry_pending_packets()</code> to re-parse buffered packets when <br>templates arrive<br> <li> Add <code>sweep_pending_buffer()</code> and <code>get_pending_stats()</code> public methods<br> <li> Modify template event callback to set flag when templates are learned<br> <li> Buffer packets on parse errors and retry after template learning</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-3ec4d0175a1f407a9c9246268da3491d1fdfacd2e8c00d536fde36357e993999">+183/-58</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pending_buffer.rs</strong><dd><code>New pending packet buffer implementation with TTL management</code></dd></summary>
<hr>

rust/netflow-collector/src/pending_buffer.rs

<ul><li>Create new module with <code>PendingPacketBuffer</code> struct managing per-source <br>packet queues<br> <li> Implement packet addition with FIFO eviction at capacity limits<br> <li> Implement expiration checking and sweep functionality based on TTL<br> <li> Provide statistics reporting for pending packets and sources<br> <li> Add comprehensive unit tests covering add, eviction, expiration, and <br>stats</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-651ab5c3b686e5207e26c5074beee37b1d97b44c586a4ef6c69a17d36f7cf37d">+162/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metrics.rs</strong><dd><code>Add pending buffer metrics reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/netflow-collector/src/metrics.rs

<ul><li>Call <code>sweep_pending_buffer()</code> during metrics reporting cycle<br> <li> Log pending packet buffer statistics when packets are buffered</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-d3fef810bfa2a5b985b71300423ec1d9c6eea321fee261710cd3257b521ad7e2">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Register pending buffer module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/netflow-collector/src/main.rs

- Add module declaration for new `pending_buffer` module


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-ec91a491c51b432333dc1b7add92effe5fdabfad9a7a807a1af3a05a9602c3bb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publisher.rs</strong><dd><code>Update test configuration for pending buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rust/netflow-collector/src/publisher.rs

<ul><li>Add <code>pending_packet_ttl_secs</code> and <code>max_pending_packets</code> fields to test <br>config<br> <li> Remove obsolete <code>nats_creds_file</code> field from test config</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2689/files#diff-10dec5866b4bc416c62590bdf2d3ded6c234b8d423ec4aebc70eac891ff0c07d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

