### PR TITLE
docker/compose: keep auth secrets root-only in cert fixer

### DIFF
--- a/docker/compose/fix-cert-permissions.sh
+++ b/docker/compose/fix-cert-permissions.sh
@@ -18,6 +18,21 @@ find "${CERT_DIR}" -type d -exec chmod 711 {} \;
 find "${CERT_DIR}" -type f -name '*.pem' ! -name '*-key.pem' -exec chmod 644 {} \;
 find "${CERT_DIR}" -type f -name '*-key.pem' -exec chmod 640 {} \;
 
+# Keep authentication/bootstrap secrets root-only even though certs are shared with runtime users.
+for secret_file in \
+  jwt-secret \
+  api-key \
+  admin-password \
+  admin-password-hash \
+  password.txt \
+  edge-onboarding.key
+do
+  if [ -f "${CERT_DIR}/${secret_file}" ]; then
+    chown 0:0 "${CERT_DIR}/${secret_file}"
+    chmod 600 "${CERT_DIR}/${secret_file}"
+  fi
+done
+
 # CNPG (PostgreSQL) key needs postgres user ownership (uid 26 in serviceradar-cnpg image)
 if [ -f "${CERT_DIR}/cnpg-key.pem" ]; then
   chown 26:26 "${CERT_DIR}/cnpg-key.pem"


### PR DESCRIPTION
### Motivation
- A recent change made `docker/compose/fix-cert-permissions.sh` recursively `chown` the shared cert volume to the runtime UID/GID, which together with `docker/compose/update-config.sh` writing `jwt-secret`/`api-key`/admin password files into the same directory exposed authentication secrets to poller/agent containers mounting the volume read-only.

### Description
- Add a minimal hardening to `docker/compose/fix-cert-permissions.sh` that, after normalizing cert/key permissions, explicitly resets high-value non-certificate secret files (`jwt-secret`, `api-key`, `admin-password`, `admin-password-hash`, `password.txt`, `edge-onboarding.key`) to `root:root` and `chmod 600`, preserving certificate sharing for mTLS while preventing runtime service UIDs from reading bootstrap/auth secrets.

### Testing
- Performed a shell syntax check with `sh -n docker/compose/fix-cert-permissions.sh`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fd25da188320ad6d26562ceeb9a1)