### PR TITLE
Fix otel_trace_summaries schema: explicit platform prefix + repair migration

### DIFF
--- a/elixir/serviceradar_core/priv/repo/migrations/20260210120000_convert_trace_summaries_to_table.exs
+++ b/elixir/serviceradar_core/priv/repo/migrations/20260210120000_convert_trace_summaries_to_table.exs
@@ -10,13 +10,20 @@ defmodule ServiceRadar.Repo.Migrations.ConvertTraceSummariesToTable do
   """
   use Ecto.Migration
 
+  @schema prefix() || "platform"
+
   def up do
     # Drop the materialized view and its indexes (CASCADE drops dependent indexes)
-    execute("DROP MATERIALIZED VIEW IF EXISTS otel_trace_summaries CASCADE")
+    # Use explicit schema prefix to avoid search_path ambiguity
+    execute("DROP MATERIALIZED VIEW IF EXISTS #{@schema}.otel_trace_summaries CASCADE")
 
-    # Create regular table with same schema
+    # Also clean up any stale copy that ended up in public
+    execute("DROP MATERIALIZED VIEW IF EXISTS public.otel_trace_summaries CASCADE")
+    execute("DROP TABLE IF EXISTS public.otel_trace_summaries CASCADE")
+
+    # Create regular table with same schema + refreshed_at for incremental upserts
     execute("""
-    CREATE TABLE IF NOT EXISTS otel_trace_summaries (
+    CREATE TABLE IF NOT EXISTS #{@schema}.otel_trace_summaries (
       trace_id         TEXT PRIMARY KEY,
       timestamp        TIMESTAMPTZ,
       root_span_id     TEXT,
@@ -38,22 +45,22 @@ defmodule ServiceRadar.Repo.Migrations.ConvertTraceSummariesToTable do
     # Same indexes as before (minus the unique one — PRIMARY KEY covers that)
     execute("""
     CREATE INDEX IF NOT EXISTS idx_trace_summaries_timestamp
-    ON otel_trace_summaries (timestamp DESC)
+    ON #{@schema}.otel_trace_summaries (timestamp DESC)
     """)
 
     execute("""
     CREATE INDEX IF NOT EXISTS idx_trace_summaries_service_timestamp
-    ON otel_trace_summaries (root_service_name, timestamp DESC)
+    ON #{@schema}.otel_trace_summaries (root_service_name, timestamp DESC)
     """)
   end
 
   def down do
     # Drop the table
-    execute("DROP TABLE IF EXISTS otel_trace_summaries CASCADE")
+    execute("DROP TABLE IF EXISTS #{@schema}.otel_trace_summaries CASCADE")
 
     # Recreate the materialized view
     execute("""
-    CREATE MATERIALIZED VIEW IF NOT EXISTS otel_trace_summaries AS
+    CREATE MATERIALIZED VIEW IF NOT EXISTS #{@schema}.otel_trace_summaries AS
     SELECT
       trace_id,
       max(timestamp) AS timestamp,
@@ -69,7 +76,7 @@ defmodule ServiceRadar.Repo.Migrations.ConvertTraceSummariesToTable do
       array_agg(DISTINCT service_name) FILTER (WHERE service_name IS NOT NULL) AS service_set,
       count(*) AS span_count,
       count(*) FILTER (WHERE status_code IS NOT NULL AND status_code != 1) AS error_count
-    FROM otel_traces
+    FROM #{@schema}.otel_traces
     WHERE timestamp >= NOW() - INTERVAL '7 days'
       AND trace_id IS NOT NULL
     GROUP BY trace_id
@@ -77,19 +84,19 @@ defmodule ServiceRadar.Repo.Migrations.ConvertTraceSummariesToTable do
 
     execute("""
     CREATE UNIQUE INDEX IF NOT EXISTS idx_trace_summaries_trace_id
-    ON otel_trace_summaries (trace_id)
+    ON #{@schema}.otel_trace_summaries (trace_id)
     """)
 
     execute("""
     CREATE INDEX IF NOT EXISTS idx_trace_summaries_timestamp
-    ON otel_trace_summaries (timestamp DESC)
+    ON #{@schema}.otel_trace_summaries (timestamp DESC)
     """)
 
     execute("""
     CREATE INDEX IF NOT EXISTS idx_trace_summaries_service_timestamp
-    ON otel_trace_summaries (root_service_name, timestamp DESC)
+    ON #{@schema}.otel_trace_summaries (root_service_name, timestamp DESC)
     """)
 
-    execute("REFRESH MATERIALIZED VIEW otel_trace_summaries")
+    execute("REFRESH MATERIALIZED VIEW #{@schema}.otel_trace_summaries")
   end
 end

--- a/elixir/serviceradar_core/priv/repo/migrations/20260226230000_fix_trace_summaries_schema.exs
+++ b/elixir/serviceradar_core/priv/repo/migrations/20260226230000_fix_trace_summaries_schema.exs
@@ -1,0 +1,90 @@
+defmodule ServiceRadar.Repo.Migrations.FixTraceSummariesSchema do
+  @moduledoc """
+  Ensures otel_trace_summaries is a table (not a materialized view) in the
+  platform schema with the refreshed_at column.
+
+  Previous migration 20260210120000 used unqualified names, which on some
+  deployments left a stale materialized view in the platform schema and/or
+  created the table in public instead. This migration is fully idempotent
+  and cleans up both scenarios.
+  """
+  use Ecto.Migration
+
+  @schema prefix() || "platform"
+
+  def up do
+    # 1. Remove any stale copy in public (table or materialized view)
+    execute("DROP TABLE IF EXISTS public.otel_trace_summaries CASCADE")
+    execute("DROP MATERIALIZED VIEW IF EXISTS public.otel_trace_summaries CASCADE")
+
+    # 2. If the platform copy is still a materialized view, replace it with a table
+    execute("""
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE c.relname = 'otel_trace_summaries'
+          AND n.nspname = '#{@schema}'
+          AND c.relkind = 'm'
+      ) THEN
+        DROP MATERIALIZED VIEW #{@schema}.otel_trace_summaries CASCADE;
+      END IF;
+    END $$
+    """)
+
+    # 3. Create the table if it doesn't exist
+    execute("""
+    CREATE TABLE IF NOT EXISTS #{@schema}.otel_trace_summaries (
+      trace_id         TEXT PRIMARY KEY,
+      timestamp        TIMESTAMPTZ,
+      root_span_id     TEXT,
+      root_span_name   TEXT,
+      root_service_name TEXT,
+      root_span_kind   INT,
+      start_time_unix_nano BIGINT,
+      end_time_unix_nano   BIGINT,
+      duration_ms      FLOAT8,
+      status_code      INT,
+      status_message   TEXT,
+      service_set      TEXT[],
+      span_count       BIGINT,
+      error_count      BIGINT,
+      refreshed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """)
+
+    # 4. Add refreshed_at if the table already exists but is missing the column
+    #    (handles case where table was created by the old unqualified migration)
+    execute("""
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '#{@schema}'
+          AND table_name = 'otel_trace_summaries'
+          AND column_name = 'refreshed_at'
+      ) THEN
+        ALTER TABLE #{@schema}.otel_trace_summaries
+          ADD COLUMN refreshed_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+      END IF;
+    END $$
+    """)
+
+    # 5. Ensure indexes exist
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_trace_summaries_timestamp
+    ON #{@schema}.otel_trace_summaries (timestamp DESC)
+    """)
+
+    execute("""
+    CREATE INDEX IF NOT EXISTS idx_trace_summaries_service_timestamp
+    ON #{@schema}.otel_trace_summaries (root_service_name, timestamp DESC)
+    """)
+  end
+
+  def down do
+    # Nothing to undo — this is a repair migration
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary
- Fix migration `20260210120000` to use explicit `platform.` schema prefix instead of relying on `search_path`, which caused the table to land in `public` on some deployments
- Add idempotent repair migration `20260226230000` that handles all broken states:
  - Drops stale copies in `public` schema (table or materialized view)
  - Converts `platform.otel_trace_summaries` from materialized view to table if still a MV
  - Adds `refreshed_at` column if missing from existing table
  - Ensures indexes exist

**Root cause**: The `CREATE TABLE IF NOT EXISTS otel_trace_summaries` in the original migration had no schema prefix. Depending on the `search_path` at migration time, this could create the table in `public` instead of `platform`, which then triggered the startup migration's "public schema has ServiceRadar tables" guard.

## Test plan
- [x] Docker compose stack starts cleanly with all 14 containers healthy
- [x] `otel_trace_summaries` table exists in `platform` schema with all 15 columns including `refreshed_at`
- [x] web-ng `RefreshTraceSummariesWorker` runs without errors
- [x] Repair migration is idempotent — safe to run on already-fixed databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)