### PR TITLE
feat: abbreviate large numbers on analytics stats cards

### DIFF
--- a/elixir/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
+++ b/elixir/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex
@@ -971,7 +971,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
         </div>
         <div class="flex-1 min-w-0">
           <div class={["text-2xl font-bold", tone_value(@tone)]}>
-            {format_number(@value)}
+            {format_compact_number(@value)}
           </div>
           <div class="text-sm text-base-content/60">
             {@title}
@@ -1005,14 +1005,6 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
   defp tone_value("warning"), do: "text-warning"
   defp tone_value("success"), do: "text-success"
   defp tone_value(_), do: "text-base-content"
-
-  defp format_number(n) when is_integer(n) and n >= 1000 do
-    n |> Integer.to_string() |> add_commas()
-  end
-
-  defp format_number(n) when is_integer(n), do: Integer.to_string(n)
-  defp format_number(n) when is_float(n), do: n |> trunc() |> format_number()
-  defp format_number(_), do: "0"
 
   defp format_compact_number(n) when is_float(n), do: n |> trunc() |> format_compact_number()
 
@@ -1048,15 +1040,6 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
     |> :erlang.float_to_binary(decimals: decimals)
     |> String.trim_trailing("0")
     |> String.trim_trailing(".")
-  end
-
-  defp add_commas(str) do
-    str
-    |> String.reverse()
-    |> String.graphemes()
-    |> Enum.chunk_every(3)
-    |> Enum.join(",")
-    |> String.reverse()
   end
 
   attr :availability, :map, required: true
@@ -1142,7 +1125,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
               <span class="w-3 h-3 rounded-full bg-success" />
               <span class="text-sm">Online</span>
             </div>
-            <span class="font-semibold">{format_number(@online)}</span>
+            <span class="font-semibold">{format_compact_number(@online)}</span>
           </.link>
           <.link
             href={~p"/devices?#{%{q: "in:devices is_available:false sort:last_seen:desc limit:20"}}"}
@@ -1152,7 +1135,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
               <span class="w-3 h-3 rounded-full bg-error" />
               <span class="text-sm">Offline</span>
             </div>
-            <span class="font-semibold">{format_number(@offline)}</span>
+            <span class="font-semibold">{format_compact_number(@offline)}</span>
           </.link>
 
           <.link
@@ -1892,7 +1875,7 @@ defmodule ServiceRadarWebNGWeb.AnalyticsLive.Index do
       phx-click={JS.navigate(@href)}
     >
       <td class={severity_text_class(@color)}>{@label}</td>
-      <td class={["text-center font-bold", severity_text_class(@color)]}>{format_number(@count)}</td>
+      <td class={["text-center font-bold", severity_text_class(@color)]}>{format_compact_number(@count)}</td>
       <td class={["text-center text-xs", severity_text_class(@color)]}>{@pct}%</td>
     </tr>
     """


### PR DESCRIPTION
### **User description**
## Summary
- Switches analytics stats cards from comma-formatted numbers (`50,000`) to compact abbreviations (`50k`, `1.5M`, `2.3B`)
- Uses the existing `format_compact_number/1` helper instead of `format_number/1`
- Applies to stat cards, device availability donut (online/offline counts), and log severity table
- Removes now-unused `format_number/1` and `add_commas/1` functions

Closes #2371

## Test plan
- [ ] Verify stat cards show abbreviated numbers (e.g. `50k` instead of `50,000`)
- [ ] Verify small numbers (<1000) still display as-is
- [ ] Verify device availability online/offline counts are abbreviated
- [ ] Verify log severity counts are abbreviated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace comma-formatted numbers with compact abbreviations (50k, 1.5M, 2.3B)

- Apply formatting to stat cards, device availability counts, and log severity table

- Remove unused `format_number/1` and `add_commas/1` helper functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Analytics Display Components"] -->|format_compact_number| B["Abbreviated Numbers"]
  C["Stat Cards"] -->|50k, 1.5M, 2.3B| B
  D["Device Availability"] -->|Online/Offline Counts| B
  E["Log Severity Table"] -->|Count Values| B
  F["Removed Functions"] -.->|format_number, add_commas| G["Cleanup"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ex</strong><dd><code>Switch to compact number formatting throughout analytics</code>&nbsp; </dd></summary>
<hr>

elixir/web-ng/lib/serviceradar_web_ng_web/live/analytics_live/index.ex

<ul><li>Replace <code>format_number/1</code> calls with <code>format_compact_number/1</code> in stat <br>card display<br> <li> Replace <code>format_number/1</code> calls with <code>format_compact_number/1</code> in device <br>availability widget (online/offline counts)<br> <li> Replace <code>format_number/1</code> calls with <code>format_compact_number/1</code> in log <br>severity table row component<br> <li> Remove unused <code>format_number/1</code> function (4 clauses handling integers, <br>floats, and fallback)<br> <li> Remove unused <code>add_commas/1</code> helper function that formatted numbers with <br>comma separators</ul>


</details>


  </td>
  <td><a href="https://github.com/carverauto/serviceradar/pull/2960/files#diff-ee008fe2b55f4a8443281692cbfd8269f679236499246beb83a39fa497353ca6">+4/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

