### PR TITLE
chore: upgrade netflow_parser to 1.0.0 and flowparser-sflow to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,15 +194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,12 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,16 +1260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if 1.0.4",
- "memchr",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,36 +1298,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1371,22 +1322,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1443,37 +1383,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1549,13 +1458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "direct-cargo-bazel-deps"
-version = "0.0.1"
-dependencies = [
- "libzetta",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,7 +1507,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -1769,15 +1671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde 1.0.228",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "flowparser-sflow"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50416be4c96c687d745696d988ad48a4c8e95591ef33c247f129e3c554d9110d"
+checksum = "80db8eaa7f8d0a68bbb5911fbe41281a3443119241cc49c2a841bc4dd4ac472e"
 dependencies = [
  "mac_address",
  "nom",
@@ -2194,18 +2087,6 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3026,17 +2907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libnv"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4fecff624ba832137c82123e6fc332d8fa94018e84055c02d84ba09705df850"
-dependencies = [
- "libc",
- "nvpair-sys",
- "quick-error 2.0.1",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,45 +2916,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "libzetta"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b445f50ec6fb16c8e5029827f72cfd4617cd18a732aec4a22ec76397bb30a4ed"
-dependencies = [
- "bitflags 1.2.1",
- "chrono",
- "cmake",
- "cstr-argument",
- "derive_builder",
- "getset",
- "lazy_static",
- "libc",
- "libnv",
- "libzetta-zfs-core-sys",
- "once_cell",
- "pest",
- "pest_derive",
- "quick-error 1.2.3",
- "regex",
- "slog",
- "slog-stdlog",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "libzetta-zfs-core-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5839d503d2c731dd8dd2366f8dbf6c3cfeaa65c2c8e5fe752ce51bd3bdbfd4c8"
-dependencies = [
- "build-env",
- "libc",
- "nvpair-sys",
- "pkg-config",
 ]
 
 [[package]]
@@ -3437,13 +3268,11 @@ dependencies = [
 
 [[package]]
 name = "netflow_parser"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5de8514e95cfcc83de161fcf47a6a2614356d446864b5985dddebf658a0e174"
+checksum = "c0e1f7859a3708e5f915bf00cc8e26dcef316a697d0f64fb01e017c054d2c677"
 dependencies = [
- "byteorder 1.5.0",
  "lru",
- "mac_address",
  "nom",
  "nom-derive",
  "serde 1.0.228",
@@ -3733,12 +3562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nvpair-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81222a842a50a0929c9d8411f839475cec320f3cb41e97735b2746524f6eb75a"
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,49 +3817,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -4357,28 +4137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4693,18 +4451,6 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5969,7 +5715,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6308,40 +6054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slog"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
-dependencies = [
- "anyhow",
- "erased-serde",
- "rustversion",
- "serde_core",
-]
-
-[[package]]
-name = "slog-scope"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b76cf645c92e7850d5a1c9205ebf2864bd32c0ab3e978e6daad51fedf7ef54"
-dependencies = [
- "arc-swap",
- "lazy_static",
- "slog",
-]
-
-[[package]]
-name = "slog-stdlog"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
-dependencies = [
- "log 0.4.29",
- "slog",
- "slog-scope",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6515,21 +6227,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
@@ -6537,20 +6237,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7450,12 +7137,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -8412,7 +8093,7 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "sha2",
- "strum 0.27.2",
+ "strum",
  "thiserror 1.0.69",
  "tokio",
  "zen-expression",
@@ -8443,8 +8124,8 @@ dependencies = [
  "serde 1.0.228",
  "serde_json 1.0.149",
  "strsim 0.11.1",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum",
+ "strum_macros",
  "thiserror 1.0.69",
  "zen-macros",
  "zen-types",

--- a/rust/flow-collector/Cargo.toml
+++ b/rust/flow-collector/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-flowparser-sflow = "0.2"
-netflow_parser = { version = "0.9.0", features = ["parse_unknown_fields"] }
+flowparser-sflow = "0.3.0"
+netflow_parser = { version = "1.0.0", features = ["parse_unknown_fields"] }
 prost = "0.13"
 async-nats = "0.42"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }

--- a/rust/flow-collector/src/netflow/converter.rs
+++ b/rust/flow-collector/src/netflow/converter.rs
@@ -3,10 +3,10 @@ use log::debug;
 use netflow_parser::NetflowPacket;
 use netflow_parser::protocol::ProtocolTypes;
 use netflow_parser::static_versions::v5::V5;
-use netflow_parser::variable_versions::data_number::{DataNumber, FieldValue};
-use netflow_parser::variable_versions::ipfix_lookup::ReverseInformationElement;
-use netflow_parser::variable_versions::ipfix_lookup::{IANAIPFixField, IPFixField};
-use netflow_parser::variable_versions::v9_lookup::V9Field;
+use netflow_parser::variable_versions::field_value::{DataNumber, FieldValue};
+use netflow_parser::variable_versions::ipfix::lookup::ReverseInformationElement;
+use netflow_parser::variable_versions::ipfix::lookup::{IANAIPFixField, IPFixField};
+use netflow_parser::variable_versions::v9::lookup::V9Field;
 use std::net::{IpAddr, SocketAddr};
 
 pub struct Converter {
@@ -208,9 +208,8 @@ impl Converter {
                 }
                 FlowSetBody::NoTemplate(info) => {
                     debug!(
-                        "V9 flowset skipped - no template for ID {} (available: {:?}, {} bytes raw data)",
+                        "V9 flowset skipped - no template for ID {} ({} bytes raw data)",
                         info.template_id,
-                        info.available_templates,
                         info.raw_data.len()
                     );
                 }
@@ -492,9 +491,8 @@ impl Converter {
                 }
                 FlowSetBody::NoTemplate(info) => {
                     debug!(
-                        "IPFIX flowset skipped - no template for ID {} (available: {:?}, {} bytes raw data)",
+                        "IPFIX flowset skipped - no template for ID {} ({} bytes raw data)",
                         info.template_id,
-                        info.available_templates,
                         info.raw_data.len()
                     );
                 }
@@ -554,6 +552,7 @@ fn data_number_to_u32(dn: &DataNumber) -> u32 {
         DataNumber::I64(v) => v.max(0).min(i64::from(u32::MAX)) as u32,
         DataNumber::U128(v) => v.min(u128::from(u32::MAX)) as u32,
         DataNumber::I128(v) => v.max(0).min(i128::from(u32::MAX)) as u32,
+        _ => 0,
     }
 }
 
@@ -571,13 +570,14 @@ fn data_number_to_u64(dn: &DataNumber) -> u64 {
         DataNumber::I64(v) => v.max(0) as u64,
         DataNumber::U128(v) => v.min(u128::from(u64::MAX)) as u64,
         DataNumber::I128(v) => v.max(0).min(i128::from(u64::MAX)) as u64,
+        _ => 0,
     }
 }
 
 fn field_value_to_u32(value: &FieldValue) -> u32 {
     match value {
         FieldValue::DataNumber(dn) => data_number_to_u32(dn),
-        FieldValue::Duration(d) => u32::try_from(d.as_millis()).unwrap_or(u32::MAX),
+        FieldValue::Duration(d) => u32::try_from(d.as_duration().as_millis()).unwrap_or(u32::MAX),
         FieldValue::ProtocolType(pt) => u32::from(u8::from(*pt)),
         FieldValue::Float64(f) => f.max(0.0).min(f64::from(u32::MAX)) as u32,
         _ => 0,
@@ -587,7 +587,7 @@ fn field_value_to_u32(value: &FieldValue) -> u32 {
 fn field_value_to_u64(value: &FieldValue) -> u64 {
     match value {
         FieldValue::DataNumber(dn) => data_number_to_u64(dn),
-        FieldValue::Duration(d) => d.as_millis().try_into().unwrap_or(u64::MAX),
+        FieldValue::Duration(d) => d.as_duration().as_millis().try_into().unwrap_or(u64::MAX),
         FieldValue::ProtocolType(pt) => u64::from(u8::from(*pt)),
         FieldValue::Float64(f) => f.max(0.0).min(u64::MAX as f64) as u64,
         _ => 0,
@@ -596,13 +596,7 @@ fn field_value_to_u64(value: &FieldValue) -> u64 {
 
 fn field_value_to_mac_u64(value: &FieldValue) -> u64 {
     match value {
-        FieldValue::MacAddr(mac_str) => {
-            let bytes: Vec<u8> = mac_str
-                .split(':')
-                .filter_map(|s| u8::from_str_radix(s, 16).ok())
-                .collect();
-            mac_to_u64(&bytes)
-        }
+        FieldValue::MacAddr(bytes) => mac_to_u64(bytes),
         _ => 0,
     }
 }
@@ -629,6 +623,7 @@ impl From<Converter> for Vec<flowpb::FlowMessage> {
             NetflowPacket::V7(_) => vec![],
             NetflowPacket::V9(ref v9) => converter.convert_v9(v9),
             NetflowPacket::IPFix(ref ipfix) => converter.convert_ipfix(ipfix),
+            _ => vec![],
         }
     }
 }
@@ -637,7 +632,7 @@ impl From<Converter> for Vec<flowpb::FlowMessage> {
 mod tests {
     use super::*;
     use netflow_parser::protocol::ProtocolTypes;
-    use std::time::Duration;
+    use netflow_parser::variable_versions::field_value::DurationValue;
 
     #[test]
     fn test_mac_to_u64() {
@@ -691,7 +686,10 @@ mod tests {
 
     #[test]
     fn test_field_value_to_u32_duration() {
-        let fv = FieldValue::Duration(Duration::from_millis(28_796_274));
+        let fv = FieldValue::Duration(DurationValue::Millis {
+            value: 28_796_274,
+            width: 4,
+        });
         assert_eq!(field_value_to_u32(&fv), 28_796_274);
     }
 

--- a/rust/flow-collector/src/netflow/mod.rs
+++ b/rust/flow-collector/src/netflow/mod.rs
@@ -12,7 +12,9 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent) {
+fn make_template_event_callback(
+    pending_enabled: bool,
+) -> impl Fn(&TemplateEvent) -> Result<(), netflow_parser::TemplateHookError> {
     move |event: &TemplateEvent| {
         use TemplateEvent::*;
         match event {
@@ -21,7 +23,7 @@ fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent
                 protocol,
             } => {
                 info!(
-                    "Template learned - ID: {}, Protocol: {:?}",
+                    "Template learned - ID: {:?}, Protocol: {:?}",
                     template_id, protocol
                 );
             }
@@ -30,7 +32,7 @@ fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent
                 protocol,
             } => {
                 warn!(
-                    "Template collision - ID: {}, Protocol: {:?}",
+                    "Template collision - ID: {:?}, Protocol: {:?}",
                     template_id, protocol
                 );
             }
@@ -39,7 +41,7 @@ fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent
                 protocol,
             } => {
                 debug!(
-                    "Template evicted - ID: {}, Protocol: {:?}",
+                    "Template evicted - ID: {:?}, Protocol: {:?}",
                     template_id, protocol
                 );
             }
@@ -48,7 +50,7 @@ fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent
                 protocol,
             } => {
                 debug!(
-                    "Template expired - ID: {}, Protocol: {:?}",
+                    "Template expired - ID: {:?}, Protocol: {:?}",
                     template_id, protocol
                 );
             }
@@ -58,19 +60,21 @@ fn make_template_event_callback(pending_enabled: bool) -> impl Fn(&TemplateEvent
             } => {
                 if pending_enabled {
                     debug!(
-                        "Missing template - ID: {}, Protocol: {:?}. \
+                        "Missing template - ID: {:?}, Protocol: {:?}. \
                          Pending flow cache enabled; data queued if capacity allows.",
                         template_id, protocol
                     );
                 } else {
                     warn!(
-                        "Missing template - ID: {}, Protocol: {:?}. \
+                        "Missing template - ID: {:?}, Protocol: {:?}. \
                          Flow data received before template definition - data lost.",
                         template_id, protocol
                     );
                 }
             }
+            _ => {}
         }
+        Ok(())
     }
 }
 
@@ -91,15 +95,15 @@ impl NetflowHandler {
             .on_template_event(make_template_event_callback(pending_enabled));
 
         if let Some(pf) = pending_flows {
-            builder = builder.with_pending_flows(PendingFlowsConfig {
-                max_pending_flows: pf.max_pending_flows,
-                max_entries_per_template: pf.max_entries_per_template,
-                max_entry_size_bytes: pf.max_entry_size_bytes,
-                ttl: Some(Duration::from_secs(pf.ttl_secs)),
-            });
+            let mut pf_config =
+                PendingFlowsConfig::with_ttl(pf.max_pending_flows, Duration::from_secs(pf.ttl_secs));
+            pf_config.max_entries_per_template = pf.max_entries_per_template;
+            pf_config.max_entry_size_bytes = pf.max_entry_size_bytes;
+            builder = builder.with_pending_flows(pf_config);
         }
 
-        let parser = AutoScopedParser::with_builder(builder);
+        let parser = AutoScopedParser::try_with_builder(builder)
+            .expect("failed to build netflow parser");
 
         Self {
             parser: Mutex::new(parser),
@@ -122,7 +126,14 @@ impl FlowHandler for NetflowHandler {
 
         let packets: Vec<_> = {
             let mut parser = self.parser.lock().unwrap();
-            parser.iter_packets_from_source(peer, buf).collect()
+            match parser.iter_packets_from_source(peer, buf) {
+                Ok(iter) => iter.collect(),
+                Err(e) => {
+                    warn!("Failed to parse NetFlow packet from {}: {:?}", peer, e);
+                    self.metrics.parse_errors.fetch_add(1, Ordering::Relaxed);
+                    return vec![];
+                }
+            }
         };
 
         let mut all_messages = Vec::new();

--- a/rust/flow-collector/src/sflow/converter.rs
+++ b/rust/flow-collector/src/sflow/converter.rs
@@ -44,8 +44,8 @@ impl Converter {
                 SflowSample::Counter(_) | SflowSample::ExpandedCounter(_) => {
                     // Skip counter samples — out of scope
                 }
-                SflowSample::Unknown { .. } => {
-                    debug!("Skipping unknown sFlow sample type");
+                SflowSample::DiscardedPacket(_) | SflowSample::Unknown { .. } => {
+                    debug!("Skipping unsupported sFlow sample type");
                 }
             }
         }


### PR DESCRIPTION
Update flow-collector dependencies and fix breaking API changes:
- Module paths renamed (data_number → field_value, ipfix_lookup → ipfix::lookup)
- FieldValue::MacAddr now holds [u8; 6] instead of string
- FieldValue::Duration now wraps DurationValue
- Template event callback returns Result
- PendingFlowsConfig is non-exhaustive, use constructors
- AutoScopedParser::with_builder → try_with_builder
- iter_packets_from_source returns Result
- Handle non-exhaustive NetflowPacket and SflowSample enums

## IMPORTANT: Please sign the Developer Certificate of Origin

Thank you for your contribution to ServiceRadar. Please note, when contributing, the developer must include
a [DCO sign-off statement]( https://developercertificate.org/) indicating the DCO acceptance in one commit message. Here
is an example DCO Signed-off-by line in a commit message:

```
Signed-off-by: J. Doe <j.doe@domain.com>
```

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [ ] I have signed the DCO?
- [ ] The build completes without errors?
- [ ] All tests are passing when running make test?
