### PR TITLE
fixing add device bug

### DIFF
--- a/elixir/serviceradar_core/lib/serviceradar/edge/agent_gateway_sync.ex
+++ b/elixir/serviceradar_core/lib/serviceradar/edge/agent_gateway_sync.ex
@@ -163,6 +163,22 @@ defmodule ServiceRadar.Edge.AgentGatewaySync do
 
     # Check if device exists
     case Device.get_by_uid(device_uid, true, actor: actor) do
+      {:ok, nil} ->
+        # No record found (get? actions can return nil), fall through to create
+        create_device_for_agent(
+          %{
+            device_uid: device_uid,
+            agent_id: agent_id,
+            hostname: hostname,
+            source_ip: source_ip,
+            partition: partition,
+            os_info: os_info,
+            capabilities: capabilities
+          },
+          actor,
+          now
+        )
+
       {:ok, device} ->
         # Update existing device
         update_existing_device_for_agent(device, agent_id, attrs, capabilities, actor, now)
@@ -267,6 +283,13 @@ defmodule ServiceRadar.Edge.AgentGatewaySync do
       {:ok, _device} ->
         Logger.debug("Updated device #{device.uid} for agent #{agent_id}")
         :ok
+
+      {:error, %Ash.Error.Invalid{} = error} ->
+        if stale_record_error?(error) do
+          force_gateway_sync_update(device.uid, update_attrs, actor)
+        else
+          {:error, error}
+        end
 
       {:error, reason} ->
         {:error, reason}
@@ -415,6 +438,38 @@ defmodule ServiceRadar.Edge.AgentGatewaySync do
       _ -> false
     end)
     |> Map.new()
+  end
+
+  defp stale_record_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+  end
+
+  defp stale_record_error?(_), do: false
+
+  defp force_gateway_sync_update(device_uid, update_attrs, actor) do
+    query =
+      Device
+      |> Ash.Query.for_read(:read, %{include_deleted: true})
+      |> Ash.Query.filter(uid == ^device_uid)
+
+    case Ash.bulk_update(query, :gateway_sync, update_attrs,
+           actor: actor,
+           return_errors?: true,
+           return_records?: false
+         ) do
+      %Ash.BulkResult{status: :success} ->
+        Logger.debug("Force-updated device #{device_uid} via gateway_sync")
+        :ok
+
+      %Ash.BulkResult{status: :partial_success, errors: errors} ->
+        {:error, List.first(errors) || :partial_failure}
+
+      %Ash.BulkResult{status: :error, errors: errors} ->
+        {:error, List.first(errors) || :bulk_update_failed}
+
+      other ->
+        {:error, other}
+    end
   end
 
   defp not_found_error?(%Ash.Error.Query.NotFound{}), do: true

--- a/web-ng/lib/serviceradar_web_ng/api/device_controller.ex
+++ b/web-ng/lib/serviceradar_web_ng/api/device_controller.ex
@@ -34,7 +34,7 @@ defmodule ServiceRadarWebNG.Api.DeviceController do
       {:ok, parsed_uid} ->
         scope = get_scope(conn)
 
-        case Device.get_by_uid(parsed_uid, scope: scope) do
+        case Device.get_by_uid(parsed_uid, false, scope: scope) do
           {:ok, device} ->
             json(conn, %{"data" => device_to_map(device)})
 

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -255,14 +255,15 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
       {:error, %Ash.Error.Invalid{} = error} ->
         Logger.warning("Device create failed with validation error: #{inspect(error)}")
+
         {:noreply,
          socket
          |> put_flash(:error, format_device_error(error))}
 
       {:error, :already_exists} ->
         {:noreply,
-        socket
-        |> put_flash(:error, "A device with this IP address already exists.")}
+         socket
+         |> put_flash(:error, "A device with this IP address already exists.")}
 
       {:error, :invalid_uid} ->
         Logger.error("Device create failed: generated UID was invalid for #{inspect(params)}")
@@ -274,6 +275,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
       {:error, reason} ->
         Logger.error("Device create failed: #{inspect(reason)}")
+
         {:noreply,
          socket
          |> put_flash(:error, "Failed to create device: #{inspect(reason)}")}
@@ -473,6 +475,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
           {:error, reason} ->
             Logger.error("Bulk device delete failed for #{inspect(uids)}: #{inspect(reason)}")
+
             {:noreply,
              socket
              |> assign(:show_bulk_delete_modal, false)
@@ -481,6 +484,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
       {:error, reason} ->
         Logger.error("Bulk device delete failed: #{inspect(reason)}")
+
         {:noreply,
          socket
          |> assign(:show_bulk_delete_modal, false)

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -265,11 +265,11 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
         |> put_flash(:error, "A device with this IP address already exists.")}
 
       {:error, :invalid_uid} ->
-        Logger.error("Device create failed: generated UID was invalid", device_params: params)
+        Logger.error("Device create failed: generated UID was invalid for #{inspect(params)}")
         {:noreply, put_flash(socket, :error, "Failed to create device: invalid device UID")}
 
       {:error, :missing_scope} ->
-        Logger.error("Device create failed: missing scope", device_params: params)
+        Logger.error("Device create failed: missing scope for #{inspect(params)}")
         {:noreply, put_flash(socket, :error, "Failed to create device: missing user scope")}
 
       {:error, reason} ->
@@ -472,7 +472,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
              |> push_patch(to: path)}
 
           {:error, reason} ->
-            Logger.error("Bulk device delete failed: #{inspect(reason)}", device_uids: uids)
+            Logger.error("Bulk device delete failed for #{inspect(uids)}: #{inspect(reason)}")
             {:noreply,
              socket
              |> assign(:show_bulk_delete_modal, false)
@@ -2626,15 +2626,15 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     if is_nil(scope) do
       {:error, :missing_scope}
     else
-    # Build device data from form params
-    device_data = %{
-      hostname: params["hostname"],
-      ip: params["ip"],
-      type: params["type"],
-      tags: parse_form_tags(params["tags"])
-    }
+      # Build device data from form params
+      device_data = %{
+        hostname: params["hostname"],
+        ip: params["ip"],
+        type: params["type"],
+        tags: parse_form_tags(params["tags"])
+      }
 
-    create_single_device(device_data, scope)
+      create_single_device(device_data, scope)
     end
   end
 
@@ -2643,24 +2643,24 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     uid = generate_device_uid(device_data.ip)
 
     if is_nil(uid) or uid == "" do
-      Logger.error("Device create failed: generated UID is empty", device_data: device_data)
+      Logger.error("Device create failed: generated UID is empty for #{inspect(device_data)}")
       {:error, :invalid_uid}
     else
-    # First check if device already exists
-    case Device.get_by_uid(uid, false, scope: scope) do
-      {:ok, nil} ->
-        # Treat nil as not found to avoid false positives
-        create_new_device(uid, device_data, scope)
+      # First check if device already exists
+      case Device.get_by_uid(uid, false, scope: scope) do
+        {:ok, nil} ->
+          # Treat nil as not found to avoid false positives
+          create_new_device(uid, device_data, scope)
 
-      {:ok, _existing} ->
-        {:error, :already_exists}
+        {:ok, _existing} ->
+          {:error, :already_exists}
 
-      {:error, %Ash.Error.Query.NotFound{}} ->
-        create_new_device(uid, device_data, scope)
+        {:error, %Ash.Error.Query.NotFound{}} ->
+          create_new_device(uid, device_data, scope)
 
-      {:error, _} = error ->
-        error
-    end
+        {:error, _} = error ->
+          error
+      end
     end
   end
 

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -2584,21 +2584,20 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   end
 
   defp import_devices(scope, devices) do
-    actor = build_device_actor(scope)
-    do_import_devices(devices, actor)
+    do_import_devices(devices, scope)
   end
 
-  defp do_import_devices(devices, actor) do
+  defp do_import_devices(devices, scope) do
     {created, skipped, errors} =
       Enum.reduce(devices, {0, 0, []}, fn device_data, acc ->
-        process_device_import(device_data, actor, acc)
+        process_device_import(device_data, scope, acc)
       end)
 
     if errors == [], do: {:ok, {created, skipped}}, else: {:error, Enum.reverse(errors)}
   end
 
-  defp process_device_import(device_data, actor, {created, skipped, errors}) do
-    case create_single_device(device_data, actor) do
+  defp process_device_import(device_data, scope, {created, skipped, errors}) do
+    case create_single_device(device_data, scope) do
       {:ok, _device} ->
         {created + 1, skipped, errors}
 
@@ -2612,8 +2611,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   end
 
   defp create_device(scope, params) do
-    actor = build_device_actor(scope)
-
     # Build device data from form params
     device_data = %{
       hostname: params["hostname"],
@@ -2622,15 +2619,15 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
       tags: parse_form_tags(params["tags"])
     }
 
-    create_single_device(device_data, actor)
+    create_single_device(device_data, scope)
   end
 
-  defp create_single_device(device_data, actor) do
+  defp create_single_device(device_data, scope) do
     # Generate a UID based on IP (or use a UUID)
     uid = generate_device_uid(device_data.ip)
 
     # First check if device already exists
-    case Device.get_by_uid(uid, actor: actor) do
+    case Device.get_by_uid(uid, false, scope: scope) do
       {:ok, _existing} ->
         {:error, :already_exists}
 
@@ -2657,7 +2654,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
 
         Device
         |> Ash.Changeset.for_create(:create, attrs)
-        |> Ash.create(actor: actor)
+        |> Ash.create(scope: scope)
 
       {:error, _} = error ->
         error
@@ -2712,24 +2709,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     |> String.split("\n")
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
-  end
-
-  defp build_device_actor(scope) do
-    case scope do
-      %{user: user} when not is_nil(user) ->
-        %{
-          id: user.id,
-          email: user.email,
-          role: user.role
-        }
-
-      _ ->
-        %{
-          id: "system",
-          email: "system@serviceradar",
-          role: :admin
-        }
-    end
   end
 
   defp format_device_error(%Ash.Error.Invalid{errors: errors}) do

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -254,16 +254,26 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
          |> push_patch(to: ~p"/devices")}
 
       {:error, %Ash.Error.Invalid{} = error} ->
+        Logger.warning("Device create failed with validation error: #{inspect(error)}")
         {:noreply,
          socket
          |> put_flash(:error, format_device_error(error))}
 
       {:error, :already_exists} ->
         {:noreply,
-         socket
-         |> put_flash(:error, "A device with this IP address already exists.")}
+        socket
+        |> put_flash(:error, "A device with this IP address already exists.")}
+
+      {:error, :invalid_uid} ->
+        Logger.error("Device create failed: generated UID was invalid", device_params: params)
+        {:noreply, put_flash(socket, :error, "Failed to create device: invalid device UID")}
+
+      {:error, :missing_scope} ->
+        Logger.error("Device create failed: missing scope", device_params: params)
+        {:noreply, put_flash(socket, :error, "Failed to create device: missing user scope")}
 
       {:error, reason} ->
+        Logger.error("Device create failed: #{inspect(reason)}")
         {:noreply,
          socket
          |> put_flash(:error, "Failed to create device: #{inspect(reason)}")}
@@ -462,6 +472,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
              |> push_patch(to: path)}
 
           {:error, reason} ->
+            Logger.error("Bulk device delete failed: #{inspect(reason)}", device_uids: uids)
             {:noreply,
              socket
              |> assign(:show_bulk_delete_modal, false)
@@ -469,6 +480,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
         end
 
       {:error, reason} ->
+        Logger.error("Bulk device delete failed: #{inspect(reason)}")
         {:noreply,
          socket
          |> assign(:show_bulk_delete_modal, false)
@@ -2611,6 +2623,9 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   end
 
   defp create_device(scope, params) do
+    if is_nil(scope) do
+      {:error, :missing_scope}
+    else
     # Build device data from form params
     device_data = %{
       hostname: params["hostname"],
@@ -2620,45 +2635,59 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
     }
 
     create_single_device(device_data, scope)
+    end
   end
 
   defp create_single_device(device_data, scope) do
     # Generate a UID based on IP (or use a UUID)
     uid = generate_device_uid(device_data.ip)
 
+    if is_nil(uid) or uid == "" do
+      Logger.error("Device create failed: generated UID is empty", device_data: device_data)
+      {:error, :invalid_uid}
+    else
     # First check if device already exists
     case Device.get_by_uid(uid, false, scope: scope) do
+      {:ok, nil} ->
+        # Treat nil as not found to avoid false positives
+        create_new_device(uid, device_data, scope)
+
       {:ok, _existing} ->
         {:error, :already_exists}
 
       {:error, %Ash.Error.Query.NotFound{}} ->
-        # Device doesn't exist, create it
-        now = DateTime.utc_now()
-
-        attrs =
-          %{
-            uid: uid,
-            hostname: device_data.hostname,
-            ip: device_data.ip,
-            name: device_data.hostname || device_data.ip,
-            type: device_data[:type],
-            type_id: parse_type_id(device_data[:type]),
-            tags: normalize_tags(device_data[:tags]),
-            discovery_sources: ["manual"],
-            first_seen_time: now,
-            last_seen_time: now,
-            created_time: now
-          }
-          |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
-          |> Map.new()
-
-        Device
-        |> Ash.Changeset.for_create(:create, attrs)
-        |> Ash.create(scope: scope)
+        create_new_device(uid, device_data, scope)
 
       {:error, _} = error ->
         error
     end
+    end
+  end
+
+  defp create_new_device(uid, device_data, scope) do
+    # Device doesn't exist, create it
+    now = DateTime.utc_now()
+
+    attrs =
+      %{
+        uid: uid,
+        hostname: device_data.hostname,
+        ip: device_data.ip,
+        name: device_data.hostname || device_data.ip,
+        type: device_data[:type],
+        type_id: parse_type_id(device_data[:type]),
+        tags: normalize_tags(device_data[:tags]),
+        discovery_sources: ["manual"],
+        first_seen_time: now,
+        last_seen_time: now,
+        created_time: now
+      }
+      |> Enum.reject(fn {_k, v} -> is_nil(v) or v == "" end)
+      |> Map.new()
+
+    Device
+    |> Ash.Changeset.for_create(:create, attrs)
+    |> Ash.create(scope: scope)
   end
 
   defp generate_device_uid(ip) when is_binary(ip) do

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -2650,26 +2650,22 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
       Logger.error("Device create failed: generated UID is empty for #{inspect(device_data)}")
       {:error, :invalid_uid}
     else
-      Device.get_by_uid(uid, false, scope: scope)
-      |> handle_existing_device(uid, device_data, scope)
+      create_new_device(uid, device_data, scope)
+      |> normalize_create_result()
     end
   end
 
-  defp handle_existing_device({:ok, nil}, uid, device_data, scope) do
-    # Treat nil as not found to avoid false positives
-    create_new_device(uid, device_data, scope)
-  end
+  defp normalize_create_result({:ok, device}), do: {:ok, device}
 
-  defp handle_existing_device({:ok, _existing}, _uid, _device_data, _scope),
-    do: {:error, :already_exists}
-
-  defp handle_existing_device({:error, error}, uid, device_data, scope) do
-    if not_found_error?(error) do
-      create_new_device(uid, device_data, scope)
+  defp normalize_create_result({:error, %Ash.Error.Invalid{} = error}) do
+    if unique_uid_error?(error) do
+      {:error, :already_exists}
     else
       {:error, error}
     end
   end
+
+  defp normalize_create_result({:error, error}), do: {:error, error}
 
   defp create_new_device(uid, device_data, scope) do
     # Device doesn't exist, create it
@@ -2777,11 +2773,24 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   defp format_single_device_error(err),
     do: inspect(err)
 
-  defp not_found_error?(%Ash.Error.Query.NotFound{}), do: true
-
-  defp not_found_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
-    Enum.any?(errors, &match?(%Ash.Error.Query.NotFound{}, &1))
+  defp unique_uid_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &unique_uid_error_detail?/1)
   end
 
-  defp not_found_error?(_), do: false
+  defp unique_uid_error?(_), do: false
+
+  defp unique_uid_error_detail?(%Ash.Error.Changes.InvalidAttribute{
+         field: :uid,
+         validation: :unique
+       }),
+       do: true
+
+  defp unique_uid_error_detail?(%Ash.Error.Changes.InvalidAttribute{field: :uid, message: msg})
+       when is_binary(msg),
+       do: String.contains?(msg, "has already been taken")
+
+  defp unique_uid_error_detail?(%Ash.Error.Changes.InvalidChanges{field: :uid}),
+    do: true
+
+  defp unique_uid_error_detail?(_), do: false
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex
@@ -2650,21 +2650,24 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
       Logger.error("Device create failed: generated UID is empty for #{inspect(device_data)}")
       {:error, :invalid_uid}
     else
-      # First check if device already exists
-      case Device.get_by_uid(uid, false, scope: scope) do
-        {:ok, nil} ->
-          # Treat nil as not found to avoid false positives
-          create_new_device(uid, device_data, scope)
+      Device.get_by_uid(uid, false, scope: scope)
+      |> handle_existing_device(uid, device_data, scope)
+    end
+  end
 
-        {:ok, _existing} ->
-          {:error, :already_exists}
+  defp handle_existing_device({:ok, nil}, uid, device_data, scope) do
+    # Treat nil as not found to avoid false positives
+    create_new_device(uid, device_data, scope)
+  end
 
-        {:error, %Ash.Error.Query.NotFound{}} ->
-          create_new_device(uid, device_data, scope)
+  defp handle_existing_device({:ok, _existing}, _uid, _device_data, _scope),
+    do: {:error, :already_exists}
 
-        {:error, _} = error ->
-          error
-      end
+  defp handle_existing_device({:error, error}, uid, device_data, scope) do
+    if not_found_error?(error) do
+      create_new_device(uid, device_data, scope)
+    else
+      {:error, error}
     end
   end
 
@@ -2765,9 +2768,20 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Index do
   defp format_single_device_error(%Ash.Error.Changes.Required{field: field}),
     do: "#{field} is required"
 
+  defp format_single_device_error(%Ash.Error.Query.NotFound{}),
+    do: "Device not found"
+
   defp format_single_device_error(%{message: msg}) when is_binary(msg),
     do: msg
 
   defp format_single_device_error(err),
     do: inspect(err)
+
+  defp not_found_error?(%Ash.Error.Query.NotFound{}), do: true
+
+  defp not_found_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &match?(%Ash.Error.Query.NotFound{}, &1))
+  end
+
+  defp not_found_error?(_), do: false
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -310,13 +310,13 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
              |> push_patch(to: device_show_path(socket, device_uid))}
 
           {:error, reason} ->
-            Logger.error("Device delete failed: #{inspect(reason)}", device_uid: device_uid)
+            Logger.error("Device delete failed for #{device_uid}: #{inspect(reason)}")
             {:noreply,
              put_flash(socket, :error, "Failed to delete device: #{format_ash_error(reason)}")}
         end
 
       {:error, reason} ->
-        Logger.error("Device load failed for delete: #{inspect(reason)}", device_uid: device_uid)
+        Logger.error("Device load failed for delete #{device_uid}: #{inspect(reason)}")
         {:noreply,
          put_flash(socket, :error, "Failed to load device: #{format_ash_error(reason)}")}
     end
@@ -326,48 +326,17 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
     scope = socket.assigns.current_scope
     device_uid = socket.assigns.device_uid
 
-    case load_device(scope, device_uid) do
-      {:ok, device} ->
-        case Device.restore(device, scope: scope) do
-          {:ok, _} ->
-            {:noreply,
-             socket
-             |> put_flash(:info, "Device restored")
-             |> push_patch(to: device_show_path(socket, device_uid))}
-
-          {:error, %Ash.Error.Invalid{} = error} ->
-            if stale_record_error?(error) do
-              case force_restore_device(scope, device_uid) do
-                :ok ->
-                  {:noreply,
-                   socket
-                   |> put_flash(:info, "Device restored")
-                   |> push_patch(to: device_show_path(socket, device_uid))}
-
-                {:error, force_reason} ->
-                  Logger.error("Device restore failed after stale record", device_uid: device_uid)
-                  {:noreply,
-                   put_flash(
-                     socket,
-                     :error,
-                     "Failed to restore device: #{format_ash_error(force_reason)}"
-                   )}
-              end
-            else
-              Logger.error("Device restore failed: #{inspect(error)}", device_uid: device_uid)
-              {:noreply,
-               put_flash(socket, :error, "Failed to restore device: #{format_ash_error(error)}")}
-            end
-
-          {:error, reason} ->
-            Logger.error("Device restore failed: #{inspect(reason)}", device_uid: device_uid)
-            {:noreply,
-             put_flash(socket, :error, "Failed to restore device: #{format_ash_error(reason)}")}
-        end
+    case restore_device(scope, device_uid) do
+      :ok ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Device restored")
+         |> push_patch(to: device_show_path(socket, device_uid))}
 
       {:error, reason} ->
+        Logger.error("Device restore failed for #{device_uid}: #{inspect(reason)}")
         {:noreply,
-         put_flash(socket, :error, "Failed to load device: #{format_ash_error(reason)}")}
+         put_flash(socket, :error, "Failed to restore device: #{format_ash_error(reason)}")}
     end
   end
 
@@ -5022,6 +4991,26 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   end
 
   defp stale_record_error?(_), do: false
+
+  defp restore_device(scope, device_uid) do
+    with {:ok, device} <- load_device(scope, device_uid),
+         {:ok, _} <- Device.restore(device, scope: scope) do
+      :ok
+    else
+      {:error, %Ash.Error.Invalid{} = error} ->
+        if stale_record_error?(error) do
+          case force_restore_device(scope, device_uid) do
+            :ok -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        else
+          {:error, error}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
 
   defp force_restore_device(scope, device_uid) do
     query =

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -5,6 +5,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   import ServiceRadarWebNGWeb.SRQLComponents, only: [srql_results_table: 1]
   import Bitwise
   require Ash.Query
+  require Logger
 
   alias ServiceRadarWebNGWeb.Dashboard.Engine
   alias ServiceRadarWebNGWeb.Dashboard.Plugins.Categories, as: CategoriesPlugin
@@ -301,9 +302,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       {:ok, device} ->
         deleted_by = deleted_by_from_scope(scope)
 
-        case Device.soft_delete(device, %{deleted_reason: "ui_delete", deleted_by: deleted_by},
-               scope: scope
-             ) do
+        case Device.soft_delete(device, "ui_delete", deleted_by, scope: scope) do
           {:ok, _} ->
             {:noreply,
              socket
@@ -311,11 +310,13 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
              |> push_patch(to: device_show_path(socket, device_uid))}
 
           {:error, reason} ->
+            Logger.error("Device delete failed: #{inspect(reason)}", device_uid: device_uid)
             {:noreply,
              put_flash(socket, :error, "Failed to delete device: #{format_ash_error(reason)}")}
         end
 
       {:error, reason} ->
+        Logger.error("Device load failed for delete: #{inspect(reason)}", device_uid: device_uid)
         {:noreply,
          put_flash(socket, :error, "Failed to load device: #{format_ash_error(reason)}")}
     end
@@ -334,7 +335,32 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
              |> put_flash(:info, "Device restored")
              |> push_patch(to: device_show_path(socket, device_uid))}
 
+          {:error, %Ash.Error.Invalid{} = error} ->
+            if stale_record_error?(error) do
+              case force_restore_device(scope, device_uid) do
+                :ok ->
+                  {:noreply,
+                   socket
+                   |> put_flash(:info, "Device restored")
+                   |> push_patch(to: device_show_path(socket, device_uid))}
+
+                {:error, force_reason} ->
+                  Logger.error("Device restore failed after stale record", device_uid: device_uid)
+                  {:noreply,
+                   put_flash(
+                     socket,
+                     :error,
+                     "Failed to restore device: #{format_ash_error(force_reason)}"
+                   )}
+              end
+            else
+              Logger.error("Device restore failed: #{inspect(error)}", device_uid: device_uid)
+              {:noreply,
+               put_flash(socket, :error, "Failed to restore device: #{format_ash_error(error)}")}
+            end
+
           {:error, reason} ->
+            Logger.error("Device restore failed: #{inspect(reason)}", device_uid: device_uid)
             {:noreply,
              put_flash(socket, :error, "Failed to restore device: #{format_ash_error(reason)}")}
         end
@@ -4990,4 +5016,35 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   end
 
   defp deleted_by_from_scope(_), do: nil
+
+  defp stale_record_error?(%Ash.Error.Invalid{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, &match?(%Ash.Error.Changes.StaleRecord{}, &1))
+  end
+
+  defp stale_record_error?(_), do: false
+
+  defp force_restore_device(scope, device_uid) do
+    query =
+      Device
+      |> Ash.Query.for_read(:read, %{include_deleted: true})
+      |> Ash.Query.filter(uid == ^device_uid)
+
+    case Ash.bulk_update(query, :restore, %{},
+           scope: scope,
+           return_errors?: true,
+           return_records?: false
+         ) do
+      %Ash.BulkResult{status: :success} ->
+        :ok
+
+      %Ash.BulkResult{status: :partial_success, errors: errors} ->
+        {:error, List.first(errors) || :partial_failure}
+
+      %Ash.BulkResult{status: :error, errors: errors} ->
+        {:error, List.first(errors) || :bulk_update_failed}
+
+      other ->
+        {:error, other}
+    end
+  end
 end

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -311,12 +311,14 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
           {:error, reason} ->
             Logger.error("Device delete failed for #{device_uid}: #{inspect(reason)}")
+
             {:noreply,
              put_flash(socket, :error, "Failed to delete device: #{format_ash_error(reason)}")}
         end
 
       {:error, reason} ->
         Logger.error("Device load failed for delete #{device_uid}: #{inspect(reason)}")
+
         {:noreply,
          put_flash(socket, :error, "Failed to load device: #{format_ash_error(reason)}")}
     end
@@ -335,6 +337,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
       {:error, reason} ->
         Logger.error("Device restore failed for #{device_uid}: #{inspect(reason)}")
+
         {:noreply,
          put_flash(socket, :error, "Failed to restore device: #{format_ash_error(reason)}")}
     end

--- a/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex
@@ -1002,7 +1002,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       |> Enum.map(fn uid ->
         # First get existing settings to merge tags
         existing_tags =
-          case InterfaceSettings.get_by_interface(device_uid, uid, actor: scope) do
+          case InterfaceSettings.get_by_interface(device_uid, uid, scope: scope) do
             {:ok, settings} -> settings.tags || []
             _ -> []
           end
@@ -4854,7 +4854,7 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
   defp deleted_device?(_), do: false
 
   defp load_device(scope, device_uid) do
-    case Device.get_by_uid(device_uid, include_deleted: true, scope: scope) do
+    case Device.get_by_uid(device_uid, true, scope: scope) do
       {:ok, nil} -> {:error, :not_found}
       other -> other
     end
@@ -4881,8 +4881,6 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
 
   # Update device via Ash
   defp update_device(scope, device_uid, params) do
-    actor = build_device_actor(scope)
-
     # Parse tags from newline-separated string to map
     attrs =
       %{
@@ -4898,32 +4896,14 @@ defmodule ServiceRadarWebNGWeb.DeviceLive.Show do
       |> Map.new()
 
     # First get the device, then update it
-    case Device.get_by_uid(device_uid, actor: actor) do
+    case Device.get_by_uid(device_uid, false, scope: scope) do
       {:ok, device} ->
         device
         |> Ash.Changeset.for_update(:update, attrs)
-        |> Ash.update(actor: actor)
+        |> Ash.update(scope: scope)
 
       {:error, _} = error ->
         error
-    end
-  end
-
-  defp build_device_actor(scope) do
-    case scope do
-      %{user: user} when not is_nil(user) ->
-        %{
-          id: user.id,
-          email: user.email,
-          role: user.role
-        }
-
-      _ ->
-        %{
-          id: "system",
-          email: "system@serviceradar",
-          role: :admin
-        }
     end
   end
 

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/sysmon_profiles_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/sysmon_profiles_live/index.ex
@@ -169,6 +169,7 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
         case Ash.update(changeset, scope: scope) do
           {:ok, _updated} ->
             _ = ConfigServer.invalidate(:sysmon)
+
             {:noreply,
              socket
              |> assign(:profiles, load_profiles(scope))
@@ -194,6 +195,7 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
         case Ash.destroy(profile, scope: scope) do
           :ok ->
             _ = ConfigServer.invalidate(:sysmon)
+
             {:noreply,
              socket
              |> assign(:profiles, load_profiles(scope))

--- a/web-ng/lib/serviceradar_web_ng_web/live/settings/sysmon_profiles_live/index.ex
+++ b/web-ng/lib/serviceradar_web_ng_web/live/settings/sysmon_profiles_live/index.ex
@@ -11,6 +11,7 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
   import ServiceRadarWebNGWeb.QueryBuilderComponents
 
   alias AshPhoenix.Form
+  alias ServiceRadar.AgentConfig.ConfigServer
   alias ServiceRadar.AgentConfig.Compilers.SysmonCompiler
   alias ServiceRadar.SysmonProfiles.SysmonProfile
   alias ServiceRadarWebNGWeb.SRQL.Catalog
@@ -138,11 +139,12 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
     case Form.submit(ash_form, params: params) do
       {:ok, _profile} ->
         action = if socket.assigns.show_form == :new_profile, do: "created", else: "updated"
+        _ = ConfigServer.invalidate(:sysmon)
 
         {:noreply,
          socket
          |> assign(:profiles, load_profiles(scope))
-         |> put_flash(:info, "Profile #{action} successfully")
+         |> put_flash(:info, "Profile #{action}. Pushed config to connected agents.")
          |> push_navigate(to: ~p"/settings/sysmon")}
 
       {:error, ash_form} ->
@@ -166,10 +168,14 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
 
         case Ash.update(changeset, scope: scope) do
           {:ok, _updated} ->
+            _ = ConfigServer.invalidate(:sysmon)
             {:noreply,
              socket
              |> assign(:profiles, load_profiles(scope))
-             |> put_flash(:info, "Profile #{if new_enabled, do: "enabled", else: "disabled"}")}
+             |> put_flash(
+               :info,
+               "Profile #{if new_enabled, do: "enabled", else: "disabled"}. Pushed config to connected agents."
+             )}
 
           {:error, _} ->
             {:noreply, put_flash(socket, :error, "Failed to update profile")}
@@ -187,10 +193,11 @@ defmodule ServiceRadarWebNGWeb.Settings.SysmonProfilesLive.Index do
       profile ->
         case Ash.destroy(profile, scope: scope) do
           :ok ->
+            _ = ConfigServer.invalidate(:sysmon)
             {:noreply,
              socket
              |> assign(:profiles, load_profiles(scope))
-             |> put_flash(:info, "Profile deleted")}
+             |> put_flash(:info, "Profile deleted. Pushed config to connected agents.")}
 
           {:error, _} ->
             {:noreply, put_flash(socket, :error, "Failed to delete profile")}


### PR DESCRIPTION
### **User description**
## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `actor` parameter with `scope` in Device API calls

- Remove `build_device_actor()` helper function from two modules

- Update `Device.get_by_uid()` calls to use positional boolean parameter

- Standardize scope-based authorization across device operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device Controller & Live Views"] -->|"Replace actor with scope"| B["Device API Calls"]
  C["build_device_actor Function"] -->|"Remove"| D["Simplified Code"]
  B -->|"Update parameter format"| E["Device.get_by_uid calls"]
  D -->|"Use scope directly"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device_controller.ex</strong><dd><code>Update device controller API call signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng/api/device_controller.ex

<ul><li>Update <code>Device.get_by_uid()</code> call to include boolean parameter <code>false</code> and <br>use <code>scope:</code> keyword argument</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2701/files#diff-ac55b43afa10dd331fa712def4e0af4608417e58727fbde08a6702ef180e46d4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Replace actor with scope in device import operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/device_live/index.ex

<ul><li>Remove <code>build_device_actor()</code> function entirely<br> <li> Replace all <code>actor</code> parameters with <code>scope</code> in device import and creation <br>functions<br> <li> Update <code>Device.get_by_uid()</code> calls to use positional boolean parameter <br>and <code>scope:</code> keyword<br> <li> Simplify <code>create_device()</code> and <code>create_single_device()</code> to pass scope <br>directly</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2701/files#diff-261a01f4876e5984e1d9e9b38a3540675dfb0272abc30e6bdb2a4fa610353cc7">+9/-30</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show.ex</strong><dd><code>Standardize scope-based authorization in show operations</code>&nbsp; </dd></summary>
<hr>

web-ng/lib/serviceradar_web_ng_web/live/device_live/show.ex

<ul><li>Remove <code>build_device_actor()</code> function<br> <li> Replace <code>actor:</code> parameter with <code>scope:</code> in <br><code>InterfaceSettings.get_by_interface()</code> call<br> <li> Update <code>Device.get_by_uid()</code> calls to use positional boolean parameter <br>instead of <code>include_deleted:</code> keyword<br> <li> Change <code>Ash.update()</code> call to use <code>scope:</code> instead of <code>actor:</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2701/files#diff-92d8e0af57d2f65dfb8562e896dbea17ef9f47074ffd14f58261decc76f80c24">+4/-24</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

