### PR TITLE
Fix flow-collector docker-compose mTLS config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -594,8 +594,9 @@ services:
       - "2055:2055/udp"       # NetFlow/IPFIX
       - "6343:6343/udp"       # sFlow
     volumes:
-      - ./rust/flow-collector/flow-collector.json:/etc/serviceradar/flow-collector.json:ro
+      - ./docker/compose/flow-collector.docker.json:/etc/serviceradar/flow-collector.json:ro
       - cert-data:/etc/serviceradar/certs:ro
+      - ${NATS_CREDS_DIR:-./docker/compose/creds}:/etc/serviceradar/creds:ro
       - flow-data:/var/lib/serviceradar
       - ./logs:/var/log/serviceradar
     environment:

--- a/docker/compose/flow-collector.docker.json
+++ b/docker/compose/flow-collector.docker.json
@@ -1,0 +1,29 @@
+{
+  "nats_url": "tls://nats:4222",
+  "nats_creds_file": "/etc/serviceradar/creds/platform.creds",
+  "stream_name": "events",
+  "channel_size": 10000,
+  "batch_size": 100,
+  "publish_timeout_ms": 5000,
+  "listeners": [
+    {
+      "protocol": "sflow",
+      "listen_addr": "0.0.0.0:6343",
+      "subject": "flows.raw.sflow"
+    },
+    {
+      "protocol": "netflow",
+      "listen_addr": "0.0.0.0:2055",
+      "subject": "flows.raw.netflow"
+    }
+  ],
+  "security": {
+    "mode": "mtls",
+    "cert_dir": "/etc/serviceradar/certs",
+    "tls": {
+      "cert_file": "flow-collector.pem",
+      "key_file": "flow-collector-key.pem",
+      "ca_file": "root.pem"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `docker/compose/flow-collector.docker.json` with proper mTLS security and NATS creds file, matching the pattern used by trapd and other services
- Update `docker-compose.yml` to mount the docker-specific config (instead of the bare `rust/flow-collector/flow-collector.json`) and add the NATS creds volume mount

The flow-collector was failing to connect to NATS with `UnknownIssuer` because the config had `nats://` (no TLS) and was missing the NATS creds file. After this fix, `git pull && docker compose up -d` works cleanly.

## Test plan
- [x] `docker compose up -d` - all 14 containers up and healthy
- [x] flow-collector connects to NATS with mTLS: `Connected to NATS at tls://nats:4222 and ensured stream 'events' exists`
- [x] Both sflow (6343) and netflow (2055) listeners running

🤖 Generated with [Claude Code](https://claude.com/claude-code)